### PR TITLE
ThunderHub nginx config and blitz.web.sh fixes

### DIFF
--- a/home.admin/60finishHDD.sh
+++ b/home.admin/60finishHDD.sh
@@ -32,6 +32,9 @@ sudo cp /home/admin/assets/${network}.conf /home/admin/.${network}/${network}.co
 # make sure all files are linked correct
 sudo /home/admin/config.scripts/blitz.datadrive.sh link
 
+# BLITZ WEB SERVICE
+/home/admin/config.scripts/blitz.web.sh on
+
 ###### ACTIVATE TOR IF SET DURING SETUP
 if [ "${runBehindTor}" = "on" ]; then
      

--- a/home.admin/_bootstrap.provision.sh
+++ b/home.admin/_bootstrap.provision.sh
@@ -168,6 +168,10 @@ sudo sed -i "s/^message=.*/message='Installing Services'/g" ${infoFile}
 
 echo "### RUNNING PROVISIONING SERVICES ###" >> ${logFile}
 
+# BLITZ WEB SERVICE
+echo "Provisioning BLITZ WEB SERVICE - run config script" >> ${logFile}
+/home/admin/config.scripts/blitz.web.sh on >> ${logFile} 2>&1
+
 # LND INTERIMS UPDATE
 if [ ${#lndInterimsUpdate} -gt 0 ]; then
   sudo sed -i "s/^message=.*/message='Provisioning LND update'/g" ${infoFile}

--- a/home.admin/assets/nginx/sites-available/btcrpcexplorer_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcrpcexplorer_ssl.conf
@@ -1,0 +1,20 @@
+## btcrpcexplorer_ssl.conf
+
+server {
+    listen 3021 ssl;
+    listen [::]:3021 ssl;
+    server_name _;
+
+    include /etc/nginx/snippets/ssl-params.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    access_log /var/log/nginx/access_thub.log;
+    error_log /var/log/nginx/error_thub.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3020;
+
+        include /etc/nginx/snippets/ssl-proxy-params.conf;
+    }
+
+}

--- a/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor.conf
+++ b/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor.conf
@@ -1,0 +1,17 @@
+## btcrpcexplorer_tor.conf
+
+server {
+    listen localhost:3022;
+    listen [::1]:3022;
+    server_name _;
+
+    access_log /var/log/nginx/access_thub.log;
+    error_log /var/log/nginx/error_thub.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3020;
+
+        include /etc/nginx/snippets/ssl-proxy-params.conf;
+    }
+
+}

--- a/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor_ssl.conf
@@ -1,0 +1,20 @@
+## btcrpcexplorer_tor_ssl.conf
+
+server {
+    listen localhost:3023 ssl;
+    listen [::1]:3023 ssl;
+    server_name _;
+
+    include /etc/nginx/snippets/ssl-params.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    access_log /var/log/nginx/access_thub.log;
+    error_log /var/log/nginx/error_thub.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3020;
+
+        include /etc/nginx/snippets/ssl-proxy-params.conf;
+    }
+
+}

--- a/home.admin/assets/nginx/sites-available/thub_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/thub_ssl.conf
@@ -1,0 +1,20 @@
+## thub_ssl.conf
+
+server {
+    listen 3011 ssl;
+    listen [::]:3011 ssl;
+    server_name _;
+
+    include /etc/nginx/snippets/ssl-params.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    access_log /var/log/nginx/access_thub.log;
+    error_log /var/log/nginx/error_thub.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3010;
+
+        include /etc/nginx/snippets/ssl-proxy-params.conf;
+    }
+
+}

--- a/home.admin/assets/nginx/sites-available/thub_tor.conf
+++ b/home.admin/assets/nginx/sites-available/thub_tor.conf
@@ -1,0 +1,17 @@
+## thub_tor.conf
+
+server {
+    listen localhost:3012;
+    listen [::1]:3012;
+    server_name _;
+
+    access_log /var/log/nginx/access_thub.log;
+    error_log /var/log/nginx/error_thub.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3010;
+
+        include /etc/nginx/snippets/ssl-proxy-params.conf;
+    }
+
+}

--- a/home.admin/assets/nginx/sites-available/thub_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/thub_tor_ssl.conf
@@ -1,0 +1,20 @@
+## thub_tor_ssl.conf
+
+server {
+    listen localhost:3013 ssl;
+    listen [::1]:3013 ssl;
+    server_name _;
+
+    include /etc/nginx/snippets/ssl-params.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    access_log /var/log/nginx/access_thub.log;
+    error_log /var/log/nginx/error_thub.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3010;
+
+        include /etc/nginx/snippets/ssl-proxy-params.conf;
+    }
+
+}

--- a/home.admin/config.scripts/blitz.web.sh
+++ b/home.admin/config.scripts/blitz.web.sh
@@ -121,11 +121,11 @@ elif [ "$1" = "1" ] || [ "$1" = "on" ]; then
   echo "Turning ON: Web"
 
   # install
-  sudo apt-get update >/dev/null
-  sudo apt-get install -y nginx apache2-utils >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y nginx apache2-utils
 
   # make sure that it is enabled and started
-  sudo systemctl enable nginx >/dev/null
+  sudo systemctl enable nginx 
   sudo systemctl start nginx
 
   # general nginx settings
@@ -134,7 +134,7 @@ elif [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo sed -i -E '/^.*server_names_hash_bucket_size [0-9]*;$/a \\tserver_names_hash_bucket_size 128;' /etc/nginx/nginx.conf
   fi
 
-  if [ -f /etc/ssl/certs/dhparam.pem ]; then
+  if [ ! -f /etc/ssl/certs/dhparam.pem ]; then
     #can take 5-10+ minutes on a Raspberry Pi 3
     echo "Running \"sudo openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048\" next."
     echo "This can take 5-10 minutes on a Raspberry Pi 3 - please be patient!"
@@ -152,7 +152,7 @@ elif [ "$1" = "1" ] || [ "$1" = "on" ]; then
   fi
 
   if ! [ -d /var/www/letsencrypt/.well-known/acme-challenge ]; then
-    sudo mkdir -p /var/www/letsencrypt/.well-known/acme-challenge >/dev/null
+    sudo mkdir -p /var/www/letsencrypt/.well-known/acme-challenge
   fi
 
   # make sure admin can write here even without sudo
@@ -175,7 +175,7 @@ elif [ "$1" = "1" ] || [ "$1" = "on" ]; then
   fi
 
   # make sure jinja2 is installed and install j2cli
-  sudo apt-get install python3-jinja2 >/dev/null
+  sudo apt-get install -y python3-jinja2
   sudo -H python3 -m pip install j2cli
 
   # create nginx app-data dir and use LND cert by default

--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -39,7 +39,7 @@ This can take multiple hours.
     # TOR
     /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
     whiptail --title " BTC-RPC-Explorer " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3002
+http://${localip}:3020
 Login is 'admin' with your Password B\n
 Hidden Service address for TOR Browser (QR see LCD):
 ${toraddress}
@@ -49,7 +49,7 @@ ${toraddress}
 
     # IP + Domain
     whiptail --title " BTC-RPC-Explorer " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3002
+http://${localip}:3020
 Login is 'admin' with your Password B\n
 Activate TOR to access the web block explorer from outside your local network.
 " 12 54
@@ -127,7 +127,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 # Host/Port to bind to
 # Defaults: shown
 BTCEXP_HOST=0.0.0.0
-BTCEXP_PORT=3002
+BTCEXP_PORT=3020
 # Bitcoin RPC Credentials (URI -OR- HOST/PORT/USER/PASS)
 # Defaults:
 #   - [host/port]: 127.0.0.1:8332
@@ -156,7 +156,7 @@ EOF
 
     # open firewall
     echo "*** Updating Firewall ***"
-    sudo ufw allow 3002 comment 'btc-rpc-explorer'
+    sudo ufw allow 3020 comment 'btc-rpc-explorer'
     echo ""
 
     # install service
@@ -204,8 +204,8 @@ EOF
   source /mnt/hdd/raspiblitz.conf
   if [ "${runBehindTor}" = "on" ]; then
     # correct old Hidden Service with port
-    sudo sed -i "s/^HiddenServicePort 3002 127.0.0.1:3002/HiddenServicePort 80 127.0.0.1:3002/g" /etc/tor/torrc
-    /home/admin/config.scripts/internet.hiddenservice.sh btc-rpc-explorer 80 3002
+    sudo sed -i "s/^HiddenServicePort 80 127.0.0.1:3002/HiddenServicePort 80 127.0.0.1:3020/g" /etc/tor/torrc
+    /home/admin/config.scripts/internet.hiddenservice.sh btc-rpc-explorer 80 3020
   fi
   exit 0
 fi
@@ -219,15 +219,19 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   isInstalled=$(sudo ls /etc/systemd/system/btc-rpc-explorer.service 2>/dev/null | grep -c 'btc-rpc-explorer.service')
   if [ ${isInstalled} -eq 1 ]; then
     echo "*** REMOVING BTC-RPC-explorer ***"
-    sudo systemctl stop btc-rpc-explorer
     sudo systemctl disable btc-rpc-explorer
     sudo rm /etc/systemd/system/btc-rpc-explorer.service
-    sudo rm -rf /home/btcrpcexplorer/btc-rpc-explorer
-    sudo rm -f /home/btcrpcexplorer/.config/btc-rpc-explorer.env
+    # delete user and home directory
+    sudo userdel -rf btcrpcexplorer
+    # close firewall
+    sudo ufw deny 3020
     echo "OK BTC-RPC-explorer removed."
   else 
     echo "BTC-RPC-explorer is not installed."
   fi
+
+  # close port on firewall
+  sudo ufw deny 3020
   exit 0
 fi
 

--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -39,7 +39,7 @@ This can take multiple hours.
     # TOR
     /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
     whiptail --title " BTC-RPC-Explorer " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3020
+https://${localip}:3021
 Login is 'admin' with your Password B\n
 Hidden Service address for TOR Browser (QR see LCD):
 ${toraddress}
@@ -49,7 +49,7 @@ ${toraddress}
 
     # IP + Domain
     whiptail --title " BTC-RPC-Explorer " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3020
+https://${localip}:3021
 Login is 'admin' with your Password B\n
 Activate TOR to access the web block explorer from outside your local network.
 " 12 54
@@ -156,7 +156,8 @@ EOF
 
     # open firewall
     echo "*** Updating Firewall ***"
-    sudo ufw allow 3020 comment 'btc-rpc-explorer'
+    sudo ufw allow 3020 comment 'btc-rpc-explorer HTTP'
+    sudo ufw allow 3021 comment 'btc-rpc-explorer HTTPS'
     echo ""
 
     
@@ -257,8 +258,9 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     echo "BTC-RPC-explorer is not installed."
   fi
 
-  # close port on firewall
+  # close ports on firewall
   sudo ufw deny 3020
+  sudo ufw deny 3021
   exit 0
 fi
 

--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -245,7 +245,7 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     # delete user and home directory
     sudo userdel -rf btcrpcexplorer
 
-    # setup nginx symlinks
+    # remove nginx symlinks
     sudo rm -f /etc/nginx/sites-enabled/btcrpcexplorer_ssl.conf
     sudo rm -f /etc/nginx/sites-enabled/btcrpcexplorer_tor.conf
     sudo rm -f /etc/nginx/sites-enabled/btcrpcexplorer_tor_ssl.conf

--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -227,7 +227,7 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   # setting value in raspi blitz config
   sudo sed -i "s/^rtlWebinterface=.*/rtlWebinterface=off/g" /mnt/hdd/raspiblitz.conf
 
-  # setup nginx symlinks
+  # remove nginx symlinks
   sudo rm -f /etc/nginx/sites-enabled/rtl_ssl.conf
   sudo rm -f /etc/nginx/sites-enabled/rtl_tor.conf
   sudo rm -f /etc/nginx/sites-enabled/rtl_tor_ssl.conf

--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -29,19 +29,21 @@ if [ "$1" = "menu" ]; then
     /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
     whiptail --title " Ride The Lightning (RTL) " --msgbox "Open the following URL in your local web browser:
 https://${localip}:3001
-SHA1 Thumb/Fingerprint: ${fingerprint}\n
+SHA1 Thumb/Fingerprint:
+${fingerprint}\n
 Use your Password B to login.\n
 Hidden Service address for TOR Browser (QRcode on LCD):\n${toraddress}
-" 14 67
+" 15 67
     /home/admin/config.scripts/blitz.lcd.sh hide
   else
     # Info without TOR
     whiptail --title " Ride The Lightning (RTL) " --msgbox "Open the following URL in your local web browser:
 https://${localip}:3001
-SHA1 Thumb/Fingerprint: ${fingerprint}\n
+SHA1 Thumb/Fingerprint:
+${fingerprint}\n
 Use your Password B to login.\n
 Activate TOR to access the web interface from outside your local network.
-" 13 57
+" 14 57
   fi
   echo "please wait ..."
   exit 0

--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -174,7 +174,8 @@ EOF
 
     # open firewall
     echo "*** Updating Firewall ***"
-    sudo ufw allow 3000 comment 'RTL'
+    sudo ufw allow 3000 comment 'RTL HTTP'
+    sudo ufw allow 3001 comment 'RTL HTTPS'
     echo ""
 
     # install service
@@ -245,8 +246,9 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     echo "RTL is not installed."
   fi
 
-  # close port on firewall
+  # close ports on firewall
   sudo ufw deny 3000
+  sudo ufw deny 3001
 
   echo "needs reboot to activate new setting"
   exit 0

--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -214,6 +214,7 @@ EOF
   # Hidden Service for RTL if Tor is active
   if [ "${runBehindTor}" = "on" ]; then
     # correct old Hidden Service with port
+    sudo sed -i "s/^HiddenServicePort 80 127.0.0.1:3000/HiddenServicePort 80 127.0.0.1:3002/g" /etc/tor/torrc
     /home/admin/config.scripts/internet.hiddenservice.sh RTL 80 3002 443 3003
   fi
   exit 0

--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -31,7 +31,7 @@ if [ "$1" = "menu" ]; then
 https://${localip}:3001
 SHA1 Thumb/Fingerprint: ${fingerprint}\n
 Use your Password B to login.\n
-Hidden Service address for TOR Browser (QR see LCD):\n${toraddress}
+Hidden Service address for TOR Browser (QRcode on LCD):\n${toraddress}
 " 14 67
     /home/admin/config.scripts/blitz.lcd.sh hide
   else
@@ -233,14 +233,17 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   isInstalled=$(sudo ls /etc/systemd/system/RTL.service 2>/dev/null | grep -c 'RTL.service')
   if [ ${isInstalled} -eq 1 ]; then
     echo "*** REMOVING RTL ***"
-    sudo systemctl stop RTL
     sudo systemctl disable RTL
     sudo rm /etc/systemd/system/RTL.service
-    sudo rm -rf /home/rtl/RTL
+    # delete user and home directory
+    sudo userdel -rf rtl
     echo "OK RTL removed."
   else
     echo "RTL is not installed."
   fi
+
+  # close port on firewall
+  sudo ufw deny 3000
 
   echo "needs reboot to activate new setting"
   exit 0

--- a/home.admin/config.scripts/bonus.thunderhub.sh
+++ b/home.admin/config.scripts/bonus.thunderhub.sh
@@ -81,7 +81,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo -u thunderhub git clone https://github.com/apotdevin/thunderhub.git /home/thunderhub/thunderhub
     cd /home/thunderhub/thunderhub
     # https://github.com/apotdevin/thunderhub/releases
-    sudo -u thunderhub git reset --hard v0.7.4
+    sudo -u thunderhub git reset --hard v0.7.8
     echo "Running npm install and run build..."
     sudo -u thunderhub npm install
     sudo -u thunderhub npm run build
@@ -116,8 +116,16 @@ LOG_LEVEL='debug'
 # -----------
 THEME='dark'
 CURRENCY='sat'
+
+# -----------
+# Privacy Configs
+# -----------
 FETCH_PRICES=false
 FETCH_FEES=false
+HODL_HODL=false
+DISABLE_LINKS=true
+NO_CLIENT_ACCOUNTS=true
+NO_VERSION_CHECK=true
 
 # -----------
 # Account Configs

--- a/home.admin/config.scripts/bonus.thunderhub.sh
+++ b/home.admin/config.scripts/bonus.thunderhub.sh
@@ -210,7 +210,9 @@ EOF
 
     # Hidden Service for thunderhub if Tor is active
     if [ "${runBehindTor}" = "on" ]; then
-      /home/admin/config.scripts/internet.hiddenservice.sh thunderhub 80 3010
+      # correct old Hidden Service with port
+      sudo sed -i "s/^HiddenServicePort 80 127.0.0.1:3001/HiddenServicePort 80 127.0.0.1:3012/g" /etc/tor/torrc
+      /home/admin/config.scripts/internet.hiddenservice.sh thunderhub 80 3012 443 3013
     fi
   fi
   exit 0

--- a/home.admin/config.scripts/bonus.thunderhub.sh
+++ b/home.admin/config.scripts/bonus.thunderhub.sh
@@ -29,19 +29,21 @@ if [ "$1" = "menu" ]; then
     /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
     whiptail --title " ThunderHub " --msgbox "Open the following URL in your local web browser:
 http://${localip}:3011
-SHA1 Thumb/Fingerprint: ${fingerprint}\n
+SHA1 Thumb/Fingerprint:
+${fingerprint}\n
 Use your Password B to login.\n
 Hidden Service address for TOR Browser (see LCD for QR):\n${toraddress}
-" 14 67
+" 15 67
     /home/admin/config.scripts/blitz.lcd.sh hide
   else
     # Info without TOR
     whiptail --title " ThunderHub " --msgbox "Open the following URL in your local web browser:
 http://${localip}:3011
-SHA1 Thumb/Fingerprint: ${fingerprint}\n
+SHA1 Thumb/Fingerprint:
+${fingerprint}\n
 Use your Password B to login.\n
 Activate TOR to access the web interface from outside your local network.
-" 13 57
+" 14 57
   fi
   echo "please wait ..."
   exit 0

--- a/home.admin/config.scripts/bonus.thunderhub.sh
+++ b/home.admin/config.scripts/bonus.thunderhub.sh
@@ -240,7 +240,7 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo ufw deny 3010
   sudo ufw deny 3011
 
-  # setup nginx symlinks
+  # remove nginx symlinks
   sudo rm -f /etc/nginx/sites-enabled/thub_ssl.conf
   sudo rm -f /etc/nginx/sites-enabled/thub_tor.conf
   sudo rm -f /etc/nginx/sites-enabled/thub_tor_ssl.conf

--- a/home.admin/config.scripts/bonus.thunderhub.sh
+++ b/home.admin/config.scripts/bonus.thunderhub.sh
@@ -28,7 +28,7 @@ if [ "$1" = "menu" ]; then
     # Info with TOR
     /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
     whiptail --title " ThunderHub " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3011
+https://${localip}:3011
 SHA1 Thumb/Fingerprint:
 ${fingerprint}\n
 Use your Password B to login.\n
@@ -38,7 +38,7 @@ Hidden Service address for TOR Browser (see LCD for QR):\n${toraddress}
   else
     # Info without TOR
     whiptail --title " ThunderHub " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3011
+https://${localip}:3011
 SHA1 Thumb/Fingerprint:
 ${fingerprint}\n
 Use your Password B to login.\n
@@ -178,7 +178,8 @@ EOF
     
     # open the firewall
     echo "*** Updating Firewall ***"
-    sudo ufw allow from any to any port 3010 comment 'allow ThunderHub'
+    sudo ufw allow from any to any port 3010 comment 'allow ThunderHub HTTP'
+    sudo ufw allow from any to any port 3011 comment 'allow ThunderHub HTTPS'
     echo ""
         
     ##################
@@ -235,8 +236,9 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo rm -f /etc/systemd/system/thunderhub.service
   # delete user and home directory
   sudo userdel -rf thunderhub
-  # close port on firewall
+  # close ports on firewall
   sudo ufw deny 3010
+  sudo ufw deny 3011
 
   # setup nginx symlinks
   sudo rm -f /etc/nginx/sites-enabled/thub_ssl.conf

--- a/home.admin/config.scripts/bonus.thunderhub.sh
+++ b/home.admin/config.scripts/bonus.thunderhub.sh
@@ -22,23 +22,26 @@ if [ "$1" = "menu" ]; then
   # get network info
   localip=$(ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
   toraddress=$(sudo cat /mnt/hdd/tor/thunderhub/hostname 2>/dev/null)
+  fingerprint=$(openssl x509 -in /mnt/hdd/app-data/nginx/tls.cert -fingerprint -noout | cut -d"=" -f2)
 
   if [ "${runBehindTor}" = "on" ] && [ ${#toraddress} -gt 0 ]; then
     # Info with TOR
     /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
     whiptail --title " ThunderHub " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3010
+http://${localip}:3011
+SHA1 Thumb/Fingerprint: ${fingerprint}\n
 Use your Password B to login.\n
-Hidden Service address for TOR Browser (QR see LCD):\n${toraddress}
-" 12 67
+Hidden Service address for TOR Browser (see LCD for QR):\n${toraddress}
+" 14 67
     /home/admin/config.scripts/blitz.lcd.sh hide
   else
     # Info without TOR
     whiptail --title " ThunderHub " --msgbox "Open the following URL in your local web browser:
-http://${localip}:3010
+http://${localip}:3011
+SHA1 Thumb/Fingerprint: ${fingerprint}\n
 Use your Password B to login.\n
 Activate TOR to access the web interface from outside your local network.
-" 12 57
+" 13 57
   fi
   echo "please wait ..."
   exit 0
@@ -76,7 +79,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo -u thunderhub git clone https://github.com/apotdevin/thunderhub.git /home/thunderhub/thunderhub
     cd /home/thunderhub/thunderhub
     # https://github.com/apotdevin/thunderhub/releases
-    sudo -u thunderhub git reset --hard v0.7.1
+    sudo -u thunderhub git reset --hard v0.7.4
     echo "Running npm install and run build..."
     sudo -u thunderhub npm install
     sudo -u thunderhub npm run build
@@ -110,9 +113,9 @@ LOG_LEVEL='debug'
 # Interface Configs
 # -----------
 THEME='dark'
-# CURRENCY='sat'
-# FETCH_PRICES=false
-# FETCH_FEES=false
+CURRENCY='sat'
+FETCH_PRICES=false
+FETCH_FEES=false
 
 # -----------
 # Account Configs
@@ -143,7 +146,31 @@ EOF
     sudo mv /home/admin/thubConfig.yaml /home/thunderhub/thubConfig.yaml
     sudo chown thunderhub:thunderhub /home/thunderhub/thubConfig.yaml
     sudo chmod 600 /home/thunderhub/thubConfig.yaml | exit 1
-
+    
+    ##################
+    # NGINX
+    ##################
+    # setup nginx symlinks
+    if ! [ -f /etc/nginx/sites-available/thub_ssl.conf ]; then
+       sudo cp /home/admin/assets/nginx/sites-available/thub_ssl.conf /etc/nginx/sites-available/thub_ssl.conf
+    fi
+    if ! [ -f /etc/nginx/sites-available/thub_tor.conf ]; then
+       sudo cp /home/admin/assets/nginx/sites-available/thub_tor.conf /etc/nginx/sites-available/thub_tor.conf
+    fi
+    if ! [ -f /etc/nginx/sites-available/thub_tor_ssl.conf ]; then
+       sudo cp /home/admin/assets/nginx/sites-available/thub_tor_ssl.conf /etc/nginx/sites-available/thub_tor_ssl.conf
+    fi
+    sudo ln -sf /etc/nginx/sites-available/thub_ssl.conf /etc/nginx/sites-enabled/
+    sudo ln -sf /etc/nginx/sites-available/thub_tor.conf /etc/nginx/sites-enabled/
+    sudo ln -sf /etc/nginx/sites-available/thub_tor_ssl.conf /etc/nginx/sites-enabled/
+    sudo nginx -t
+    sudo systemctl reload nginx
+    
+    # open the firewall
+    echo "*** Updating Firewall ***"
+    sudo ufw allow from any to any port 3010 comment 'allow ThunderHub'
+    echo ""
+        
     ##################
     # SYSTEMD SERVICE
     ##################
@@ -176,9 +203,6 @@ EOF
     sudo systemctl enable thunderhub
     echo "OK - the ThunderHub service is now enabled"
 
-    # open the firewall
-    sudo ufw allow from any to any port 3010 comment 'allow ThunderHub'
-
     # setting value in raspiblitz config
     sudo sed -i "s/^thunderhub=.*/thunderhub=on/g" /mnt/hdd/raspiblitz.conf
 
@@ -199,6 +223,16 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo rm -f /etc/systemd/system/thunderhub.service
   # delete user and home directory
   sudo userdel -rf thunderhub
+  # close port on firewall
+  sudo ufw deny 3010
+
+  # setup nginx symlinks
+  sudo rm -f /etc/nginx/sites-enabled/thub_ssl.conf
+  sudo rm -f /etc/nginx/sites-enabled/thub_tor.conf
+  sudo rm -f /etc/nginx/sites-enabled/thub_tor_ssl.conf
+  sudo nginx -t
+  sudo systemctl reload nginx
+
   echo "OK ThunderHub removed."
 
   # setting value in raspi blitz config

--- a/home.admin/config.scripts/internet.hiddenservice.sh
+++ b/home.admin/config.scripts/internet.hiddenservice.sh
@@ -92,6 +92,7 @@ HiddenServicePort $toPort 127.0.0.1:$fromPort" | sudo tee -a /etc/tor/torrc
   echo "use with the port: $toPort"
   echo ""
   if [ ${#toPort2} -gt 0 ]; then
+    alreadyThere=$(sudo cat /etc/tor/torrc 2>/dev/null | grep -c "\b127.0.0.1:$fromPort2\b")
     if [ ${alreadyThere} -eq 0 ]; then
       echo "or the port: $toPort2"
     else


### PR DESCRIPTION
- [x] add Thunderhub nginx config https://github.com/rootzoll/raspiblitz/issues/1233
- [x]  fixing blitz.web install:  https://github.com/rootzoll/raspiblitz/issues/255
- [x] add BTCRPCExplorer Nginx config
- [x] run blitz.web.sh automatically during setup
- [x] add the HTTPS ports to UFW during setup and closed on uninstall for RTL, THub and Explorer