### PR TITLE
fix error when using a new disk + add support for the Nvidia Jetson Nano

### DIFF
--- a/alternative.platforms/README.md
+++ b/alternative.platforms/README.md
@@ -18,7 +18,7 @@ Specifications of the tested hardware: [hw_comparison.md](hw_comparison.md)
 All testers are welcome. Open an issue for your specific board to collaborate and share your experience.
 
 ---
-## Armbian
+## Armbian Stretch
 Many SBC-s are supported:
 https://www.armbian.com/download/
 
@@ -40,12 +40,13 @@ Continue with building the SDcard: https://github.com/rootzoll/raspiblitz#build-
 
 ---
 
-## Ubuntu
+## Ubuntu Bionic
 
 A common distro to be supplied by the manufacturer for various boards.
 
 Tested on:
 * Odroid XU4 with ubuntu-18.04.1-4.14-minimal image from https://de.eu.odroid.in/ubuntu_18.04lts/XU3_XU4_MC1_HC1_HC2
+* Nvidia Jetson Nano with Ubuntu Bionic image from https://developer.nvidia.com/embedded/learn/get-started-jetson-nano-devkit#write
 
 Burn the image to the SDCard with [Etcher](https://www.balena.io/etcher/).
 

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -148,6 +148,12 @@ if [ "${baseImage}" = "ubuntu" ] || [ "${baseImage}" = "armbian" ]; then
   sudo adduser pi sudo
 fi
 
+# special prepare when Nvidia Jetson Nano 
+if [ "${baseImage}" = "ubuntu" ] && [ ${isAARCH64} -eq 1 ] ; then
+  # disable GUI on boot
+  sudo systemctl set-default multi-user.target
+fi
+
 echo ""
 echo "*** CONFIG ***"
 # based on https://github.com/Stadicus/guides/blob/master/raspibolt/raspibolt_20_pi.md#raspi-config

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -62,6 +62,7 @@ isDietPi=$(uname -n | grep -c 'DietPi')
 isRaspbian=$(cat /etc/os-release 2>/dev/null | grep -c 'Raspbian')
 isArmbian=$(cat /etc/os-release 2>/dev/null | grep -c 'Debian')
 isUbuntu=$(cat /etc/os-release 2>/dev/null | grep -c 'Ubuntu')
+isNvidia=$(uname -a | grep -c 'tegra')
 if [ ${isRaspbian} -gt 0 ]; then
   baseImage="raspbian"
 fi
@@ -149,7 +150,7 @@ if [ "${baseImage}" = "ubuntu" ] || [ "${baseImage}" = "armbian" ]; then
 fi
 
 # special prepare when Nvidia Jetson Nano 
-if [ "${baseImage}" = "ubuntu" ] && [ ${isAARCH64} -eq 1 ] ; then
+if [ ${isNvidia} -eq 1 ] ; then
   # disable GUI on boot
   sudo systemctl set-default multi-user.target
 fi

--- a/home.admin/00raspiblitz.sh
+++ b/home.admin/00raspiblitz.sh
@@ -20,6 +20,7 @@ if [ ${hddExists} -eq 0 ]; then
     echo "Press ENTER to create a Partition - or CTRL+C to abort"
     read key
     echo "Creating Partition ..."
+    sudo parted -s /dev/sda mklabel msdos
     sudo parted -s /dev/sda unit s mkpart primary `sudo parted /dev/sda unit s print free | grep 'Free Space' | tail -n 1`
     echo "DONE."
     sleep 3


### PR DESCRIPTION
* add special prepare for Nvidia Jetson Nano and add base image link to docs
Disables GUI/X11 login to make sure that you can login after rebooting.
Detailed here: https://github.com/openoms/raspiblitz/pull/50

* make parted to label a disk without a partition to avoid the error:  
`Error: /dev/sda: unrecognised disk label`
```
Starting the main menu ...
***********************************************************
WARNING: HDD HAS NO PARTITIONS
***********************************************************
Press ENTER to create a Partition - or CTRL+C to abort


Creating Partition ...
Error: /dev/sda: unrecognised disk label
Error: /dev/sda: unrecognised disk label
DONE.

...

*** Checking if HDD is connected ***
FAIL - no HDD as device sda1 found
lsblk -o UUID,NAME,FSTYPE,SIZE,LABEL,MODEL
check if HDD is properly connected and has enough power - then try again
sometimes a reboot helps: sudo shutdown -r now

```