### PR TITLE
Disable Bluetooth

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -699,6 +699,21 @@ echo "*** HARDENING ***"
 # fail2ban (no config required)
 sudo apt-get install -y --no-install-recommends python3-systemd fail2ban
 
+if [ "${baseImage}" = "raspbian" ]; then
+  echo ""
+  echo "*** DISABLE BLUETOOTH ***"
+
+  # disable bluetooth module
+  sudo sh -c "echo 'dtoverlay=pi3-disable-bt' >> /boot/config.txt"
+
+  # remove bluetooth services
+  sudo systemctl disable bluetooth.service
+  sudo systemctl disable hciuart.service
+
+  # remove bluetooth packages
+  sudo apt remove -y --purge pi-bluetooth bluez bluez-firmware
+fi
+
 # *** BOOTSTRAP ***
 # see background README for details
 echo ""
@@ -815,7 +830,6 @@ if [ "${baseImage}" = "raspbian" ]; then
   overscan_bottom=0
   framebuffer_width=800
   framebuffer_height=480
-
 
   enable_dpi_lcd=1
   display_default_lcd=1


### PR DESCRIPTION
Disabling Bluetooth offers more security and also brings a small performance improvement. As Bluetooth is anyway not actively used on a RaspiBlitz, it's services and packages can be removed. Also the Bluetooth module is disabled in ``/boot/config.txt``.

I only tested this using Rasbian and therefore restricted this step to that distribution. Someone else could change it accordingly to serve other distributions.