### PR TITLE
btcpay:update to v1.0.3.150

### DIFF
--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -181,7 +181,7 @@ EOF
     sudo -u btcpay git clone https://github.com/btcpayserver/btcpayserver.git
     cd btcpayserver
     # https://github.com/btcpayserver/btcpayserver/releases 
-    sudo -u btcpay git reset --hard v1.0.3.146 
+    sudo -u btcpay git reset --hard v1.0.3.150 
     # sudo -u btcpay ./build.sh
     sudo -u btcpay dotnet build -c Release BTCPayServer/BTCPayServer.csproj
 


### PR DESCRIPTION
BTCPay had a couple of new tags in the last 25h mainly for sorting the BitcoinAverage API
The latest tested ok.