### PR TITLE
Added Pi4 support while deactivating Bluetooth

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -705,6 +705,7 @@ if [ "${baseImage}" = "raspbian" ]; then
 
   # disable bluetooth module
   sudo sh -c "echo 'dtoverlay=pi3-disable-bt' >> /boot/config.txt"
+  sudo sh -c "echo 'dtoverlay=disable-bt' >> /boot/config.txt"
 
   # remove bluetooth services
   sudo systemctl disable bluetooth.service


### PR DESCRIPTION
The former implementation did not cover the Raspberry 4 as the ``dtoverlay`` was changed to ``disable-bt``. I added both, so all Raspberry models are covered when deactivating Bluetooth.