### PR TITLE
use netcat instead of bitnodes

### DIFF
--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -117,9 +117,9 @@ if [ "${public_port}" = "" ]; then
   fi
 fi
 
-public_check=$(curl -s https://bitnodes.earn.com/api/v1/nodes/me-${public_port}/ | jq .success)
+public_check=$(timeout 2s nc -z ${public_ip} ${public_port}; echo $?)
 
-if [ $public_check = "true" ]; then
+if [ $public_check = "0" ]; then
   public="Yes"
   public_color="${color_green}"
 else


### PR DESCRIPTION
kept running into issues that pi displayed me as not reachable as the return from bitnodes was "request throttled" rather than success, this problem was also described here:
https://github.com/Stadicus/guides/issues/81

changes for fix from here:
https://github.com/Stadicus/guides/pull/121/files

uses netcat instead of bitnodes, worked for me