### PR TITLE
Remove source bitcoin.conf from txindex and wallet script

### DIFF
--- a/home.admin/config.scripts/network.txindex.sh
+++ b/home.admin/config.scripts/network.txindex.sh
@@ -3,19 +3,30 @@
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  echo "config script to switch txindex on or off"
- echo "network.txindex.sh [on|off]"
+ echo "network.txindex.sh [status|on|off]"
  exit 1
 fi
 
 source /mnt/hdd/raspiblitz.conf
-source /mnt/hdd/${network}/${network}.conf
 
-# add default value to bitcoin.conf if needed
-if [ ${#txindex} -eq 0 ]; then
-  echo "txindex=0" >> /mnt/hdd/${network}/${network}.conf
-  source /mnt/hdd/${network}/${network}.conf
+# add txindex with default value (0) to bitcoin.conf if missing
+if ! grep -Eq "^txindex=.*" /mnt/hdd/${network}/${network}.conf; then
+  echo "txindex=0" | sudo tee -a /mnt/hdd/${network}/${network}.conf >/dev/null
 fi
 
+# set variable ${txindex}
+source <(grep -E "^txindex=.*" /mnt/hdd/${network}/${network}.conf)
+
+# check for testnet and set pathAdd (e.g. for debug.log)
+pathAdd=""
+if [ "${chain}" = "test" ]; then
+	  pathAdd="/testnet3"
+fi
+
+
+###################
+# STATUS
+###################
 if [ "$1" = "status" ]; then
 
   echo "##### STATUS TXINDEX"
@@ -26,9 +37,9 @@ if [ "$1" = "status" ]; then
   fi
 
   # try to gather if still indexing
-  indexedToBlock=$(sudo tail -n 100 /mnt/hdd/${network}/debug.log | grep "Syncing txindex with block chain from height" | tail -n 1 | cut -d " " -f 9 | sed 's/[^0-9]*//g')
+  indexedToBlock=$(sudo tail -n 200 /mnt/hdd/${network}${pathAdd}/debug.log | grep "Syncing txindex with block chain from height" | tail -n 1 | cut -d " " -f 9 | sed 's/[^0-9]*//g')
   blockchainHeight=$(sudo -u bitcoin ${network}-cli getblockchaininfo 2>/dev/null | jq -r '.blocks' | sed 's/[^0-9]*//g')
-  indexFinished=$(sudo tail -n 100 /mnt/hdd/${network}/debug.log | grep -c "txindex is enabled at height")
+  indexFinished=$(sudo tail -n 200 /mnt/hdd/${network}${pathAdd}/debug.log | grep -c "txindex is enabled at height")
   echo "indexedToBlock=${indexedToBlock}"
   echo "blockchainHeight=${blockchainHeight}"
   echo "indexFinished=${indexFinished}"
@@ -48,14 +59,17 @@ if [ "$1" = "status" ]; then
 
 fi
 
+
+###################
 # switch on
+###################
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   if [ ${txindex} == 0 ]; then
     sudo sed -i "s/^txindex=.*/txindex=1/g" /mnt/hdd/${network}/${network}.conf
     echo "switching txindex=1 and restarting ${network}d"
     sudo systemctl restart ${network}d
     echo "The indexing takes ~7h on an RPi4 with SSD"
-    echo "monitor with: sudo tail -n 20 -f /mnt/hdd/${network}/debug.log"
+    echo "monitor with: sudo tail -n 20 -f /mnt/hdd/${network}${pathAdd}/debug.log"
     exit 0
   else
     echo "txindex is already active"
@@ -63,7 +77,10 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   fi
 fi
 
+
+###################
 # switch off
+###################
 if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo sed -i "s/^txindex=.*/txindex=0/g" /mnt/hdd/${network}/${network}.conf
   sudo systemctl restart ${network}d

--- a/home.admin/config.scripts/network.wallet.sh
+++ b/home.admin/config.scripts/network.wallet.sh
@@ -3,14 +3,36 @@
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  echo "config script to switch the Bitcoin Core wallet on or off"
- echo "network.wallet.sh [on|off]"
+ echo "network.wallet.sh [status|on|off]"
  exit 1
 fi
 
 source /mnt/hdd/raspiblitz.conf
-source /mnt/hdd/${network}/${network}.conf
 
+# add disablewallet with default value (0) to bitcoin.conf if missing
+if ! grep -Eq "^disablewallet=.*" /mnt/hdd/${network}/${network}.conf; then
+  echo "disablewallet=0" | sudo tee -a /mnt/hdd/${network}/${network}.conf >/dev/null
+fi
+
+# set variable ${disablewallet}
+source <(grep -E "^disablewallet=.*" /mnt/hdd/${network}/${network}.conf)
+
+
+###################
+# STATUS
+###################
+if [ "$1" = "status" ]; then
+
+  echo "##### STATUS disablewallet"
+  echo "disablewallet=${disablewallet}"
+
+  exit 0
+fi
+
+
+###################
 # switch on
+###################
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   if [ ${disablewallet} == 1 ]; then
     sudo sed -i "s/^disablewallet=.*/disablewallet=0/g" /mnt/hdd/${network}/${network}.conf
@@ -23,7 +45,10 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   fi
 fi
 
+
+###################
 # switch off
+###################
 if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo sed -i "s/^disablewallet=.*/disablewallet=1/g" /mnt/hdd/${network}/${network}.conf
   sudo systemctl restart ${network}d


### PR DESCRIPTION
Sourcing the bitcoin.conf file can potentially print errors and cause unexpected behavior.

Related to #950 
