### PR TITLE
btcpay: correct ports in nginx config

### DIFF
--- a/home.admin/assets/nginx/sites-available/btcpay_tor.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_tor.conf
@@ -9,7 +9,7 @@ server {
     error_log /var/log/nginx/error_btcpay.log;
 
     location / {
-        proxy_pass http://127.0.0.1:23001;
+        proxy_pass http://127.0.0.1:23000;
 
         include /etc/nginx/snippets/ssl-proxy-params.conf;
     }

--- a/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
@@ -12,7 +12,7 @@ server {
     error_log /var/log/nginx/error_btcpay.log;
 
     location / {
-        proxy_pass http://127.0.0.1:23001;
+        proxy_pass http://127.0.0.1:23000;
 
         include /etc/nginx/snippets/ssl-proxy-params.conf;
     }


### PR DESCRIPTION
Fixes https://github.com/rootzoll/raspiblitz/issues/1258#issuecomment-649736636

HTTPS clearnet 
.onion
HTTPS .onion

all working now with BTCpay as well.