### PR TITLE
ufw: remove redundant enable commands

### DIFF
--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -157,7 +157,6 @@ EOF
     # open firewall
     echo "*** Updating Firewall ***"
     sudo ufw allow 3002 comment 'btc-rpc-explorer'
-    sudo ufw --force enable
     echo ""
 
     # install service

--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -125,7 +125,6 @@ EOF
     # open firewall
     echo "*** Updating Firewall ***"
     sudo ufw allow 25441 comment 'cryptoadvance-specter'
-    sudo ufw --force enable
     echo ""
 
     echo "*** Installing udev-rules for hardware-wallets ***"

--- a/home.admin/config.scripts/bonus.lnbits.sh
+++ b/home.admin/config.scripts/bonus.lnbits.sh
@@ -169,7 +169,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     echo
     echo "*** Updating Firewall ***"
     sudo ufw allow 5000 comment 'lnbits'
-    sudo ufw --force enable
     echo ""
 
     # install service

--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -154,7 +154,6 @@ EOF
     # open firewall
     echo "*** Updating Firewall ***"
     sudo ufw allow 3000 comment 'RTL'
-    sudo ufw --force enable
     echo ""
 
     # install service

--- a/home.admin/config.scripts/internet.hiddenservice.sh
+++ b/home.admin/config.scripts/internet.hiddenservice.sh
@@ -91,7 +91,6 @@ HiddenServicePort $toPort 127.0.0.1:$fromPort" | sudo tee -a /etc/tor/torrc
   echo "$TOR_ADDRESS"
   echo "use with the port: $toPort"
   echo ""
-  alreadyThere=$(sudo cat /etc/tor/torrc 2>/dev/null | grep -c "\b127.0.0.1:$fromPort2\b")
   if [ ${#toPort2} -gt 0 ]; then
     if [ ${alreadyThere} -eq 0 ]; then
       echo "or the port: $toPort2"

--- a/home.admin/config.scripts/lnd.setport.sh
+++ b/home.admin/config.scripts/lnd.setport.sh
@@ -79,6 +79,5 @@ sudo systemctl enable lnd
 
 # make sure port is open on firewall
 sudo ufw allow ${portnumber} comment 'LND Port'
-sudo ufw --force enable
 
 echo "needs reboot to activate new setting -> sudo shutdown -r now"


### PR DESCRIPTION
The firewall is enabled in: https://github.com/rootzoll/raspiblitz/blob/master/home.admin/90finishSetup.sh#L49

So all other `sudo ufw --force enable` commands are redundant,

As discussed with @frennkie 