### PR TITLE
Add shopping list for Switzerland and driver for custom display

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Fastest and cheapest way to get your own Lightning Node running - on a Raspberry
 **Total Price: 124,11 EUR** (thats under 150 USD)
 
 Amazon shopping lists for different countries:
-[ [USA](shoppinglist_usa.md) ] [ [UK](shoppinglist_uk.md) ] [ [France](shoppinglist_fr.md) ] [ [China](shoppinglist_cn.md) ] [ [Australia](shoppinglist_au.md) ] [ [Czech](shoppinglist_cz.md) ]
+[ [USA](shoppinglist_usa.md) ] [ [UK](shoppinglist_uk.md) ] [ [France](shoppinglist_fr.md) ] [ [China](shoppinglist_cn.md) ] [ [Australia](shoppinglist_au.md) ] [ [Czech](shoppinglist_cz.md) ] [ [Switzerland](shoppinglist_ch.md) ]
 
 You can even pay your RaspiBlitz Amazon Shopping with Bitcoin & Lightning thru [Bitrefill](https://blog.bitrefill.com/its-here-buy-amazon-vouchers-with-bitcoin-on-bitrefill-bb2a4449724a).
 
@@ -171,7 +171,7 @@ You can simply use the HDD of another RaspiBlitz or you prepare a HDD yourself b
 
 * format second HDD with exFAT (availbale on Windows and Mac)
 * copy an indexed Blockchain into the root folder "bitcoin"
-* when youre HDD is ready the content of your folder bitcoin should look like this:
+* when your HDD is ready the content of your folder bitcoin should look like this:
 
 ![BitcoinFolderData](pictures/seedhdd.png)
 

--- a/shoppinglist_ch.md
+++ b/shoppinglist_ch.md
@@ -1,0 +1,13 @@
+The RaspiBlitz software is built and tested for the following hardware set that you can buy on [PLAY-ZONE](https://www.play-zone.ch/) and [BRACK](https://www.brack.ch/):
+
+* Raspberry Pi3 Model B+ (CHF 57.90): https://www.play-zone.ch/de/raspberry-pi3-model-b-1-4ghz-gigabit-lan-wlan-bluetooth-64bit-inkl-16-gb-noobs-sd-karte.html
+  * Includes a Micro SD card with 16GB capacity
+* 3.5'' TFT Display (CHF 69.90): https://www.play-zone.ch/de/3-5-tft-display-800x480-pixel-60fps-mit-acryl-gehause-fur-den-raspberry-pi.html
+  * Includes an acryl glass case
+* Power supply 3A (CHF 29.90): https://www.play-zone.ch/de/netzteil-ac-dc-adapter-5v-dc-3000ma-microusb.html
+* 1TB Hard Drive (CHF 51.00): https://www.brack.ch/maxtor-externe-festplatte-421628
+
+Total: CHF 208.70
+
+**Warning**: This display is different from the one available at Amazon and needs a specific driver!
+Be sure to select "No" when asked by the install script if you have the default display!


### PR DESCRIPTION
Some parts from the shopping list for Germany cannot be delivered to Switzerland by Amazon.

That's why I went ahead and found similar parts in Swiss online shops.

Unfortunately, the display is not the same and needs a custom driver.
So I have added a dialog in the `./raspbianStretchDesktop.sh` script that asks which display you are using.