### PR TITLE
Update Funding and Opening channel sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ This is the screen that gets displayed on the LCD/display. It's useful to call i
 
 Before you can open channels with other nodes you need to put some coins onto your LND on-chain wallet. Use this option to generate an address to send funds to.
 
-*Reminder: RaspiBlitz & LND is still experimental software. With funding your LND node you accept the risk of loosing funds. So just play with small amounts - something in then area of 20 EUR/USD should be enough to make your first experiences.*
+*Reminder: RaspiBlitz & LND is still experimental software. With funding your LND node you accept the risk of loosing funds. So just play with small amounts - something in then area of 20 EUR/USD should be enough to make your first experiences. Also, it's a good privacy practice to [coinjoin your coins](https://bitcoin-only.com/#privacy) before sending them to any Lightning Network wallet.*
 
 You can make multiple fundings - so you can start with small amounts first to test. LND will generate always a different address, but all funds you send will get into the same LND on-chain wallet.
 
@@ -403,6 +403,8 @@ Opening a channel with a peer is just optional. Having another node a peer helps
 To open a payment channel with another node you can use this option.
 
 Find interesting nodes to open channels with on online directories like [1ML.com](https://1ml.com/) or join the RaspiBlitz NodeManager telegram group to meet people to open channels with: https://t.me/raspiblitz
+
+Bear in mind that this option will open a public channel that can be seen by everyone in the network. This is good if you want to route payments. If your intention is to use it privately only, you will need to go to the command line and open the channel with the -private option
 
 *This is just a very basic shell script. For more usability try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
 


### PR DESCRIPTION
Add disclaimers about the public nature of the lightning channels and some tips on how to achieve increased privacy.

Maybe you want to leave it simpler, but I believe this is important since some noobs have the assumption they are shielded by the LN when in reality public channel points show everyone their TXs and can link all their UTXOs under 1 entity. If not careful, they can expose a lot of information to chain analysis crossing the info.

I tried to leave it short and simple, just so noobs think about it and consider the option of coinjoining and opening private channels instead of going with the public default