### PR TITLE
Blitztui update logging

### DIFF
--- a/home.admin/BlitzTUI/CHANGELOG.md
+++ b/home.admin/BlitzTUI/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.0] - 2020-01-25
+### Added
+- clean up log statements
+- add debug flag
+
 ## [0.44.0] - 2019-12-30
 ### Added
 - make sure to close LN RPC channels

--- a/home.admin/BlitzTUI/blitztui/__init__.py
+++ b/home.admin/BlitzTUI/blitztui/__init__.py
@@ -1,9 +1,1 @@
 # -*- coding: utf-8 -*-
-
-import logging
-from blitztui.version import __version__
-from blitztui.file_logger import setup_logging
-
-log = logging.getLogger()
-setup_logging()
-log.info("Starting BlitzTUI v{}".format(__version__))

--- a/home.admin/BlitzTUI/blitztui/config.py
+++ b/home.admin/BlitzTUI/blitztui/config.py
@@ -111,7 +111,7 @@ class RaspiBlitzInfo(object):
         """load config from file"""
         parser = ConfigParser()
 
-        log.info("loading RaspiBlitzInfo config from file: {}".format(self.abs_path))
+        log.debug("loading RaspiBlitzInfo config from file: {}".format(self.abs_path))
         with open(self.abs_path) as f:
             parser.read_string("[{}]\n".format(DEFAULTSECT) + f.read())
 
@@ -125,7 +125,6 @@ class RaspiBlitzInfo(object):
         self.state = get_str_clean(default_s, "state", self.state)
         self.undervoltage_reports = get_int_safe(default_s, "undervoltageReports", self.undervoltage_reports)
 
-        log.info("status --> {}".format(self.state))
 
 def get_int_safe(cp_section, key, default_value):
     """take a ConfigParser section, get key that might be string encoded int and return int"""

--- a/home.admin/BlitzTUI/blitztui/file_logger.py
+++ b/home.admin/BlitzTUI/blitztui/file_logger.py
@@ -7,7 +7,7 @@ import sys
 IS_WIN32_ENV = sys.platform == "win32"
 
 
-def setup_logging(default_path=os.path.abspath(os.path.expanduser('~/.blitz-tui.json'))):
+def setup_logging(default_path=os.path.abspath(os.path.expanduser('~/.blitz-tui.json')), log_level="INFO"):
     """Setup logging configuration"""
     path = default_path
     if os.path.exists(path):
@@ -33,7 +33,7 @@ def setup_logging(default_path=os.path.abspath(os.path.expanduser('~/.blitz-tui.
                                   'formatter': 'extended',
                                   'stream': 'ext://sys.stdout'},
                       'file_handler': {'class': 'logging.handlers.RotatingFileHandler',
-                                       'level': 'DEBUG',
+                                       'level': log_level,
                                        'formatter': 'extended',
                                        'filename': log_file,
                                        'maxBytes': 10485760,

--- a/home.admin/BlitzTUI/blitztui/main.py
+++ b/home.admin/BlitzTUI/blitztui/main.py
@@ -17,6 +17,7 @@ import qrcode
 from PyQt5.QtCore import Qt, QProcess, QThread, pyqtSignal, QCoreApplication, QTimer, QEventLoop
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QMainWindow, QApplication, QDialog, QDialogButtonBox
+from blitztui.file_logger import setup_logging
 from blitztui.client import ReadOnlyStub, InvoiceStub
 from blitztui.client import check_lnd, check_lnd_channels
 from blitztui.client import check_invoice_paid, create_invoice, get_node_uri
@@ -142,8 +143,8 @@ class AppWindow(QMainWindow):
         self.show()
 
     def start_info_lcd(self, pause=12):
-        # if system has been running for more than 90 seconds then skip pause
-        if self.uptime > 90:
+        # if system has been running for more than 180 seconds then skip pause
+        if self.uptime > 180:
             pause = 0
 
         process = QProcess(self)
@@ -177,7 +178,7 @@ class AppWindow(QMainWindow):
         if not os.path.exists(rb_info_abs_path):
             log.warning("file does not exist: {}".format(rb_info_abs_path))
 
-        log.info("init lnd.conf")
+        log.debug("init lnd.conf")
         lnd_cfg_valid = False
         self.lnd_cfg = LndConfig(lnd_cfg_abs_path)
         try:
@@ -186,7 +187,7 @@ class AppWindow(QMainWindow):
         except Exception as err:
             pass
 
-        log.info("init raspiblitz.conf")
+        log.debug("init raspiblitz.conf")
         rb_cfg_valid = False
         self.rb_cfg = RaspiBlitzConfig(rb_cfg_abs_path)
         try:
@@ -195,7 +196,7 @@ class AppWindow(QMainWindow):
         except Exception as err:
             pass
 
-        log.info("init raspiblitz.info")
+        log.debug("init raspiblitz.info")
         rb_info_valid = False
         self.rb_info = RaspiBlitzInfo(rb_info_abs_path)
         try:
@@ -625,7 +626,7 @@ class BeatThread(QThread):
         self.beat_timer.timeout.connect(self.tick)
 
     def tick(self):
-        # log.debug("beat")
+        log.info("beat")
         self.signal.emit(0)
 
     def run(self):
@@ -661,8 +662,17 @@ Keep on stacking SATs..! :-D"""
                         help="print version", action="version",
                         version=__version__)
 
+    parser.add_argument('-d', '--debug', help="enable debug logging", action="store_true")
+
     # parse args
     args = parser.parse_args()
+
+    if args.debug:
+        setup_logging(log_level="DEBUG")
+    else:
+        setup_logging()
+
+    log.info("Starting BlitzTUI v{}".format(__version__))
 
     # initialize app
     app = QApplication(sys.argv)

--- a/home.admin/BlitzTUI/blitztui/version.py
+++ b/home.admin/BlitzTUI/blitztui/version.py
@@ -4,5 +4,5 @@
 # 3) we can import it into your module module
 """
 
-__version_info__ = ('0', '44', '0')
+__version_info__ = ('0', '45', '0')
 __version__ = '.'.join(__version_info__)

--- a/home.admin/config.scripts/blitz.touchscreen.sh
+++ b/home.admin/config.scripts/blitz.touchscreen.sh
@@ -81,7 +81,7 @@ EOF
 #!/bin/sh
 
 unset QT_QPA_PLATFORMTHEME
-/home/admin/python3-env-lnd/bin/blitz-tui
+/home/admin/python3-env-lnd/bin/blitz-tui --debug
 EOF
   sudo chmod a+x /home/pi/autostart.sh
   sudo chown pi:pi /home/pi/autostart.sh


### PR DESCRIPTION
Cleanup logging in BlitzTUI.

Some DEBUG lines were still set as INFO.

Also added a "--debug" flag to be able to activate DEBUG (but run as INFO normally).