### PR TITLE
add check to background for Tor

### DIFF
--- a/home.admin/_background.sh
+++ b/home.admin/_background.sh
@@ -91,6 +91,12 @@ do
   if [ ${#lndAddress} -gt 3 ]; then
     recheckPublicIP=0
   fi
+
+  # prevent also when runBehindTor is on
+  if [ "${runBehindTor}" = "1" ] || [ "${runBehindTor}" = "on" ]; then
+    recheckPublicIP=0
+  fi
+
   updateDynDomain=0
   if [ ${recheckPublicIP} -eq 1 ]; then
     echo "*** RECHECK PUBLIC IP ***"


### PR DESCRIPTION
When `runBehindTor` is set the "Public IP Check" is bad for privacy and most likely useless (at least as far as I see it - correct me if I'm wrong.. :-) ).

Fix #894 