### PR TITLE
add a command-line fuzzy finder

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -677,6 +677,10 @@ sudo apt-get -y install screen
 sudo bash -c "echo 'net.core.rmem_max = 4194304' >> /etc/sysctl.conf"
 sudo bash -c "echo 'net.core.wmem_max = 1048576' >> /etc/sysctl.conf"
 
+# install a command-line fuzzy finder (https://github.com/junegunn/fzf)
+sudo apt-get -y install fzf
+sudo bash -c "echo 'source /usr/share/doc/fzf/examples/key-bindings.bash' >> /home/admin/.bashrc"
+
 # *** SHELL SCRIPTS AND ASSETS
 
 # move files from gitclone


### PR DESCRIPTION
Add a command-line fuzzy finder: https://github.com/junegunn/fzf

A great tool to search through previous terminal entries. Proved very useful with heavy usage of cli-s.

Use by pressing CTRL+R at the command prompt and start typing to search in terminal history.

Try on an already setup RaspiBlitz by running:
`sudo apt-get -y install fzf && sudo bash -c "echo 'source /usr/share/doc/fzf/examples/key-bindings.bash' >> /home/admin/_commands.sh" && source /usr/share/doc/fzf/examples/key-bindings.bash`