### PR TITLE
BlitzTUI - Node URI remove line break

### DIFF
--- a/home.admin/BlitzTUI/CHANGELOG.md
+++ b/home.admin/BlitzTUI/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- remove line break for longer TORv3 NodeURI
+
 
 ## [0.42.0] - 2019-12-25
 ### Added

--- a/home.admin/BlitzTUI/blitztui/main.py
+++ b/home.admin/BlitzTUI/blitztui/main.py
@@ -300,7 +300,7 @@ class AppWindow(QMainWindow):
             pub = [(pub[i:i + n]) for i in range(0, len(pub), n)]
             host = [(host[i:i + n]) for i in range(0, len(host), n)]
             self.ui_qr_code.memo_value.show()
-            self.ui_qr_code.memo_value.setText("{} \n@\n{} \n:{}".format(" ".join(pub), " ".join(host), port))
+            self.ui_qr_code.memo_value.setText("{} \n@{} \n:{}".format(" ".join(pub), " ".join(host), port))
 
             self.ui_qr_code.status_key.hide()
             self.ui_qr_code.status_value.hide()
@@ -625,12 +625,6 @@ Keep on stacking SATs..! :-D"""
     parser.add_argument("-V", "--version",
                         help="print version", action="version",
                         version=__version__)
-    #
-    # parser.add_argument("-g", "--game",
-    #                     help="game binary", type=str)
-    #
-    # parser.add_argument("-s", "--skip",
-    #                     help="skip", action="store_true")
 
     # parse args
     args = parser.parse_args()


### PR DESCRIPTION
Needed due to the longer TORv3 addresses.