### PR TITLE
Update 10setupBlitz.sh

### DIFF
--- a/home.admin/10setupBlitz.sh
+++ b/home.admin/10setupBlitz.sh
@@ -196,7 +196,7 @@ if [ ${mountOK} -eq 1 ]; then
   if [ ${network} = "bitcoin" ]; then
     echo "Bitcoin Options"
     menuitem=$(dialog --clear --beep --backtitle "RaspiBlitz" --title "Getting the Blockchain" \
-    --menu "You need a copy of the Bitcoin Blockchain - you have 5 options:" 13 75 5 \
+    --menu "You need a copy of the Bitcoin Blockchain - you have 4 options:" 13 75 5 \
     T "TORRENT  --> MAINNET + TESTNET thru Torrent (DEFAULT)" \
     C "COPY     --> BLOCKCHAINDATA from another node with SCP" \
     N "CLONE    --> BLOCKCHAINDATA from 2nd HDD (extra cable)"\
@@ -206,7 +206,7 @@ if [ ${mountOK} -eq 1 ]; then
   elif [ ${network} = "litecoin" ]; then
     echo "Litecoin Options"
     menuitem=$(dialog --clear --beep --backtitle "RaspiBlitz" --title "Getting the Blockchain" \
-    --menu "You need a copy of the Litecoin Blockchain - you have 3 options:" 13 75 4 \
+    --menu "You need a copy of the Litecoin Blockchain - you have 2 options:" 13 75 4 \
     T "TORRENT  --> MAINNET thru Torrent (DEFAULT)" \
     S "SYNC     --> MAINNET thru Litecoin Network (FALLBACK+SLOW)" 2>&1 >/dev/tty)
 


### PR DESCRIPTION
Fixed typo that offered one option count more than available. 
"..choose from these 5 options ..." > "..choose from these 4 options.."
"..choose from these 3 options ..." > "..choose from these 2 options.."

Just had to do the setup more than once. 