### PR TITLE
tor-nyx setup patch

### DIFF
--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -257,6 +257,9 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     echo ""
 
     echo "*** Install Tor ***"
+    echo "*** Installing NYX - TOR monitoring Tool ***"
+    # NYX - Tor monitor tool
+    #  https://nyx.torproject.org/#home
     sudo apt install tor tor-arm -y
 
     echo ""
@@ -335,18 +338,7 @@ EOF
     sudo rm $torrc
     sudo mv ./torrc $torrc
     sudo chmod 644 $torrc
-    sudo chown -R bitcoin:bitcoin /var/run/tor/
-    echo ""
-
-    # NYX - Tor monitor tool
-    #  https://nyx.torproject.org/#home
-    echo "*** Installing NYX - TOR monitoring Tool ***"
-    nyxInstalled=$(sudo pip list 2>/dev/null | grep 'nyx' -c)
-    if [ ${nyxInstalled} -eq 0 ]; then
-      sudo pip install nyx
-    else
-      echo "NYX already installed"
-    fi
+    sudo chown -R bitcoin:bitcoin /var/run/tor/ 2>/dev/null
     echo ""
 
     echo "ReadWriteDirectories=-/mnt/hdd/tor" | sudo tee -a /lib/systemd/system/tor@default.service


### PR DESCRIPTION
A little update to fix the Nyx installation:

Nyx is installed by the `tor-arm` package:

```
$ sudo apt install tor-arm
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  nyx python3-stem
The following NEW packages will be installed:
  nyx python3-stem tor-arm
0 upgraded, 3 newly installed, 0 to remove and 42 not upgraded.
Need to get 355 kB of archives.
After this operation, 1,778 kB of additional disk space will be used.
Do you want to continue? [Y/n] 
```
so the pip command is not necessary and fails anyway:

New SD Card, tailing the raspiblitz.log and detected this: 
```
*** Tor Config ***
chown: cannot access '/var/run/tor/': No such file or directory

*** Installing NYX - TOR monitoring Tool ***
sudo: pip: command not found
```

The PR hides the chown error too. `/var/run/tor/``is not present at that point.