### PR TITLE
Fix closeallchannels option syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ The whole build process takes a while. And the end the LCD drives get installed 
 At the beginning of this README you can find the newest SD card we provide. Or you can build the newest SD card image yourself like in the chapter above. The SD card image is used to setup a fresh install of the RaspiBlitz. So what to do if you already have an older version running and you want to upgrade?
 
 Until we reach version 1.0 the update process will be a bit rough .. so what you do is:
-* close all open lightning channels you have (`lncli --force closeallchannels`)
+* close all open lightning channels you have (`lncli closeallchannels --force`)
 * wait until all closing transactions are done
 * move all on-chain funds to a wallet outsie raspiblitz (`lncli --conf_target 3 sendcoins [ADDRESS]`)
 * run the script `./XXcleanHDD.sh` in admin home directory (Blockchain will stay on HDD)


### PR DESCRIPTION
The `command option` (`--force`) has to come after `command`:

```
NAME:
   lncli - control plane for your Lightning Network Daemon (lnd)

USAGE:
   lncli [global options] command [command options] [arguments...]

VERSION:
   0.5 commit=3b2c807288b1b7f40d609533c1e96a510ac5fa6d
```

```
USAGE:
   lncli closeallchannels [command options] [arguments...]
[...]
OPTIONS:
   --inactive_only  close inactive channels only
   --force          ask for confirmation once before attempting to close existing channels
```