### PR TITLE
Note shopping list China added

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Fastest and cheapest way to get your own Lightning Node running - on a Raspberry
 **Total Price: 127,31 EUR** (thats under 150 USD)
 
 Amazon shopping lists for different countries:
-[ [USA](shoppinglist_usa.md) ] [ [UK](shoppinglist_uk.md) ] [ [FR](shoppinglist_fr.md) ] [ [China (Taobao/T-Mall](shoppinglist_cn.md) ]
+[ [USA](shoppinglist_usa.md) ] [ [UK](shoppinglist_uk.md) ] [ [FR](shoppinglist_fr.md) ] [ [China](shoppinglist_cn.md) ]
+
+Shopping list China refers to Taobao/T-Mall.
 
 You can even pay your RaspiBlitz Amazon Shopping with Bitcoin & Lightning thru [Bitrefill](https://blog.bitrefill.com/its-here-buy-amazon-vouchers-with-bitcoin-on-bitrefill-bb2a4449724a).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Fastest and cheapest way to get your own Lightning Node running - on a Raspberry
 **Total Price: 127,31 EUR** (thats under 150 USD)
 
 Amazon shopping lists for different countries:
-[ [USA](shoppinglist_usa.md) ] [ [UK](shoppinglist_uk.md) ] [ [FR](shoppinglist_fr.md) ] [ [China](shoppinglist_cn.md) ]
+[ [USA](shoppinglist_usa.md) ] [ [UK](shoppinglist_uk.md) ] [ [FR](shoppinglist_fr.md) ] [ [China (Taobao/T-Mall](shoppinglist_cn.md) ]
 
 You can even pay your RaspiBlitz Amazon Shopping with Bitcoin & Lightning thru [Bitrefill](https://blog.bitrefill.com/its-here-buy-amazon-vouchers-with-bitcoin-on-bitrefill-bb2a4449724a).
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Fastest and cheapest way to get your own Lightning Node running - on a Raspberry
 Amazon shopping lists for different countries:
 [ [USA](shoppinglist_usa.md) ] [ [UK](shoppinglist_uk.md) ] [ [FR](shoppinglist_fr.md) ] [ [China](shoppinglist_cn.md) ]
 
-Shopping list China refers to Taobao/T-Mall.
-
 You can even pay your RaspiBlitz Amazon Shopping with Bitcoin & Lightning thru [Bitrefill](https://blog.bitrefill.com/its-here-buy-amazon-vouchers-with-bitcoin-on-bitrefill-bb2a4449724a).
+
+The shopping list for China refers to Taobao/T-Mall.
 
 ### Optional Hardware
 


### PR DESCRIPTION
Added a hint that the shopping list China does not refer to Amazon. 

Background: Amazon.cn has only very limited option to buy stuff from internationally merchants in China. The idea to buy from amazon.cn makes is misleading. If people from China are interested in creating a raspiBlitz they will checkout taobao. 