### PR TITLE
build_sdcard: fix PGPcheck for @roasbeef key

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -494,7 +494,7 @@ lndVersion="0.7.1-beta"
 
 # olaoluwa
 PGPpkeys="https://keybase.io/roasbeef/pgp_keys.asc"
-PGPcheck="BD599672C804AF2770869A048B80CD2BB8BD8132"
+PGPcheck="9769140D255C759B1EB77B46A96387A57CAAE94D"
 # bitconner
 #PGPpkeys="https://keybase.io/bitconner/pgp_keys.asc"
 #PGPcheck="9C8D61868A7C492003B2744EE7D737B67FA592C7"


### PR DESCRIPTION
The correct fingerprint of the PGP key downloaded is being checked, but @roasbeef's key has been rotated on 2019-07-10 which has not been updated in the script.
This does not affect the verification of the manifest file and lnd package, but causes an error message during the SDcard build.
Fixes https://github.com/rootzoll/raspiblitz/issues/797