### PR TITLE
bug fixes for alternative platforms

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -278,6 +278,7 @@ sudo -H pip3 install redis
 # check for dependencies on DietPi, Ubuntu, Armbian
 sudo apt-get install -y build-essential
 sudo apt-get install -y python-pip
+sudo apt-get install -y python-dev
 # rsync is needed to copy from HDD
 sudo apt install -y rsync
 # install ifconfig
@@ -293,6 +294,7 @@ sudo apt install -y openssh-client
 sudo apt install -y openssh-sftp-server
 # install killall, fuser
 sudo apt-get install -y psmisc
+
 sudo apt-get clean
 sudo apt-get -y autoremove
 

--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -506,7 +506,7 @@ if [ "${baseImage}" = "raspbian" ] ; then
   sed -i "s/^state=.*/state=stresstest/g" ${infoFile}
   sed -i "s/^message=.*/message='Testing Hardware 60s'/g" ${infoFile}
   sudo /home/admin/config.scripts/blitz.stresstest.sh /home/admin/stresstest.report
-
-  echo "DONE BOOTSTRAP" >> $logFile
-  exit 0
 fi
+
+echo "DONE BOOTSTRAP" >> $logFile
+exit 0

--- a/home.admin/config.scripts/blitz.stresstest.sh
+++ b/home.admin/config.scripts/blitz.stresstest.sh
@@ -7,6 +7,12 @@ if [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  exit 1
 fi
 
+isRaspbian=$(cat /etc/os-release 2>/dev/null | grep -c 'Raspbian')
+if [ ${isRaspbian} -eq 0 ]; then
+  echo "the OS is not Raspbian - the stresstest is only for the Raspberry Pi"
+  exit 0
+fi
+
 # Based on https://github.com/bamarni/pi64/issues/4#issuecomment-292707581
 # sysbench manual: http://imysql.com/wp-content/uploads/2014/10/sysbench-manual.pdf
 

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -12,6 +12,33 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  exit 1
 fi
 
+echo "Detect Base Image ..." 
+baseImage="?"
+isDietPi=$(uname -n | grep -c 'DietPi')
+isRaspbian=$(cat /etc/os-release 2>/dev/null | grep -c 'Raspbian')
+isArmbian=$(cat /etc/os-release 2>/dev/null | grep -c 'Debian')
+isUbuntu=$(cat /etc/os-release 2>/dev/null | grep -c 'Ubuntu')
+if [ ${isRaspbian} -gt 0 ]; then
+  baseImage="raspbian"
+fi
+if [ ${isArmbian} -gt 0 ]; then
+  baseImage="armbian"
+fi 
+if [ ${isUbuntu} -gt 0 ]; then
+baseImage="ubuntu"
+fi
+if [ ${isDietPi} -gt 0 ]; then
+  baseImage="dietpi"
+fi
+if [ "${baseImage}" = "?" ]; then
+  cat /etc/os-release 2>/dev/null
+  echo "!!! FAIL !!!"
+  echo "Base Image cannot be detected or is not supported."
+  exit 1
+else
+  echo "OK running ${baseImage}"
+fi
+
 # function: install keys & sources
 prepareTorSources()
 {
@@ -29,8 +56,13 @@ prepareTorSources()
     echo ""
  
     echo "*** Adding Tor Sources to sources.list ***"
-    echo "deb https://deb.torproject.org/torproject.org stretch main" | sudo tee -a /etc/apt/sources.list
-    echo "deb-src https://deb.torproject.org/torproject.org stretch main" | sudo tee -a /etc/apt/sources.list
+    if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "armbian" ] || [ "${baseImage}" = "dietpi" ]; then
+      echo "deb https://deb.torproject.org/torproject.org stretch main" | sudo tee -a /etc/apt/sources.list
+      echo "deb-src https://deb.torproject.org/torproject.org stretch main" | sudo tee -a /etc/apt/sources.list
+    elif [ "${baseImage}" = "ubuntu" ]; then
+      echo "deb https://deb.torproject.org/torproject.org bionic main" | sudo tee -a /etc/apt/sources.list
+      echo "deb-src https://deb.torproject.org/torproject.org bionic main" | sudo tee -a /etc/apt/sources.list    
+    fi
     echo "OK"
     echo ""
 }


### PR DESCRIPTION
- let bootstrap finish on every system
- make stresstest exit 0 if not on Raspbian
- add ubuntu bionic repo to sources.list for Tor
- added apt install pyhton-dev because it is missing on some minimal repos and caused the build of lnd grpc fail