### PR TITLE
include .specter/.env/bin to path in systemd-service of specter

### DIFF
--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -213,7 +213,7 @@ After=${network}d.service
 [Service]
 ExecStart=/home/bitcoin/.specter/.env/bin/python3 -m cryptoadvance.specter server --host 0.0.0.0 --cert=/home/bitcoin/.specter/cert.pem --key=/home/bitcoin/.specter/key.pem
 User=bitcoin
-Environment=PATH=/home/bitcoin/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/bin
+Environment=PATH=/home/bitcoin/.specter/.env/bin:/home/bitcoin/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/bin
 Restart=always
 TimeoutSec=120
 RestartSec=30


### PR DESCRIPTION
At least in version 0.2.0 and maybe also in others, the hwi-executable must be on the path for specter, otherwise hwi won't work, at least on my box.