### PR TITLE
Change RaspiBlitz RAM disk to 32 MB

### DIFF
--- a/home.admin/config.scripts/blitz.cache.sh
+++ b/home.admin/config.scripts/blitz.cache.sh
@@ -22,7 +22,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     else
       # missing -> add
       echo "" | sudo tee -a /etc/fstab >/dev/null
-      echo "tmpfs         /var/cache/raspiblitz  tmpfs  nodev,nosuid,size=8M  0  0" | sudo tee -a /etc/fstab >/dev/null
+      echo "tmpfs         /var/cache/raspiblitz  tmpfs  nodev,nosuid,size=32M  0  0" | sudo tee -a /etc/fstab >/dev/null
     fi
   fi
 


### PR DESCRIPTION
Now will setup fstab to use 32 megabytes of RAM as a cache disk.

Related to #1205