### PR TITLE
Update Firewall

### DIFF
--- a/home.admin/90finishSetup.sh
+++ b/home.admin/90finishSetup.sh
@@ -41,10 +41,15 @@ echo "allow: lightning REST API"
 sudo ufw allow 8080 comment 'lightning REST API'
 echo "allow: transmission"
 sudo ufw allow 49200:49250/tcp comment 'rtorrent'
-echo "allow: local web admin"
-sudo ufw allow from 192.168.0.0/16 to any port 80 comment 'allow local LAN web'
-sudo ufw allow from 192.168.0.0/16 to any port 443 comment 'allow local LAN web'
+echo "allow: public web HTTP"
+sudo ufw allow from any to any port 80 comment 'allow public web HTTP'
+echo "allow: local web admin HTTPS"
+sudo ufw allow from 10.0.0.0/8 to any port 443 comment 'allow local LAN HTTPS'
+sudo ufw allow from 172.16.0.0/12 to any port 443 comment 'allow local LAN HTTPS'
+sudo ufw allow from 192.168.0.0/16 to any port 443 comment 'allow local LAN HTTPS'
 echo "open firewall for auto nat discover (see issue #129)"
+sudo ufw allow proto udp from 10.0.0.0/8 port 1900 to any comment 'allow local LAN SSDP for UPnP discovery'
+sudo ufw allow proto udp from 172.16.0.0/12 port 1900 to any comment 'allow local LAN SSDP for UPnP discovery'
 sudo ufw allow proto udp from 192.168.0.0/16 port 1900 to any comment 'allow local LAN SSDP for UPnP discovery'
 echo "enable lazy firewall"
 sudo ufw --force enable


### PR DESCRIPTION
The rational here is: Port 80 does only host the public - non confidential info page. In a normal NAT setup this isn't reachable from the internet anyway. Therefore any to port 80 should be ok. It would also be needed for HTTP-01 (Let's Encrypt).

The other changes add the other RFC1918 private LAN IP ranges.