### PR TITLE
joinmarket: fix no usessl for server1 error in .cfg

### DIFF
--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -154,7 +154,6 @@ else
   sudo sed -i "s/^socks5 = false/#socks5 = false/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   sudo sed -i "s/^#socks5 = true/socks5 = true/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   sudo sed -i "s/^#port = 6667/port = 6667/g" /home/joinmarket/.joinmarket/joinmarket.cfg
-  sudo sed -i "s/^usessl = true/#usessl = true/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   sudo sed -i "s/^#usessl = false/usessl = false/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   echo "Edited the joinmarket.cfg to communicate over Tor only."
   echo ""


### PR DESCRIPTION
Run:
Edit the :
`nano /home/joinmarket/.joinmarket/joinmarket.cfg`
and change to:
`usessl = true ` 
under `[MESSAGING:server1] `

to correct without needing to delete the joinmarket,cfg and reinstall.
