### PR TITLE
add Go to PATH

### DIFF
--- a/home.admin/97addMobileWalletLNDconnect.sh
+++ b/home.admin/97addMobileWalletLNDconnect.sh
@@ -69,6 +69,7 @@ if [ ${goInstalled} -eq 0 ];then
   export PATH=$PATH:$GOROOT/bin
   export GOPATH=/usr/local/gocode
   export PATH=$PATH:$GOPATH/bin
+  sudo bash -c "echo 'PATH=\$PATH:/usr/local/gocode/bin/' >> /etc/profile"
   goInstalled=$(go version 2>/dev/null | grep -c 'go')
 fi
 if [ ${goInstalled} -eq 0 ];then


### PR DESCRIPTION
Resolves the issue when `lndconnect -j`  is not available if Go is not freshly installed.

LNDconnect displays this under the QR, causing confusion if the command is not available: 
![Screenshot from 2019-09-11 10-15-18](https://user-images.githubusercontent.com/43343391/64684525-2ba8e400-d47d-11e9-8032-058c1f719498.png)