### PR TITLE
README.md: fix link to LNBits repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ It can be used as:
 
 You can also develop extensions on it.
 
-[Details on Service](https://github.com/bitromortac/lndmanage/blob/master/README.md)
+[Details on Service](https://github.com/arcbtc/lnbits/blob/master/README.md)
 
 #### MOBILE: Connect Mobile Wallet
 


### PR DESCRIPTION
Just a minor fix of a copy-paste error in README.md:
In one place the link to the LNBits Repo is incorrect (points to `lndmanage` repo instead).