### PR TITLE
Fixes explanation about LND mnemonic as aezeed

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -226,9 +226,9 @@ Then give LND some time to rescan the blockchain. In the end you will have resto
 
 ## What is this mnemonic seed word list?
 
-With the 24 word list given you by LND on wallet creation you can recover your private key (BIP 39). You should write it down and store it at a save place. 
+With the 24 word list given you by LND on wallet creation you can recover your private key. You should write it down and store it at a save place. Bear in mind that *this 24 word mnemonic seed is not based on the BIP 39* and therefore cannot be recovered using a Bitcoin wallet.
 
-For more background on mnemonic seeds see this video: https://www.youtube.com/watch?v=wWCIQFNf_8g
+For more background on the LND mnemonic seed [read this article](https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md#recovering-funds-from-lnd-funds-are-safu).
 
 ## How does PASSWORD D effects the word seed?
 


### PR DESCRIPTION
Recently my node got corrupted and I tried recovering my onchain funds using the Samourai wallet, but it didn't work. The reason is that LND mnemonic is actually aezeed cipher seed, not BIP 39.

On [LND Developer Community](https://join.slack.com/t/lightningcommunity/shared_invite/enQtMzQ0OTQyNjE5NjU1LWRiMGNmOTZiNzU0MTVmYzc1ZGFkZTUyNzUwOGJjMjYwNWRkNWQzZWE3MTkwZjdjZGE5ZGNiNGVkMzI2MDU4ZTE) two dudes, Paul Gregg and moli, told me that Bitcoin seed and LND seed are different. They pointed out the recent attacks to Electrum as some of the reasons why LND doesn't use the same standard.

Another dude with nickname @walletofsatoshi pointed to two related issues on this repo: https://github.com/rootzoll/raspiblitz/issues/290 and https://github.com/rootzoll/raspiblitz/issues/278

But this readme doesn't reflect this information yet, this pull request improves the doc to help people avoid the struggle.