### PR TITLE
go: fix GOPATH settings

### DIFF
--- a/home.admin/97addMobileWalletLNDconnect.sh
+++ b/home.admin/97addMobileWalletLNDconnect.sh
@@ -23,6 +23,9 @@ source /mnt/hdd/raspiblitz.conf
 # make sure lndconnect is installed
 /home/admin/config.scripts/bonus.lndconnect.sh
 
+# get Go vars
+source /etc/profile
+
 # default host to local IP and port
 local=1
 localIP=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')

--- a/home.admin/97addMobileWalletTor.sh
+++ b/home.admin/97addMobileWalletTor.sh
@@ -18,6 +18,9 @@ fi
 # make sure lndconnect is installed
 /home/admin/config.scripts/bonus.lndconnect.sh
 
+# get Go vars
+source /etc/profile
+
 if [ $1 == zeus ]; then
   echo ""
   echo "Set up on your mobile: " 

--- a/home.admin/config.scripts/bonus.go.sh
+++ b/home.admin/config.scripts/bonus.go.sh
@@ -48,6 +48,9 @@ if [ ${goInstalled} -eq 0 ];then
   sudo bash -c "echo 'GOPATH=/usr/local/gocode' >> /etc/profile"   
   sudo bash -c "echo 'PATH=\$PATH:\$GOPATH/bin/' >> /etc/profile"
   
+  # set GOPATH https://github.com/golang/go/wiki/SettingGOPATH
+  go env -w GOPATH=/usr/local/gocode
+  
   goInstalled=$(go version 2>/dev/null | grep -c 'go')
 fi
 if [ ${goInstalled} -eq 0 ];then

--- a/home.admin/config.scripts/bonus.lndconnect.sh
+++ b/home.admin/config.scripts/bonus.lndconnect.sh
@@ -7,10 +7,11 @@ commit=82d7103bb8c8dd3c8ae8de89e3bc061eef82bb8f
 isInstalled=$(lndconnect -h | grep "nocert" -c)
 if [ $isInstalled -eq 0 ]; then
   echo "Installing lndconnect.."
+  # get Go vars
+  source /etc/profile
   # Install latest lndconnect from source:
   go get -d github.com/LN-Zap/lndconnect
-  # locate lndconnect download dir 
-  cd /usr/local/gocode/src/github.com/LN-Zap/lndconnect
+  cd $GOPATH/src/github.com/LN-Zap/lndconnect
   git checkout $commit
   make
 else

--- a/home.admin/config.scripts/bonus.loop.sh
+++ b/home.admin/config.scripts/bonus.loop.sh
@@ -22,8 +22,11 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   
   isInstalled=$(sudo ls /etc/systemd/system/loopd.service 2>/dev/null | grep -c 'loopd.service')
   if [ ${isInstalled} -eq 0 ]; then
-    /home/admin/config.scripts/go.install.sh
+    /home/admin/config.scripts/bonus.go.sh
     
+    # get Go vars
+    source /etc/profile
+
     cd /home/bitcoin
     sudo -u bitcoin git clone https://github.com/lightninglabs/loop.git
     cd /home/bitcoin/loop
@@ -32,7 +35,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     go install ./...
     
     # make systemd service
-    # sudo nano /etc/systemd/system/electrs.service 
+    # sudo nano /etc/systemd/system/loopd.service 
     echo "
 [Unit]
 Description=Loopd Service


### PR DESCRIPTION
fixing the problem that GOPATH was not active after Go was installed fresh with the separate script

modifying the default GOPATH (~go) systemwide with  `go env -w GOPATH=/usr/local/gocode`

fixing a filename