### PR TITLE
RTL: change to CUSTOM auth type 

### DIFF
--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -76,7 +76,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     chmod 600 ./RTL/RTL.conf || exit 1
     sudo sed -i "s/^macroonPath=.*/macroonPath=\/mnt\/hdd\/lnd\/data\/chain\/${network}\/${chain}net/g" ./RTL/RTL.conf
     sudo sed -i "s/^lndConfigPath=.*/lndConfigPath=\/mnt\/hdd\/lnd\/lnd.conf/g" ./RTL/RTL.conf
-    sudo sed -i "s/^nodeAuthType=.*/nodeAuthType=DEFAULT/g" ./RTL/RTL.conf
+    sudo sed -i "s/^nodeAuthType=.*/nodeAuthType=CUSTOM/g" ./RTL/RTL.conf
     # getting ready for the phasing out of the "DEFAULT" auth type
     # will need to change blitz.setpassword.sh too
     PASSWORD_B=$(sudo cat /mnt/hdd/${network}/${network}.conf | grep rpcpassword | cut -c 13-)


### PR DESCRIPTION
Note from @saubyk: 
1. We are deprecating RTL.conf (ini format). This was originally designed for single-user config setup.
2. “DEFAULT” auth type will be removed. The auth config available will be CUSTOM or SSO
3. The new and only config file will now be named as ‘RTL-Config.json’
4. RTL will migrate the old conf (ini format) to the new conf file.

Tested ok with latest 1.4RC2+