### PR TITLE
change blockchain size calculation

### DIFF
--- a/home.admin/00raspiblitz.sh
+++ b/home.admin/00raspiblitz.sh
@@ -114,9 +114,20 @@ waitUntilChainNetworkIsReady()
       rm error.tmp
 
       # check for missing blockchain data
-      minSize=210000000000
-      if [ "${network}" = "litecoin" ]; then
-        minSize=20000000000
+      if [ "${network}" = "bitcoin" ]; then
+        if [ "${chain}" = "main" ]; then
+          minSize=210000000000
+        else
+          minSize=27000000000
+        fi
+      elif [ "${network}" = "litecoin" ]; then
+        if [ "${chain}" = "main" ]; then
+          minSize=20000000000
+        else
+          minSize=27000000000
+        fi
+      else
+        minSize=210000000000000
       fi
       isSyncing=$(sudo ls -la /mnt/hdd/${network}/blocks/.selfsync 2>/dev/null | grep -c '.selfsync')
       blockchainsize=$(sudo du -shbc /mnt/hdd/${network}/ 2>/dev/null | head -n1 | awk '{print $1;}')

--- a/home.admin/50cloneHDD.sh
+++ b/home.admin/50cloneHDD.sh
@@ -131,7 +131,7 @@ if [ ${count} -gt 0 ]; then
    anyDataAtAll=1
 fi
 if [ ${count} -lt 300 ]; then
-  echo "FAIL: transfere seems invalid - less then 300 .dat files (${count})"
+  echo "FAIL: transfer seems invalid - less then 300 .dat files (${count})"
   quickCheckOK=0
 fi
 count=$(sudo find /mnt/hdd/bitcoin/ -iname *.ldb -type f | wc -l)
@@ -140,7 +140,7 @@ if [ ${count} -gt 0 ]; then
    anyDataAtAll=1
 fi
 if [ ${count} -lt 700 ]; then
-  echo "FAIL: transfere seems invalid - less then 700 .ldb files (${count})"
+  echo "FAIL: transfer seems invalid - less then 700 .ldb files (${count})"
   quickCheckOK=0
 fi
 

--- a/home.admin/50cloneHDD.sh
+++ b/home.admin/50cloneHDD.sh
@@ -125,22 +125,22 @@ sudo unlink /home/bitcoin/.bitcoin
 # make quick check if data is there
 anyDataAtAll=0
 quickCheckOK=1
-count=$(sudo ls /mnt/hdd/bitcoin/blocks 2>/dev/null | grep -c '.dat')
+count=$(sudo find /mnt/hdd/bitcoin/ -iname *.dat -type f | wc -l)
 if [ ${count} -gt 0 ]; then
    echo "Found data in /mnt/hdd/bitcoin/blocks"
    anyDataAtAll=1
 fi
-if [ ${count} -lt 3000 ]; then
-  echo "FAIL: transfere seems invalid - less then 3000 .dat files (${count})"
+if [ ${count} -lt 300 ]; then
+  echo "FAIL: transfere seems invalid - less then 300 .dat files (${count})"
   quickCheckOK=0
 fi
-count=$(sudo ls /mnt/hdd/bitcoin/chainstate 2>/dev/null | grep -c '.ldb')
+count=$(sudo find /mnt/hdd/bitcoin/ -iname *.ldb -type f | wc -l)
 if [ ${count} -gt 0 ]; then
    echo "Found data in /mnt/hdd/bitcoin/chainstate"
    anyDataAtAll=1
 fi
-if [ ${count} -lt 1400 ]; then
-  echo "FAIL: transfere seems invalid - less then 1400 .ldb files (${count})"
+if [ ${count} -lt 700 ]; then
+  echo "FAIL: transfere seems invalid - less then 700 .ldb files (${count})"
   quickCheckOK=0
 fi
 

--- a/home.admin/50copyHDD.sh
+++ b/home.admin/50copyHDD.sh
@@ -88,22 +88,22 @@ read key
 # make quick check if data is there
 anyDataAtAll=0
 quickCheckOK=1
-count=$(sudo ls /mnt/hdd/bitcoin/blocks 2>/dev/null | grep -c '.dat')
+count=$(sudo find /mnt/hdd/bitcoin/ -iname *.dat -type f | wc -l)
 if [ ${count} -gt 0 ]; then
    echo "Found data in /mnt/hdd/bitcoin/blocks"
    anyDataAtAll=1
 fi
-if [ ${count} -lt 3000 ]; then
-  echo "FAIL: transfere seems invalid - less then 3000 .dat files (${count})"
+if [ ${count} -lt 300 ]; then
+  echo "FAIL: transfere seems invalid - less then 300 .dat files (${count})"
   quickCheckOK=0
 fi
-count=$(sudo ls /mnt/hdd/bitcoin/chainstate 2>/dev/null | grep -c '.ldb')
+count=$(sudo find /mnt/hdd/bitcoin/ -iname *.ldb -type f | wc -l)
 if [ ${count} -gt 0 ]; then
    echo "Found data in /mnt/hdd/bitcoin/chainstate"
    anyDataAtAll=1
 fi
-if [ ${count} -lt 1400 ]; then
-  echo "FAIL: transfere seems invalid - less then 1400 .ldb files (${count})"
+if [ ${count} -lt 700 ]; then
+  echo "FAIL: transfere seems invalid - less then 700 .ldb files (${count})"
   quickCheckOK=0
 fi
 

--- a/home.admin/50copyHDD.sh
+++ b/home.admin/50copyHDD.sh
@@ -94,7 +94,7 @@ if [ ${count} -gt 0 ]; then
    anyDataAtAll=1
 fi
 if [ ${count} -lt 300 ]; then
-  echo "FAIL: transfere seems invalid - less then 300 .dat files (${count})"
+  echo "FAIL: transfer seems invalid - less then 300 .dat files (${count})"
   quickCheckOK=0
 fi
 count=$(sudo find /mnt/hdd/bitcoin/ -iname *.ldb -type f | wc -l)
@@ -103,7 +103,7 @@ if [ ${count} -gt 0 ]; then
    anyDataAtAll=1
 fi
 if [ ${count} -lt 700 ]; then
-  echo "FAIL: transfere seems invalid - less then 700 .ldb files (${count})"
+  echo "FAIL: transfer seems invalid - less then 700 .ldb files (${count})"
   quickCheckOK=0
 fi
 


### PR DESCRIPTION
There are some "sanity" checks that make sure that the system is in the expected state. E.g. there are checks that enough blockchain files are in the blocks directory. The assumed values only worked for mainnet.

This should fix #949.

I'm not too happy with the hardcoded values buried in several scripts.. might make sense to have a central file with "constant values" for this.