### PR TITLE
Adding Specter-Desktop to Raspiblitz

### DIFF
--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+# https://github.com/cryptoadvance/specter-desktop  
+# ~/.config/btc-rpc-explorer.env
+# https://github.com/janoside/btc-rpc-explorer/blob/master/.env-sample
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+ echo "small config script to switch cryptoadvance specter on or off"
+ echo "bonus.cryptoadvance-specter.sh [status|on|off]"
+ exit 1
+fi
+
+source /mnt/hdd/raspiblitz.conf
+
+# show info menu
+if [ "$1" = "menu" ]; then
+
+  # get status
+  echo "# collecting status info ... (please wait)"
+  source <(sudo /home/admin/config.scripts/bonus.cryptoadvance-specter.sh status)
+
+  # get network info
+  localip=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  toraddress=https://$(sudo cat /mnt/hdd/tor/cryptoadvance-specter/hostname 2>/dev/null)
+
+  if [ "${runBehindTor}" = "on" ] && [ ${#toraddress} -gt 0 ]; then
+
+    # TOR
+    /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
+    whiptail --title " Cryptoadvance Specter " --msgbox "Open the following URL in your local web browser:
+https://${localip}:25441
+You have to accept the self-signed-certificate.
+Login with the Pin being Password B. If you have connected to a different Bitcoin RPC Endpoint, the Pin is the configured RPCPassword.
+Hidden Service address for TOR Browser (QR see LCD):
+${toraddress}\n
+" 16 70
+    /home/admin/config.scripts/blitz.lcd.sh hide
+  else
+
+    # IP + Domain
+    whiptail --title " Cryptoadvance Specter " --msgbox "Open the following URL in your local web browser:
+https://${localip}:25441
+You have to accept the self-signed-certificate.
+Login with the Pin being Password B. If you have connected to a different Bitcoin RPC Endpoint, the Pin is the configured RPCPassword.\n
+Activate TOR to access the web block explorer from outside your local network.
+Unfortunately the camera is currently not usable via Tor, though.
+" 12 54
+  fi
+
+  echo "please wait ..."
+  exit 0
+fi
+
+# add default value to raspi config if needed
+if ! grep -Eq "^specter=" /mnt/hdd/raspiblitz.conf; then
+  echo "specter=off" >> /mnt/hdd/raspiblitz.conf
+fi
+
+# status
+if [ "$1" = "status" ]; then
+
+  if [ "${specter}" = "on" ]; then
+    echo "configured=1"
+
+    # check for error
+    isDead=$(sudo systemctl status cryptoadvance-specter | grep -c 'inactive (dead)')
+    if [ ${isDead} -eq 1 ]; then
+      echo "error='Service Failed'"
+      exit 1
+    fi
+
+  else
+    echo "configured=0"
+  fi
+  exit 0
+fi
+
+# stop service
+echo "making sure services are not running"
+sudo systemctl stop cryptoadvance-specter 2>/dev/null
+
+# switch on
+if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+  echo "*** INSTALL Cryptoadvance Specter ***"
+
+  isInstalled=$(sudo ls /etc/systemd/system/cryptoadvance-specter.service 2>/dev/null | grep -c 'cryptoadvance-specter.service')
+  if [ ${isInstalled} -eq 0 ]; then
+
+    echo "*** Enable wallets in Bitcoin Core ***"
+    sudo sed -i "s/^disablewallet=.*/disablewallet=0/g" /home/bitcoin/.bitcoin/bitcoin.conf
+    sudo service bitcoind stop
+    sudo service bitcoind start
+
+    echo "*** Installing prerequisites ***"
+    sudo apt install libusb-1.0.0-dev libudev-dev virtualenv
+    sudo -u bitcoin pip3 install --upgrade cryptoadvance.specter
+
+    # activating Authentication here ...
+    echo "*** creating App-config ***"
+    cat > /home/admin/config.json <<EOF
+{
+	"auth":"rpcpasswordaspin"
+}
+EOF
+    sudo mkdir -p /home/bitcoin/.specter
+    sudo mv /home/admin/config.json /home/bitcoin/.specter/config.json
+    sudo chown -R bitcoin:bitcoin /home/bitcoin/.specter
+
+    echo "*** creating a virtualenv ***"
+    sudo -u bitcoin virtualenv --python=python3 /home/bitcoin/.specter/.env
+
+    echo "*** installing specter ***"
+    sudo -u bitcoin /home/bitcoin/.specter/.env/bin/python3 -m pip install --upgrade cryptoadvance.specter
+    
+    
+    # Creating self-signed-certificate
+    # Mandatory as the camera doesn't work without https
+    echo "*** Creating self-signed certificate ***"
+   openssl req -x509 -newkey rsa:4096 -nodes -out /tmp/cert.pem -keyout /tmp/key.pem -days 365 -subj "/C=US/ST=Nooneknows/L=Springfield/O=Dis/CN=www.fakeurl.com"
+    sudo mv /tmp/cert.pem /home/bitcoin/.specter
+    sudo chown -R bitcoin:bitcoin /home/bitcoin/.specter/cert.pem
+    sudo mv /tmp/key.pem /home/bitcoin/.specter
+    sudo chown -R bitcoin:bitcoin /home/bitcoin/.specter/key.pem
+
+    # open firewall
+    echo "*** Updating Firewall ***"
+    sudo ufw allow 25441 comment 'cryptoadvance-specter'
+    sudo ufw --force enable
+    echo ""
+
+    # install service
+    echo "*** Install cryptoadvance-specter systemd service ***"
+    cat > /home/admin/cryptoadvance-specter.service <<EOF
+# systemd unit for Cryptoadvance Specter
+
+[Unit]
+Description=cryptoadvance-specter
+Wants=${network}d.service
+After=${network}d.service
+
+[Service]
+ExecStart=/home/bitcoin/.specter/.env/bin/python3 -m cryptoadvance.specter server --host 0.0.0.0 --cert=/home/bitcoin/.specter/cert.pem --key=/home/bitcoin/.specter/key.pem
+User=bitcoin
+Environment=PATH=/home/bitcoin/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/bin
+Restart=always
+TimeoutSec=120
+RestartSec=30
+StandardOutput=null
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    sudo mv /home/admin/cryptoadvance-specter.service /etc/systemd/system/cryptoadvance-specter.service 
+    sudo systemctl enable cryptoadvance-specter
+    sudo systemctl start cryptoadvance-specter
+    echo "OK - the cryptoadvance-specter service is now enabled and started"
+
+  else 
+    echo "cryptoadvance-specter already installed."
+  fi
+
+  # setting value in raspi blitz config
+  sudo sed -i "s/^specter=.*/specter=on/g" /mnt/hdd/raspiblitz.conf
+  
+  ## Enable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
+  # see /home/admin/config.scripts/bonus.electrsexplorer.sh
+  # run every 10 min by _background.sh
+
+  # Hidden Service for BTC-RPC-explorer if Tor is active
+  source /mnt/hdd/raspiblitz.conf
+  if [ "${runBehindTor}" = "on" ]; then
+    # correct old Hidden Service with port
+    sudo sed -i "s/^HiddenServicePort 25441 127.0.0.1:25441/HiddenServicePort 80 127.0.0.1:25441/g" /etc/tor/torrc
+    /home/admin/config.scripts/internet.hiddenservice.sh cryptoadvance-specter 80 25441
+  fi
+  exit 0
+fi
+
+# switch off
+if [ "$1" = "0" ] || [ "$1" = "off" ]; then
+
+  # setting value in raspi blitz config
+  sudo sed -i "s/^specter=.*/specter=off/g" /mnt/hdd/raspiblitz.conf
+
+  isInstalled=$(sudo ls /etc/systemd/system/cryptoadvance-specter.service 2>/dev/null | grep -c 'cryptoadvance-specter.service')
+  if [ ${isInstalled} -eq 1 ]; then
+    echo "*** REMOVING Cryptoadvance Specter ***"
+    sudo systemctl stop cryptoadvance-specter
+    sudo systemctl disable cryptoadvance-specter
+    sudo rm /etc/systemd/system/cryptoadvance-specter.service
+
+    echo "*** Removing wallets in core ***"
+    bitcoin-cli listwallets | jq -r .[] | tail -n +2
+    for i in $(bitcoin-cli listwallets | jq -r .[] | tail -n +2) 
+    do  
+	name=$(echo $i | cut -d"/" -f2)
+       	bitcoin-cli unloadwallet specter/$name 
+    done
+    sudo rm -rf /home/bitcoin/.bitcoin/specter
+
+    echo "*** Removing /home/bitcoin/.specter ***"
+    sudo rm -rf /home/bitcoin/.specter
+
+    echo "OK Cryptoadvance Specter removed."
+  else 
+    echo "Cryptoadvance Specter is not installed."
+  fi
+  exit 0
+fi
+
+echo "FAIL - Unknown Parameter $1"
+exit 1

--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -94,7 +94,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
     echo "*** Installing prerequisites ***"
     sudo apt install libusb-1.0.0-dev libudev-dev virtualenv
-    sudo -u bitcoin pip3 install --upgrade cryptoadvance.specter
 
     # activating Authentication here ...
     echo "*** creating App-config ***"
@@ -264,17 +263,19 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     sudo systemctl disable cryptoadvance-specter
     sudo rm /etc/systemd/system/cryptoadvance-specter.service
 
-    echo "*** Removing wallets in core ***"
-    bitcoin-cli listwallets | jq -r .[] | tail -n +2
-    for i in $(bitcoin-cli listwallets | jq -r .[] | tail -n +2) 
-    do  
+    if whiptail --defaultno --yesno "Do you want to delete all Data related to specter? This includes also Bitcoin-Core-Wallets managed by specter?" 0 0; then
+      echo "*** Removing wallets in core ***"
+      bitcoin-cli listwallets | jq -r .[] | tail -n +2
+      for i in $(bitcoin-cli listwallets | jq -r .[] | tail -n +2) 
+      do  
 	name=$(echo $i | cut -d"/" -f2)
        	bitcoin-cli unloadwallet specter/$name 
-    done
-    sudo rm -rf /home/bitcoin/.bitcoin/specter
+      done
+      sudo rm -rf /home/bitcoin/.bitcoin/specter
 
-    echo "*** Removing /home/bitcoin/.specter ***"
-    sudo rm -rf /home/bitcoin/.specter
+      echo "*** Removing /home/bitcoin/.specter ***"
+      sudo rm -rf /home/bitcoin/.specter
+    fi
 
     echo "OK Cryptoadvance Specter removed."
   else 

--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -129,6 +129,78 @@ EOF
     sudo ufw --force enable
     echo ""
 
+    echo "*** Installing udev-rules for hardware-wallets ***"
+    cat > /home/admin/20-hw1.rules <<EOF
+ HW.1 / Nano
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl"
+# Blue
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000|0000|0001|0002|0003|0004|0005|0006|0007|0008|0009|000a|000b|000c|000d|000e|000f|0010|0011|0012|0013|0014|0015|0016|0017|0018|0019|001a|001b|001c|001d|001e|001f", TAG+="uaccess", TAG+="udev-acl"
+# Nano S
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001|1000|1001|1002|1003|1004|1005|1006|1007|1008|1009|100a|100b|100c|100d|100e|100f|1010|1011|1012|1013|1014|1015|1016|1017|1018|1019|101a|101b|101c|101d|101e|101f", TAG+="uaccess", TAG+="udev-acl"
+# Aramis
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0002|2000|2001|2002|2003|2004|2005|2006|2007|2008|2009|200a|200b|200c|200d|200e|200f|2010|2011|2012|2013|2014|2015|2016|2017|2018|2019|201a|201b|201c|201d|201e|201f", TAG+="uaccess", TAG+="udev-acl"
+# HW2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0003|3000|3001|3002|3003|3004|3005|3006|3007|3008|3009|300a|300b|300c|300d|300e|300f|3010|3011|3012|3013|3014|3015|3016|3017|3018|3019|301a|301b|301c|301d|301e|301f", TAG+="uaccess", TAG+="udev-acl"
+# Nano X
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004|4000|4001|4002|4003|4004|4005|4006|4007|4008|4009|400a|400b|400c|400d|400e|400f|4010|4011|4012|4013|4014|4015|4016|4017|4018|4019|401a|401b|401c|401d|401e|401f", TAG+="uaccess", TAG+="udev-acl"
+EOF
+    cat > /home/admin/51-coinkite.rules <<EOF
+# Linux udev support file.
+#
+# This is a example udev file for HIDAPI devices which changes the permissions
+# to 0666 (world readable/writable) for a specific device on Linux systems.
+#
+# - Copy this file into /etc/udev/rules.d and unplug and re-plug your Coldcard.
+# - Udev does not have to be restarted.
+#
+
+# probably not needed:
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="d13e", ATTRS{idProduct}=="cc10", GROUP="plugdev", MODE="0666"
+
+# required:
+# from <https://github.com/signal11/hidapi/blob/master/udev/99-hid.rules>
+KERNEL=="hidraw*", ATTRS{idVendor}=="d13e", ATTRS{idProduct}=="cc10", GROUP="plugdev", MODE="0666"
+EOF
+    cat > /home/admin/51-trezor.rules <<EOF
+# Trezor: The Original Hardware Wallet
+# https://trezor.io/
+#
+# Put this file into /etc/udev/rules.d
+#
+# If you are creating a distribution package,
+# put this into /usr/lib/udev/rules.d or /lib/udev/rules.d
+# depending on your distribution
+
+# Trezor
+SUBSYSTEM=="usb", ATTR{idVendor}=="534c", ATTR{idProduct}=="0001", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="534c", ATTRS{idProduct}=="0001", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+
+# Trezor v2
+SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c0", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+SUBSYSTEM=="usb", ATTR{idVendor}=="1209", ATTR{idProduct}=="53c1", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="trezor%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="53c1", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+EOF
+    cat > /home/admin/51-usb-keepkey.rules <<EOF
+# KeepKey: Your Private Bitcoin Vault
+# http://www.keepkey.com/
+# Put this file into /usr/lib/udev/rules.d or /etc/udev/rules.d
+
+# KeepKey HID Firmware/Bootloader
+SUBSYSTEM=="usb", ATTR{idVendor}=="2b24", ATTR{idProduct}=="0001", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="keepkey%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="2b24", ATTRS{idProduct}=="0001",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+
+# KeepKey WebUSB Firmware/Bootloader
+SUBSYSTEM=="usb", ATTR{idVendor}=="2b24", ATTR{idProduct}=="0002", MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl", SYMLINK+="keepkey%n"
+KERNEL=="hidraw*", ATTRS{idVendor}=="2b24", ATTRS{idProduct}=="0002",  MODE="0666", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+EOF
+
+    sudo mv /home/admin/20-hw1.rules /home/admin/51-coinkite.rules /home/admin/51-trezor.rules /home/admin/51-usb-keepkey.rules /etc/udev/rules.d/
+    sudo chown root:root /etc/udev/rules.d/*
+    sudo udevadm trigger
+    sudo udevadm control --reload-rules
+    sudo groupadd plugdev
+    sudo usermod -aG plugdev bitcoin
+
     # install service
     echo "*** Install cryptoadvance-specter systemd service ***"
     cat > /home/admin/cryptoadvance-specter.service <<EOF
@@ -153,11 +225,11 @@ StandardError=journal
 WantedBy=multi-user.target
 EOF
 
-    sudo mv /home/admin/cryptoadvance-specter.service /etc/systemd/system/cryptoadvance-specter.service 
+    sudo mv /home/admin/cryptoadvance-specter.service /etc/systemd/system/cryptoadvance-specter.service
     sudo systemctl enable cryptoadvance-specter
     sudo systemctl start cryptoadvance-specter
-    echo "OK - the cryptoadvance-specter service is now enabled and started"
 
+    echo "OK - the cryptoadvance-specter service is now enabled and started"
   else 
     echo "cryptoadvance-specter already installed."
   fi


### PR DESCRIPTION
As described in #1059 :
* Installation of specter-desktop via services like the others in a virtualenv + pip install 
* cryptoadvance.specter (in home/admin/.specter/.env)
* On top it creates a self-signed-cert and exposes it via https (on port 25441) 
also it creates a Tor-hidden-service. 
* Authentication is enabled by default (Pin of "Password B")
* the installation-procedure is also creating udev-rules in /etc/udev/rules.d for all major hardware-wallets as described in https://github.com/bitcoin-core/HWI/blob/master/hwilib/udev/README.md
* deinstallation-procedure is asking the user whether to keep the data
