### PR TITLE
fix goOS version and check for v1.12.8 by default

### DIFF
--- a/home.admin/97addMobileWalletLNDconnect.sh
+++ b/home.admin/97addMobileWalletLNDconnect.sh
@@ -28,13 +28,13 @@ if [ ${#GOPATH} -eq 0 ]; then
 fi
 
 # make sure go is installed
-goVersion="1.11"
+goVersion="1.12.8"
 echo "### Check Framework: GO ###"
 goInstalled=$(go version 2>/dev/null | grep -c 'go')
 if [ ${goInstalled} -eq 0 ];then
   goVersion="1.12.8"
   if [ ${isARM} -eq 1 ] ; then
-    goOSversion="armv7l"
+    goOSversion="armv6l"
   fi
   if [ ${isAARCH64} -eq 1 ] ; then
     goOSversion="arm64"

--- a/home.admin/97addMobileWalletZeus.sh
+++ b/home.admin/97addMobileWalletZeus.sh
@@ -19,7 +19,7 @@ goInstalled=$(go version 2>/dev/null | grep -c 'go')
 if [ ${goInstalled} -eq 0 ];then
   goVersion="1.12.8"
   if [ ${isARM} -eq 1 ] ; then
-    goOSversion="armv7l"
+    goOSversion="armv6l"
   fi
   if [ ${isAARCH64} -eq 1 ] ; then
     goOSversion="arm64"


### PR DESCRIPTION
fixing https://github.com/rootzoll/raspiblitz/issues/730

Go does not have ARM7l version only ARM6l.
The fix was tested to work.

The unnecessary warning about `untested version of GO` is removed by checking for the installed version.