### PR TITLE
Fix tor prepare when called by sd_build.sh

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -712,10 +712,6 @@ sudo systemctl enable background
 echo "*** Prepare TOR source+keys ***"
 sudo /home/admin/config.scripts/internet.tor.sh prepare
 echo ""
-echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-echo "If you see fails above .. please run again later on:"
-echo "sudo /home/admin/config.scripts/internet.tor.sh prepare"
-echo ""
 
 # *** RASPIBLITZ IMAGE READY ***
 echo ""

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -14,11 +14,12 @@ fi
 
 # check and load raspiblitz config
 # to know which network is running
-source /home/admin/raspiblitz.info
-source /mnt/hdd/raspiblitz.conf
-if [ ${#network} -eq 0 ]; then
- echo "FAIL - missing /mnt/hdd/raspiblitz.conf"
- exit 1
+if [ -f "/home/admin/raspiblitz.info" ]; then
+  source /home/admin/raspiblitz.info
+fi
+
+if [ -f "/mnt/hdd/raspiblitz.conf" ]; then
+  source /mnt/hdd/raspiblitz.conf
 fi
 
 echo "Detect Base Image ..." 
@@ -169,19 +170,25 @@ if [ "$1" = "prepare" ] || [ "$1" = "-prepare" ]; then
   exit 0
 fi
 
-# if started with prepare 
+# make sure the network was set (by sourcing raspiblitz.conf)
+if [ ${#network} -eq 0 ]; then
+ echo "FAIL - unknwon network due to missing /mnt/hdd/raspiblitz.conf"
+ exit 1
+fi
+
+# if started with btcconf-on 
 if [ "$1" = "btcconf-on" ]; then
   activateBitcoinOverTOR
   exit 0
 fi
 
-# if started with prepare 
+# if started with btcconf-off
 if [ "$1" = "btcconf-off" ]; then
   deactivateBitcoinOverTOR
   exit 0
 fi
 
-# if started with prepare 
+# if started with lndconf-on
 if [ "$1" = "lndconf-on" ]; then
   activateLndOverTOR
   exit 0
@@ -356,6 +363,6 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   exit 0
 fi
 
-echo "FAIL - Unknown Paramter $1"
+echo "FAIL - Unknown Parameter $1"
 echo "may needs reboot to run normal again"
 exit 1


### PR DESCRIPTION
The sd_build.sh script is run when raspiblitz.conf is not yet present. The function `prepare` doesn't need anything from raspiblitz.conf and can therefore run even if the file is not present.