### PR TITLE
skip LND config check

### DIFF
--- a/home.admin/BlitzTUI/CHANGELOG.md
+++ b/home.admin/BlitzTUI/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.0] - 2020-04-17
+### Added
+- remove LND config check
+
 ## [0.45.0] - 2020-01-25
 ### Added
 - clean up log statements

--- a/home.admin/BlitzTUI/CHANGELOG.md
+++ b/home.admin/BlitzTUI/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.46.0] - 2020-04-17
+## [0.46.1] - 2020-04-17
 ### Added
 - remove LND config check
 

--- a/home.admin/BlitzTUI/blitztui/main.py
+++ b/home.admin/BlitzTUI/blitztui/main.py
@@ -178,15 +178,6 @@ class AppWindow(QMainWindow):
         if not os.path.exists(rb_info_abs_path):
             log.warning("file does not exist: {}".format(rb_info_abs_path))
 
-        log.debug("init lnd.conf")
-        lnd_cfg_valid = False
-        self.lnd_cfg = LndConfig(lnd_cfg_abs_path)
-        try:
-            self.lnd_cfg.reload()
-            lnd_cfg_valid = True
-        except Exception as err:
-            pass
-
         log.debug("init raspiblitz.conf")
         rb_cfg_valid = False
         self.rb_cfg = RaspiBlitzConfig(rb_cfg_abs_path)
@@ -305,7 +296,6 @@ class AppWindow(QMainWindow):
 
     def update_watched_attr(self):
         log.debug("updating: watched attributes")
-        self.lnd_cfg.reload()
         self.rb_cfg.reload()
         self.rb_info.reload()
 

--- a/home.admin/BlitzTUI/blitztui/main.py
+++ b/home.admin/BlitzTUI/blitztui/main.py
@@ -196,7 +196,7 @@ class AppWindow(QMainWindow):
         except Exception as err:
             pass
 
-        self.cfg_valid = lnd_cfg_valid and rb_cfg_valid and rb_info_valid
+        self.cfg_valid = rb_cfg_valid and rb_info_valid
         log.debug("checked cfg_valid with result: {}".format(self.cfg_valid))
 
     def check_invoice(self, flag, tick=0):

--- a/home.admin/BlitzTUI/blitztui/version.py
+++ b/home.admin/BlitzTUI/blitztui/version.py
@@ -4,5 +4,5 @@
 # 3) we can import it into your module module
 """
 
-__version_info__ = ('0', '46', '0')
+__version_info__ = ('0', '46', '1')
 __version__ = '.'.join(__version_info__)

--- a/home.admin/BlitzTUI/blitztui/version.py
+++ b/home.admin/BlitzTUI/blitztui/version.py
@@ -4,5 +4,5 @@
 # 3) we can import it into your module module
 """
 
-__version_info__ = ('0', '45', '0')
+__version_info__ = ('0', '46', '0')
 __version__ = '.'.join(__version_info__)

--- a/home.admin/config.scripts/blitz.configcheck.py
+++ b/home.admin/config.scripts/blitz.configcheck.py
@@ -174,30 +174,6 @@ def main():
     # parse args
     args = parser.parse_args()
 
-
-    # LND Config
-    lnd_cfg_valid = False
-
-    lnd_cfg = LndConfig()
-    if os.path.exists(lnd_cfg.abs_path):
-        try:
-            lnd_cfg.reload()
-
-            lnd_cfg_valid = True
-            if not args.quiet:
-                print("LND Config: \t\tOK")
-        except Exception as err:
-            if not args.quiet:
-                print("LND Config: \t\tERROR")
-                log.warning(err)
-                print("# Use command to fix: sudo nano /mnt/hdd/lnd/lnd.conf")
-                print("# CTRL+o to save / CRTL+x to exit / then reboot")
-
-    else:
-        if not args.quiet:
-            print("LND Config: \t\tMISSING")
-
-
     # Raspi Config
     rb_cfg_valid = False
 
@@ -244,17 +220,6 @@ def main():
 
 
     if args.print:
-        print("=======\n= LND =\n=======")
-        if lnd_cfg_valid:
-            print("rpc_list: \t\t{}".format(lnd_cfg.rpc_listen))
-            print("rpc_list_host: \t\t{}".format(lnd_cfg.rpc_listen_host))
-            print("rpc_list_port: \t\t{}".format(lnd_cfg.rpc_listen_port))
-            print("")
-        else:
-            print("invalid or missing")
-            print("")
-
-
         print("====================\n= RaspiBlitzConfig =\n====================")
         if rb_cfg_valid:
             print("auto_nat_discovery: \t\t{}".format(rb_cfg.auto_nat_discovery))


### PR DESCRIPTION
The Python included  "configuration checker" I used in BlitzTUI does not accept multiple lines with the same settings. As we are not using LND config information for anything at the moment it's safe to simply remove this.