### PR TITLE
electrs: use as address API if active, allow large history

### DIFF
--- a/home.admin/_background.sh
+++ b/home.admin/_background.sh
@@ -308,6 +308,16 @@ do
   fi
 
   ###############################
+  # Set the address API use for BTC-RPC-Explorer depending on Electrs status
+  ###############################
+
+  # check every 10 minutes
+  electrsExplorer=$((($counter % 600)+1))
+  if [ ${electrsExplorer} -eq 1 ]; then
+    /home/admin/config.scripts/bonus.electrsexplorer.sh
+  fi
+
+  ###############################
   # Prepare next loop
   ###############################
 

--- a/home.admin/_background.sh
+++ b/home.admin/_background.sh
@@ -314,7 +314,9 @@ do
   # check every 10 minutes
   electrsExplorer=$((($counter % 600)+1))
   if [ ${electrsExplorer} -eq 1 ]; then
-    /home/admin/config.scripts/bonus.electrsexplorer.sh
+    if [ "${BTCRPCexplorer}" = "on" ] & [ "${ElectRS}" = "on" ]; then
+      /home/admin/config.scripts/bonus.electrsexplorer.sh
+    fi
   fi
 
   ###############################

--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -95,8 +95,8 @@ BTCEXP_BASIC_AUTH_PASSWORD=$PASSWORD_B
 # If electrumx set, the BTCEXP_ELECTRUMX_SERVERS variable must also be
 # set.
 # Default: none
-# BTCEXP_ADDRESS_API=electrumx
-# BTCEXP_ELECTRUMX_SERVERS=tcp://127.0.0.1:50001
+BTCEXP_ADDRESS_API=none
+BTCEXP_ELECTRUMX_SERVERS=tcp://127.0.0.1:50001
 EOF
     sudo mv /home/admin/btc-rpc-explorer.env /home/bitcoin/.config/btc-rpc-explorer.env
     sudo chown bitcoin:bitcoin /home/bitcoin/.config/btc-rpc-explorer.env
@@ -138,17 +138,6 @@ EOF
     echo "BTC-RPC-explorer already installed."
   fi
 
-  # Enable BTCEXP_ADDRESS_API if electrs is active
-  if [ $(sudo -u bitcoin lsof -i | grep -c 50001) -eq 1 ]; then
-    echo "electrs is active - switching support on"
-    sudo -u bitcoin sed -i '/BTCEXP_ADDRESS_API=electrumx/s/^#//g' /home/bitcoin/.config/btc-rpc-explorer.env
-    sudo -u bitcoin sed -i '/BTCEXP_ELECTRUMX_SERVERS=/s/^#//g' /home/bitcoin/.config/btc-rpc-explorer.env
-  else
-    echo "electrs is not active - switching support off"
-    sudo -u bitcoin sed -i '/BTCEXP_ADDRESS_API=electrumx/s/^/#/g' /home/bitcoin/.config/btc-rpc-explorer.env
-    sudo -u bitcoin sed -i '/BTCEXP_ELECTRUMX_SERVERS=/s/^/#/g' /home/bitcoin/.config/btc-rpc-explorer.env    
-  fi
-
   # start service
   echo "Starting service"
   sudo systemctl start btc-rpc-explorer 2>/dev/null
@@ -158,6 +147,9 @@ EOF
   
   echo "needs to finish creating txindex to be functional"
   echo "monitor with: sudo tail -n 20 -f /mnt/hdd/bitcoin/debug.log"
+
+  ## Enable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
+  /home/admin/config.scripts/bonus.electrsexplorer.sh
 
   # Hidden Service for BTC-RPC-explorer if Tor is active
   source /mnt/hdd/raspiblitz.conf

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -102,6 +102,8 @@ timestamp = true
 jsonrpc_import = true
 db_dir = "/mnt/hdd/electrs/db"
 cookie = "$RPC_USER:$PASSWORD_B"
+# allow BTC-RPC-explorer show tx-s for addresses with a history of more than 100
+txid_limit = 0
 EOF
     sudo mv /home/admin/config.toml /home/electrs/.electrs/config.toml
     sudo chown electrs:electrs /home/electrs/.electrs/config.toml
@@ -263,19 +265,8 @@ WantedBy=multi-user.target
   fi
 
   ## Enable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
-  if [ "${BTCRPCexplorer}" = "on" ]; then
-      # Enable BTCEXP_ADDRESS_API if electrs is active
-      if [ $(sudo -u bitcoin lsof -i | grep -c 50001) -eq 1 ]; then
-        echo "electrs is active - switching support on"
-        sudo -u bitcoin sed -i '/BTCEXP_ADDRESS_API=electrumx/s/^#//g' /home/bitcoin/.config/btc-rpc-explorer.env
-        sudo -u bitcoin sed -i '/BTCEXP_ELECTRUMX_SERVERS=/s/^#//g' /home/bitcoin/.config/btc-rpc-explorer.env
-      else
-        echo "electrs is not active - switching support off"
-        sudo -u bitcoin sed -i '/BTCEXP_ADDRESS_API=electrumx/s/^/#/g' /home/bitcoin/.config/btc-rpc-explorer.env
-        sudo -u bitcoin sed -i '/BTCEXP_ELECTRUMX_SERVERS=/s/^/#/g' /home/bitcoin/.config/btc-rpc-explorer.env    
-      fi
-  fi
-
+  /home/admin/config.scripts/bonus.electrsexplorer.sh
+  
   echo ""
   echo "To connect through SSL from outside of the local network make sure the port 50002 is forwarded on the router"
   echo "Electrum wallet: start with the options \`electrum --oneserver --server RaspiBlitz_IP:50002:s\`"
@@ -303,11 +294,7 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     echo "OK ElectRS removed."
     
     ## Disable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
-    if [ "${BTCRPCexplorer}" = "on" ]; then
-      echo "electrs is not active - switching support off"
-      sudo -u bitcoin sed -i '/BTCEXP_ADDRESS_API=electrumx/s/^/#/g' /home/bitcoin/.config/btc-rpc-explorer.env
-      sudo -u bitcoin sed -i '/BTCEXP_ELECTRUMX_SERVERS=/s/^/#/g' /home/bitcoin/.config/btc-rpc-explorer.env    
-    fi
+    /home/admin/config.scripts/bonus.electrsexplorer.sh
   else 
     echo "ElectRS is not installed."
   fi

--- a/home.admin/config.scripts/bonus.electrsexplorer.sh
+++ b/home.admin/config.scripts/bonus.electrsexplorer.sh
@@ -56,8 +56,8 @@ EOF
      sudo sed -i "s/^ExecStart=\/home\/bitcoin\/btc-rpc-explorer.run.sh/ExecStart=\/usr\/local\/lib\/nodejs\/node-$(node -v)-$DISTRO\/bin\/btc-rpc-explorer/g" /etc/systemd/system/btc-rpc-explorer.service
      sudo systemctl daemon-reload
      sudo systemctl restart btc-rpc-explorer
-
    fi
+
 else
   ## Disable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
   if [ "${BTCRPCexplorer}" = "on" ]; then

--- a/home.admin/config.scripts/bonus.electrsexplorer.sh
+++ b/home.admin/config.scripts/bonus.electrsexplorer.sh
@@ -1,0 +1,71 @@
+# config script to make BTC-RPC-Explorer use Electrs if both active
+
+source /mnt/hdd/raspiblitz.conf
+
+# determine nodeJS DISTRO
+isARM=$(uname -m | grep -c 'arm')   
+isAARCH64=$(uname -m | grep -c 'aarch64')
+isX86_64=$(uname -m | grep -c 'x86_64')
+isX86_32=$(uname -m | grep -c 'i386\|i486\|i586\|i686\|i786')
+if [ ${isARM} -eq 1 ] ; then
+DISTRO="linux-armv7l"
+fi
+if [ ${isAARCH64} -eq 1 ] ; then
+DISTRO="linux-arm64"
+fi
+if [ ${isX86_64} -eq 1 ] ; then
+DISTRO="linux-x64"
+fi
+if [ ${isX86_32} -eq 1 ] ; then
+echo "FAIL: No X86 32bit build available - will abort setup"
+exit 1
+fi
+if [ ${#DISTRO} -eq 0 ]; then
+echo "FAIL: Was not able to determine architecture"
+exit 1
+fi
+
+if [ "${BTCRPCexplorer}" = "on" ] & [ "${ElectRS}" = "on" ]; then
+  ## Enable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
+  if [ $(sudo -u electrs lsof -i | grep -c 50001) -gt 0 ]; then
+      echo "electrs is active - switching address API support on in BTC-RPC-Explorer"
+      sudo -u bitcoin sed -i 's/^BTCEXP_ADDRESS_API=none/BTCEXP_ADDRESS_API=electrumx/g' /home/bitcoin/.config/btc-rpc-explorer.env
+
+      # create ExecStart=/home/bitcoin/btc-rpc-explorer.run.sh     
+      cat > /home/admin/btc-rpc-explorer.run.sh <<EOF
+#!/bin/bash
+echo "Waiting Electrs on port 50001..."
+while [ $(sudo -u electrs lsof -i | grep -c 50001) -eq 0 ]; do
+  sleep 1
+done
+echo "Electrs started, launching BTC-RPC-Explorer..."
+/usr/local/lib/nodejs/node-$(node -v)-$DISTRO/bin/btc-rpc-explorer
+EOF
+     sudo mv /home/admin/btc-rpc-explorer.run.sh /home/bitcoin/btc-rpc-explorer.run.sh
+     sudo chown bitcoin:bitcoin /home/bitcoin/btc-rpc-explorer.run.sh
+     sudo chmod +x /home/bitcoin/btc-rpc-explorer.run.sh
+
+     sudo sed -i "s/^ExecStart=\/usr\/local\/lib\/nodejs\/node-$(node -v)-$DISTRO\/bin\/btc-rpc-explorer/ExecStart=\/home\/bitcoin\/btc-rpc-explorer.run.sh/g" /etc/systemd/system/btc-rpc-explorer.service
+     sudo systemctl daemon-reload
+     sudo systemctl restart btc-rpc-explorer
+   
+   else
+     echo "electrs is not active - switching address API support off in BTC-RPC-Explorer"
+     sudo -u bitcoin sed -i 's/^BTCEXP_ADDRESS_API=electrumx/BTCEXP_ADDRESS_API=none/g' /home/bitcoin/.config/btc-rpc-explorer.env
+     
+     sudo sed -i "s/^ExecStart=\/home\/bitcoin\/btc-rpc-explorer.run.sh/ExecStart=\/usr\/local\/lib\/nodejs\/node-$(node -v)-$DISTRO\/bin\/btc-rpc-explorer/g" /etc/systemd/system/btc-rpc-explorer.service
+     sudo systemctl daemon-reload
+     sudo systemctl restart btc-rpc-explorer
+
+   fi
+else
+  ## Disable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
+  if [ "${BTCRPCexplorer}" = "on" ]; then
+     echo "electrs is not active - switching address API support off in BTC-RPC-Explorer"
+     sudo -u bitcoin sed -i 's/^BTCEXP_ADDRESS_API=electrumx/BTCEXP_ADDRESS_API=none/g' /home/bitcoin/.config/btc-rpc-explorer.env
+     
+     sudo sed -i "s/^ExecStart=\/home\/bitcoin\/btc-rpc-explorer.run.sh/ExecStart=\/usr\/local\/lib\/nodejs\/node-$(node -v)-$DISTRO\/bin\/btc-rpc-explorer/g" /etc/systemd/system/btc-rpc-explorer.service
+     sudo systemctl daemon-reload
+     sudo systemctl restart btc-rpc-explorer
+  fi
+fi


### PR DESCRIPTION
Address history is only functional in BTC-RPC-Explorer if Electrs is synced and running.

* check Electrs status and switch the address API function on/off for BTC-RPC-Explorer
* use a script for systemctl to wait with starting BTC-RPC-Explorer until Electrs is synced https://github.com/openoms/raspiblitz-extras/issues/4

* allow scanning large address history for electrs https://github.com/openoms/raspiblitz-extras/issues/3