### PR TITLE
BTCPay update - adds SATS currency denomination

### DIFF
--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -236,7 +236,7 @@ EOF
     sudo -u btcpay git clone https://github.com/btcpayserver/btcpayserver.git 2>/dev/null
     cd btcpayserver
     # check https://github.com/btcpayserver/btcpayserver/releases 
-    sudo -u btcpay git reset --hard v1.0.3.153 
+    sudo -u btcpay git reset --hard v1.0.3.156 
     # from the build.sh with path
     sudo -u btcpay /home/btcpay/dotnet/dotnet build -c Release /home/btcpay/btcpayserver/BTCPayServer/BTCPayServer.csproj   
     


### PR DESCRIPTION
Tested extensively on 1.4RC3 with a domain name too.

Can set SATS denomination on a tipping page now