### PR TITLE
add script to enable automatic LND unlock

### DIFF
--- a/home.admin/AAunlockLND.py
+++ b/home.admin/AAunlockLND.py
@@ -48,7 +48,7 @@ def _read_macaroon(lnd_macaroon_file):
 def check_locked(password_file, lnd_cert_file, lnd_macaroon_file, host="localhost", port="8080", verbose=False):
     # check locked
     if verbose:
-        print("Checking for lock with the following data:")
+        print("Checking for lock")
 
     passwd_b64 = _read_pwd(password_file)
     macaroon_hex_dump = _read_macaroon(lnd_macaroon_file)
@@ -76,7 +76,7 @@ def check_locked(password_file, lnd_cert_file, lnd_macaroon_file, host="localhos
 
 def unlock(password_file, lnd_cert_file, lnd_macaroon_file, host="localhost", port="8080", verbose=False):
     if verbose:
-        print("Trying to unlock with the following data:")
+        print("Trying to unlock")
 
     passwd_b64 = _read_pwd(password_file)
     macaroon_hex_dump = _read_macaroon(lnd_macaroon_file)
@@ -146,11 +146,11 @@ def main():
 
     if check_locked(password_file, lnd_cert_file, lnd_macaroon_file,
                     host=options.host, port=options.port, verbose=options.verbose):
-        print("\033[93m{}\033[00m".format("Locked"))
-    else:
         if options.verbose:
-            print("\033[92m{}\033[00m".format("Not Locked"))
-            sys.exit(1)
+            print("\033[93m{}\033[00m".format("Locked"))
+    else:
+        print("\033[92m{}\033[00m".format("Not Locked"))
+        sys.exit(1)
 
     if unlock(password_file, lnd_cert_file, lnd_macaroon_file,
               host=options.host, port=options.port, verbose=options.verbose):

--- a/home.admin/AAunlockLND.py
+++ b/home.admin/AAunlockLND.py
@@ -63,7 +63,9 @@ def check_locked(password_file, lnd_cert_file, lnd_macaroon_file, host="localhos
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                        universal_newlines=True, shell=False, timeout=None)
     if not p.returncode == 0:
-        print("Something went wrong! Returncode\n{}\nStderr: {}".format(p.returncode, p.stderr))
+        print("\033[91mSomething went wrong!\033[00m \033[93mIs lnd running? Wrong credentials?\033[00m")
+        # print("Returncode: {}".format(p.returncode))
+        # print("Stderr: {}".format(p.stderr))
         sys.exit(1)
 
     if p.stdout == "Not Found\n":
@@ -93,7 +95,9 @@ def unlock(password_file, lnd_cert_file, lnd_macaroon_file, host="localhost", po
         return True
     else:
         if verbose:
-            print("Something went wrong! Returncode\n{}\nStderr: {}".format(p.returncode, p.stderr))
+            print("\033[91mSomething went wrong!\033[00m \033[93mIs lnd running? Wrong credentials?\033[00m")
+            # print("Returncode: {}".format(p.returncode))
+            # print("Stderr: {}".format(p.stderr))
         return False
 
 

--- a/home.admin/AAunlockLND.py
+++ b/home.admin/AAunlockLND.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import base64
+import os
+import signal
+import subprocess
+import sys
+from optparse import OptionParser
+
+try:  # make sure that (unsupported) Python2 can fail gracefully
+    import configparser
+except ImportError:
+    pass
+
+if sys.version_info < (3, 5, 0):
+    print("Python2 not supported! Please run with Python3.5+")
+    sys.exit(1)
+
+
+def sigint_handler(signum, frame):
+    print('CTRL+C pressed - exiting!')
+    sys.exit(0)
+
+
+def _read_pwd(password_file):
+    # read and convert password from file
+    p = subprocess.run("sudo cat {}".format(password_file),
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       universal_newlines=False, shell=True, timeout=None)
+    if not p.returncode == 0:
+        print("unable to read password from: {}".format(password_file))
+        sys.exit(1)
+    passwd_bytes = p.stdout.split(b"\n")[0]
+    passwd_b64 = base64.encodebytes(passwd_bytes).decode('utf-8').split("\n")[0]
+    return passwd_b64
+
+
+def _read_macaroon(lnd_macaroon_file):
+    # read and convert macaroon from file
+    p = subprocess.run("sudo xxd -ps -u -c 1000 {}".format(lnd_macaroon_file),
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       universal_newlines=True, shell=True, timeout=None)
+    macaroon_hex_dump = p.stdout.split("\n")[0]
+    return macaroon_hex_dump
+
+
+def check_locked(password_file, lnd_cert_file, lnd_macaroon_file, host="localhost", port="8080", verbose=False):
+    # check locked
+    if verbose:
+        print("Checking for lock with the following data:")
+        print("Password File: \033[93m{}\033[00m".format(password_file))
+        print("TLS CERT File: \033[93m{}\033[00m".format(lnd_cert_file))
+        print("Macaroon File: \033[93m{}\033[00m".format(lnd_macaroon_file))
+        print("URL: \033[93mhttps://{}:{}\033[00m".format(host, port))
+
+    passwd_b64 = _read_pwd(password_file)
+    macaroon_hex_dump = _read_macaroon(lnd_macaroon_file)
+
+    cmds = ["curl", "-s",
+            "-H", "'Grpc-Metadata-macaroon: {}'".format(macaroon_hex_dump),
+            "--cacert", "{}".format(lnd_cert_file),
+            "-d", "{{\"wallet_password\": \"{}\"}}".format(passwd_b64),
+            "https://{}:{}/v1/getinfo".format(host, port)]
+
+    p = subprocess.run(cmds,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       universal_newlines=True, shell=False, timeout=None)
+    if not p.returncode == 0:
+        print("Something went wrong! Returncode\n{}\nStderr: {}".format(p.returncode, p.stderr))
+        sys.exit(1)
+
+    if p.stdout == "Not Found\n":
+        return True
+    else:
+        return False
+
+
+def unlock(password_file, lnd_cert_file, lnd_macaroon_file, host="localhost", port="8080", verbose=False):
+    if verbose:
+        print("Trying to unlock with the following data:")
+        print("Password File: \033[93m{}\033[00m".format(password_file))
+        print("TLS CERT File: \033[93m{}\033[00m".format(lnd_cert_file))
+        print("Macaroon File: \033[93m{}\033[00m".format(lnd_macaroon_file))
+        print("URL: \033[93mhttps://{}:{}\033[00m".format(host, port))
+
+    passwd_b64 = _read_pwd(password_file)
+    macaroon_hex_dump = _read_macaroon(lnd_macaroon_file)
+
+    # unlock lnd by calling curl
+    cmds = ["curl", "-s",
+            "-H", "'Grpc-Metadata-macaroon: {}'".format(macaroon_hex_dump),
+            "--cacert", "{}".format(lnd_cert_file),
+            "-d", "{{\"wallet_password\": \"{}\"}}".format(passwd_b64),
+            "https://{}:{}/v1/unlockwallet".format(host, port)]
+
+    p = subprocess.run(cmds,
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       universal_newlines=True, shell=False, timeout=None)
+    if p.returncode == 0:
+        return True
+    else:
+        if verbose:
+            print("Something went wrong! Returncode\n{}\nStderr: {}".format(p.returncode, p.stderr))
+        return False
+
+
+def main():
+    signal.signal(signal.SIGINT, sigint_handler)
+
+    usage = "usage: %prog [Options]"
+    parser = OptionParser(usage=usage, version="%prog {}".format("0.1"))
+
+    parser.add_option("-v", "--verbose", dest="verbose", action="store_true",
+                      help="Print more output")
+
+    parser.add_option("-H", dest="host", type="string", default="localhost",
+                      help="Host (default: localhost)")
+    parser.add_option("-P", dest="port", type="string", default="8080",
+                      help="Port (default: 8080)")
+
+    parser.add_option("-p", dest="password_file", type="string", default="pwd",
+                      help="File containing *cleartext* password (default: pwd)")
+    parser.add_option("-c", dest="cert", type="string",
+                      help="TLS certificate file (e.g. ~/.lnd/tls.cert)"),
+    parser.add_option("-m", dest="macaroon", type="string", default="pwd",
+                      help="Macaroon file (e.g. readonly.macaroon)")
+    options, args = parser.parse_args()
+
+    password_file = os.path.abspath(options.password_file)
+    if not os.path.exists(password_file):
+        print("Password file does not exist - exiting: {}".format(password_file))
+        sys.exit(1)
+
+    if options.cert:
+        lnd_cert_file = options.cert
+    else:
+        lnd_cert_file = "/home/bitcoin/.lnd/tls.cert"
+
+    if options.macaroon:
+        lnd_macaroon_file = options.macaroon
+    else:
+        lnd_macaroon_file = "/home/bitcoin/.lnd/data/chain/bitcoin/mainnet/readonly.macaroon"
+
+    if check_locked(password_file, lnd_cert_file, lnd_macaroon_file,
+                    host=options.host, port=options.port, verbose=options.verbose):
+        print("\033[93m{}\033[00m".format("Locked"))
+    else:
+        if options.verbose:
+            print("\033[92m{}\033[00m".format("Not Locked"))
+            sys.exit(1)
+
+    if unlock(password_file, lnd_cert_file, lnd_macaroon_file,
+              host=options.host, port=options.port, verbose=options.verbose):
+        print("\033[92m{}\033[00m".format("Successfully unlocked."))
+    else:
+        print("\033[91m{}\033[00m".format("Failed to unlock."))
+
+
+if __name__ == "__main__":
+    main()

--- a/home.admin/AAunlockLND.py
+++ b/home.admin/AAunlockLND.py
@@ -49,10 +49,6 @@ def check_locked(password_file, lnd_cert_file, lnd_macaroon_file, host="localhos
     # check locked
     if verbose:
         print("Checking for lock with the following data:")
-        print("Password File: \033[93m{}\033[00m".format(password_file))
-        print("TLS CERT File: \033[93m{}\033[00m".format(lnd_cert_file))
-        print("Macaroon File: \033[93m{}\033[00m".format(lnd_macaroon_file))
-        print("URL: \033[93mhttps://{}:{}\033[00m".format(host, port))
 
     passwd_b64 = _read_pwd(password_file)
     macaroon_hex_dump = _read_macaroon(lnd_macaroon_file)
@@ -79,10 +75,6 @@ def check_locked(password_file, lnd_cert_file, lnd_macaroon_file, host="localhos
 def unlock(password_file, lnd_cert_file, lnd_macaroon_file, host="localhost", port="8080", verbose=False):
     if verbose:
         print("Trying to unlock with the following data:")
-        print("Password File: \033[93m{}\033[00m".format(password_file))
-        print("TLS CERT File: \033[93m{}\033[00m".format(lnd_cert_file))
-        print("Macaroon File: \033[93m{}\033[00m".format(lnd_macaroon_file))
-        print("URL: \033[93mhttps://{}:{}\033[00m".format(host, port))
 
     passwd_b64 = _read_pwd(password_file)
     macaroon_hex_dump = _read_macaroon(lnd_macaroon_file)
@@ -123,7 +115,7 @@ def main():
                       help="File containing *cleartext* password (default: pwd)")
     parser.add_option("-c", dest="cert", type="string",
                       help="TLS certificate file (e.g. ~/.lnd/tls.cert)"),
-    parser.add_option("-m", dest="macaroon", type="string", default="pwd",
+    parser.add_option("-m", dest="macaroon", type="string",
                       help="Macaroon file (e.g. readonly.macaroon)")
     options, args = parser.parse_args()
 
@@ -141,6 +133,12 @@ def main():
         lnd_macaroon_file = options.macaroon
     else:
         lnd_macaroon_file = "/home/bitcoin/.lnd/data/chain/bitcoin/mainnet/readonly.macaroon"
+
+    if options.verbose:
+        print("Password File: \033[93m{}\033[00m".format(password_file))
+        print("TLS CERT File: \033[93m{}\033[00m".format(lnd_cert_file))
+        print("Macaroon File: \033[93m{}\033[00m".format(lnd_macaroon_file))
+        print("URL: \033[93mhttps://{}:{}\033[00m".format(options.host, options.port))
 
     if check_locked(password_file, lnd_cert_file, lnd_macaroon_file,
                     host=options.host, port=options.port, verbose=options.verbose):


### PR DESCRIPTION
This script is a wrapper around the tools mentioned in https://github.com/Stadicus/guides/blob/master/raspibolt/raspibolt_6A_auto-unlock.md. It provides a few command line options but currently does not have a lot of `magic` (e.g. detecting/reading network or chain).

**Warning** This currently depends on the unlock password to be present on disk in a file in clear text!



```
$: ./AAunlockLND.py -h
Usage: AAunlockLND.py [Options]

Options:
  --version         show program's version number and exit
  -h, --help        show this help message and exit
  -v, --verbose     Print more output
  -H HOST           Host (default: localhost)
  -P PORT           Port (default: 8080)
  -p PASSWORD_FILE  File containing *cleartext* password (default: pwd)
  -c CERT           TLS certificate file (e.g. ~/.lnd/tls.cert)
  -m MACAROON       Macaroon file (e.g. readonly.macaroon)
```

Simple run:

```
$: ./AAunlockLND.py
Locked
Successfully unlocked.
```

Being a bit more verbose:

```
$: ./AAunlockLND.py -v
Trying to unlock with the following data:
Password File: /home/admin/pwd
TLS CERT File: /home/bitcoin/.lnd/tls.cert
Macaroon File: /home/bitcoin/.lnd/data/chain/bitcoin/mainnet/readonly.macaroon
URL: https://localhost:8080
Successfully unlocked.
```

This works with `lnd` 0.5-beta and could be placed either into a boot script, cronjob or be hooked into the LCDinfo screen loop.