### PR TITLE
build_sdcard: remove plymouth during sdcard build

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -142,7 +142,7 @@ if [ "${baseImage}" = "raspbian" ]; then
   # see https://github.com/rootzoll/raspiblitz/issues/428#issuecomment-472822840
   echo "max_usb_current=1" | sudo tee -a /boot/config.txt
   # extra: remove some big packages not needed
-  sudo apt-get remove -y --purge libreoffice* oracle-java* chromium-browser nuscratch scratch sonic-pi minecraft-pi python-pygame
+  sudo apt-get remove -y --purge libreoffice* oracle-java* chromium-browser nuscratch scratch sonic-pi minecraft-pi python-pygame plymouth
   sudo apt-get clean
   sudo apt-get -y autoremove
 fi


### PR DESCRIPTION
Remove the plymouth package during the SDcard build

fixes: https://github.com/rootzoll/raspiblitz/issues/796, https://github.com/rootzoll/raspiblitz/issues/861
