### PR TITLE
recreate nginx log dir after log cleanup

### DIFF
--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -71,7 +71,15 @@ logsMegaByte=$(sudo du -c -m /var/log | grep "total" | awk '{print $1;}')
 if [ ${logsMegaByte} -gt 1000 ]; then
   echo "WARN !! Logs /var/log in are bigger then 1GB"
   echo "ACTION --> DELETED ALL LOGS"
+  if [ -d "/var/log/nginx" ]; then
+    nginxLog=1
+    echo "/var/log/nginx is present"
+  fi
   sudo rm -r /var/log/*
+  if [ $nginxLog == 1 ]; then
+    sudo mkdir /var/log/nginx
+    echo "Recreated /var/log/nginx"
+  fi
   sleep 3
   echo "WARN !! Logs in /var/log in were bigger then 1GB and got emergency delete to prevent fillup."
   echo "If you see this in the logs please report to the GitHub issues, so LOG config needs to hbe optimized."


### PR DESCRIPTION
To fix an other rare cause of Nginx failing with the error:
```
systemd[1]: Starting A high performance web server and a reverse proxy server...
nginx[8966]: nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (2: No such file or directory)
nginx[8966]: 2020/04/16 03:16:57 [emerg] 8966#8966: open() "/var/log/nginx/access.log" failed (2: No such file or directory)
nginx[8966]: nginx: configuration file /etc/nginx/nginx.conf test failed
systemd[1]: nginx.service: Control process exited, code=exited, status=1/FAILURE
systemd[1]: nginx.service: Failed with result 'exit-code'.
systemd[1]: Failed to start A high performance web server and a reverse proxy server.
```

Related: https://github.com/rootzoll/raspiblitz/issues/1060