### PR TITLE
Fix typos in initHDD, migration, and LND rescue scripts

### DIFF
--- a/home.admin/30initHDD.sh
+++ b/home.admin/30initHDD.sh
@@ -119,7 +119,7 @@ if [ ${hddGotBlockchain}  -eq 0 ]; then
    else
     clear
     echo "# Not formatting the HDD/SSD - Setup Process stopped."
-    echo "# Rearrange your hardware and retstart with a fresh sd card again."
+    echo "# Rearrange your hardware and restart with a fresh sd card again."
     exit 1
   fi
 

--- a/home.admin/config.scripts/blitz.migration.sh
+++ b/home.admin/config.scripts/blitz.migration.sh
@@ -145,7 +145,7 @@ if [ "$1" = "export-gui" ]; then
   echo "ON YOUR LAPTOP - RUN IN NEW TERMINAL:"
   echo "${scpDownload}"
   echo ""
-  echo "Use password A to authenticate file transfere."
+  echo "Use password A to authenticate file transfer."
   echo
   echo "Your Lightning node is now stopped. After download press ENTER to shutdown your raspiblitz."
   echo "To complete the data migration follow then instructions on the github FAQ."
@@ -326,7 +326,7 @@ if [ "$1" = "import-gui" ]; then
   echo "COPY, PASTE AND EXECUTE THE FOLLOWING COMMAND:"
   echo "scp -r ./raspiblitz-*.tar.gz admin@${localip}:${defaultZipPath}"
   echo ""
-  echo "Use password 'raspiblitz' to authenticate file transfere."
+  echo "Use password 'raspiblitz' to authenticate file transfer."
   echo "PRESS ENTER when upload is done."
   read key
 

--- a/home.admin/config.scripts/blitz.migration.sh
+++ b/home.admin/config.scripts/blitz.migration.sh
@@ -218,7 +218,7 @@ if [ "$1" = "import" ]; then
     echo "# OK -> checksum looks good: ${md5checksum}"
   else
     echo "# FAIL -> Checksum not correct: ${md5checksum}"
-    echo "# Maybe transfere/upload failed?"
+    echo "# Maybe transfer/upload failed?"
     echo "error='bad checksum'"
     exit 1
   fi

--- a/home.admin/config.scripts/lnd.rescue.sh
+++ b/home.admin/config.scripts/lnd.rescue.sh
@@ -128,7 +128,7 @@ elif [ ${mode} = "restore" ]; then
           echo "OK -> checksum looks good: ${md5checksum}"
         else
           echo "!!! FAIL -> Checksum not correct."
-          echo "Maybe transfere failed? Continue on your own risk!"
+          echo "Maybe transfer failed? Continue on your own risk!"
           echo "Recommend to abort and upload again!"
         fi
 

--- a/home.admin/config.scripts/lnd.rescue.sh
+++ b/home.admin/config.scripts/lnd.rescue.sh
@@ -61,7 +61,7 @@ if [ ${mode} = "backup" ]; then
   echo "ON YOUR LAPTOP - RUN IN NEW TERMINAL:"
   echo "scp -r 'admin@${localip}:/home/admin/lnd-rescue-*.tar.gz' ./"
   echo ""
-  echo "Use password A to authenticate file transfere."
+  echo "Use password A to authenticate file transfer."
   echo
   echo "BEWARE: Your Lightning node is now stopped. Its safe to backup the data and"
   echo "restore it on a fresh RaspiBlitz. But once this Lightning node gets started"
@@ -98,7 +98,7 @@ elif [ ${mode} = "restore" ]; then
         echo "COPY, PASTE AND EXECUTE THE FOLLOWING COMMAND:"
         echo "scp -r ./lnd-rescue-*.tar.gz admin@${localip}:/home/admin/"
         echo ""
-        echo "Use password A to authenticate file transfere."
+        echo "Use password A to authenticate file transfer."
         echo "PRESS ENTER when upload is done."
       fi
       if [ ${countZips} -gt 1 ]; then
@@ -186,7 +186,7 @@ elif [ ${mode} = "scb-down" ]; then
   echo "RUN THE FOLLOWING COMMAND ON YOUR LAPTOP IN NEW TERMINAL:"
   echo "scp -r admin@${localip}:/home/admin/.lnd/data/chain/${network}/${chain}net/channel.backup ./"
   echo ""
-  echo "Use password A to authenticate file transfere."
+  echo "Use password A to authenticate file transfer."
   echo
   echo "NOTE: Use this file when setting up a fresh RaspiBlitz by choosing" 
   echo "option OLD WALLET and then SCB+SEED -> Seed & channel.backup file" 
@@ -218,7 +218,7 @@ elif [ ${mode} = "scb-up" ]; then
     echo "COPY, PASTE AND EXECUTE THE FOLLOWING COMMAND:"
     echo "scp ./channel.backup admin@${localip}:/home/admin/"
     echo ""
-    echo "Use password A to authenticate file transfere."
+    echo "Use password A to authenticate file transfer."
     echo "PRESS ENTER when upload is done. Enter x & ENTER to cancel."
 
     # wait user interaction


### PR DESCRIPTION
Found two trivial typos while upgrading to 1.4. Turns out they were in multiple places.