### PR TITLE
Add ufw allow for REST API

### DIFF
--- a/home.admin/90finishSetup.sh
+++ b/home.admin/90finishSetup.sh
@@ -60,6 +60,8 @@ echo "allow: lightning mainnet"
 sudo ufw allow 9735 comment 'lightning mainnet'
 echo "allow: lightning gRPC"
 sudo ufw allow 10009 comment 'lightning gRPC'
+echo "allow: lightning REST API"
+sudo ufw allow 8080 comment 'lightning REST API'
 echo "allow: trasmission"
 sudo ufw allow 51413 comment 'transmission'
 echo "allow: local web admin"


### PR DESCRIPTION
Just helped a user debug hooking up their raspiblitz to my chrome extension Joule (https://github.com/wbobeirne/joule-extension) which hit a snag because that extension has to use the REST API rather than the gRPC API due to browser limitations. I've added a ufw allow for 8080 to open it up. I personally haven't been able to test this, but I assume this is enough to make it accessible. Let me know if I'm wrong!