### PR TITLE
Mail notification improvements

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -772,8 +772,8 @@ If you want to use the HDMI output you can place a file called `hdmi` on the `bo
 
 If you are already logged in you can use on the console the commands:
 
-- `hdmi` --> to witch to HDMI
-- `lcd` --> to witch to LCD
+- `hdmi` --> switch to HDMI
+- `lcd` --> switch to LCD
 
 ## How do I set up VNC?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,5 +1,10 @@
 # FAQ - Frequently Asked Questions
 
+## Whats new in Version 1.5.1 of RaspiBlitz?
+
+- Bugfix: DropBox Backup of Static-Channel-Backup
+- Bugfix: Torrentfiles with active tracker 
+
 ## Whats new in Version 1.5 of RaspiBlitz?
 
 Beside many small improvements and changes, these are most important changes:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *Build your own Lightning Node on a RaspberryPi with a nice Display.*
 
-`Version 1.5 with lnd 0.9.2-beta (0.10.0-beta optional) and bitcoin 0.19.1 (or litecoin 0.17.1)`
+`Version 1.5.1 with lnd 0.9.2-beta (0.10.0-beta optional) and bitcoin 0.19.1 (or litecoin 0.17.1)`
 
 ![RaspiBlitz](pictures/raspiblitz.jpg)
 
@@ -114,13 +114,11 @@ In the end your RaspiBlitz should look like this:
 
 Your SD-card needs to contain the RaspiBlitz software. You can take the long road by [building the SD-card image yourself](#build-the-sd-card-image) or use the already prepared SD-Card image:
 
-**Download SD-Card image - Version 1.5:**
+**Download SD-Card image - Version 1.5.1:**
 
-Browser: http://blitz.rotzoll.de/raspiblitz-v1.5-2020-05-08.img.gz
+Browser: https://files.rotzoll.de/raspiblitz-v1.5.1-2020-05-30.img.gz
 
-Torrent: https://github.com/rootzoll/raspiblitz/raw/v1.5/home.admin/assets/raspiblitz-v1.5-2020-05-08.img.gz.torrent
-
-SHA-256: 51cf8cc0f5ff9f562327ed8ba6779cffef8ba8e3c6e2b8e21bcd2f931f630584 or [SIGNATURE](http://blitz.rotzoll.de/raspiblitz-v1.5-2020-05-08.img.gz.sig)
+SHA-256: e896c7c1cc38622b02037569c2b76ad56b72dfb93c01024a0cb278d0d899d210 or [SIGNATURE](https://files.rotzoll.de/raspiblitz-v1.5.1-2020-05-30.img.gz.sig)
 
 * [Whats new in Version 1.5 of RaspiBlitz?](FAQ.md#whats-new-in-version-15-of-raspiblitz)
 * [How to update my RaspiBlitz?](README.md#updating-raspiblitz-to-new-version)

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ This is also the best option if you don't like to run your RaspberryPi 3 with a 
 
 More details: [I have the full blockchain on another computer. How do I copy it to the RaspiBlitz?](FAQ.md#i-have-the-full-blockchain-on-another-computer-how-do-i-copy-it-to-the-raspiblitz)
 
-#### 3. Torrent Fallback
+#### 3. Torrent Fallback (NOTE: to-be-deprecated in 1.6)
 
 *This is recommended for old RaspberryPi 3s - for the newer RaspberryPi 4 you might consider the `SYNC` option.*
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Your SD-card needs to contain the RaspiBlitz software. You can take the long roa
 
 **Download SD-Card image - Version 1.5:**
 
-Browser: https://raspiblitz.com/raspiblitz-v1.5-2020-05-08.img.gz
+Browser: http://blitz.rotzoll.de/raspiblitz-v1.5-2020-05-08.img.gz
 
 Torrent: https://github.com/rootzoll/raspiblitz/raw/v1.5/home.admin/assets/raspiblitz-v1.5-2020-05-08.img.gz.torrent
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Browser: http://blitz.rotzoll.de/raspiblitz-v1.5-2020-05-08.img.gz
 
 Torrent: https://github.com/rootzoll/raspiblitz/raw/v1.5/home.admin/assets/raspiblitz-v1.5-2020-05-08.img.gz.torrent
 
-SHA-256: 51cf8cc0f5ff9f562327ed8ba6779cffef8ba8e3c6e2b8e21bcd2f931f630584 or [SIGNATURE](https://raspiblitz.com/raspiblitz-v1.5-2020-05-08.img.gz.sig)
+SHA-256: 51cf8cc0f5ff9f562327ed8ba6779cffef8ba8e3c6e2b8e21bcd2f931f630584 or [SIGNATURE](http://blitz.rotzoll.de/raspiblitz-v1.5-2020-05-08.img.gz.sig)
 
 * [Whats new in Version 1.5 of RaspiBlitz?](FAQ.md#whats-new-in-version-15-of-raspiblitz)
 * [How to update my RaspiBlitz?](README.md#updating-raspiblitz-to-new-version)

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ This is the screen that gets displayed on the LCD/display. It's useful to call i
 
 Before you can open channels with other nodes you need to put some coins onto your LND on-chain wallet. Use this option to generate an address to send funds to.
 
-*Reminder: RaspiBlitz & LND is still experimental software. With funding your LND node you accept the risk of loosing funds. So just play with small amounts - something in then area of 20 EUR/USD should be enough to make your first experiences. Also, it's a good privacy practice to [coinjoin your coins](https://bitcoin-only.com/#privacy) before sending them to any Lightning Network wallet.*
+*Reminder: RaspiBlitz & LND is still experimental software. With funding your LND node you accept the risk of losing funds. So just play with small amounts - something in then area of 20 EUR/USD should be enough to make your first experiences. Also, it's a good privacy practice to [coinjoin your coins](https://bitcoin-only.com/#privacy) before sending them to any Lightning Network wallet.*
 
 You can make multiple fundings - so you can start with small amounts first to test. LND will generate always a different address, but all funds you send will get into the same LND on-chain wallet.
 

--- a/home.admin/00raspiblitz.sh
+++ b/home.admin/00raspiblitz.sh
@@ -166,7 +166,7 @@ waitUntilChainNetworkIsReady()
 
           whiptail --title "RaspiBlitz - Repair Script" --yes-button "DELETE+REPAIR" --no-button "Ignore" --yesno "Your blockchain data needs to be repaired.
 This can be due to power problems or a failing HDD.
-For more info see: https://raspiblitz.com -> FAQ
+For more info see: https://raspiblitz.org -> FAQ
 
 Before RaspiBlitz can offer you repair options the old
 corrupted blockchain needs to be deleted while your LND

--- a/home.admin/70initLND.sh
+++ b/home.admin/70initLND.sh
@@ -172,7 +172,7 @@ if [ ${walletExists} -eq 0 ]; then
 
   # UI: Ask if user wants NEW wallet or RECOVER a wallet
   OPTIONS=(NEW "Setup a brand new Lightning Node (DEFAULT)" \
-           OLD "I had a old Node I want to recover/restore")
+           OLD "I had an old Node I want to recover/restore")
   CHOICE=$(dialog --backtitle "RaspiBlitz" --clear --title "LND Setup" --menu "LND Data & Wallet" 11 60 6 "${OPTIONS[@]}" 2>&1 >/dev/tty)
   echo "choice($CHOICE)"
 

--- a/home.admin/XXsendNotification.py
+++ b/home.admin/XXsendNotification.py
@@ -93,6 +93,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
         print("send mail")
         print("msg: {}".format(message))
         print("to: {}".format(recipient))
+        print("from: {} <{}>".format(from_name, from_address))
         print("subject: {}".format(subject))
         print("cert: {}".format(cert))
         print("encrypt: {}".format(encrypt))
@@ -103,7 +104,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
 
         msg_content = [
             "To: {}".format(recipient),
-            'From: "{} <{}>'.format(from_name, from_address),
+            'From: {} <{}>'.format(from_name, from_address),
             "Subject: {}".format(subject),
             "",
             "{}".format(message)
@@ -118,7 +119,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
         msg = EmailMessage()
 
         msg['Subject'] = "{}".format(subject)
-        msg['From'] = '"{} <{}>'.format(from_name, from_address),
+        msg['From'] = '{} <{}>'.format(from_name, from_address),
         msg['To'] = recipient
 
         msg.set_payload(message)

--- a/home.admin/_version.info
+++ b/home.admin/_version.info
@@ -1,2 +1,2 @@
 # RaspiBlitz Version - always [main].[sub]
-codeVersion="1.5"
+codeVersion="1.5.1"

--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -138,9 +138,9 @@ if [ "$1" = "send" ]; then
     /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py ext ${notifyExtCmd} "$2"
   elif [ "${notifyMethod}" = "mail" ]; then
     if [ "${notifyMailEncrypt}" = "on" ]; then
-      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail --cert ${notifyMailToCert} --encrypt ${notifyMailTo} "$2"
+      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail "${@:3}" --cert ${notifyMailToCert} --encrypt ${notifyMailTo} "$2"
     else
-      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail ${notifyMailTo} "$2"
+      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail "${@:3}" ${notifyMailTo} "$2"
     fi
   elif [ "${notifyMethod}" = "slack" ]; then
     /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py slack -h "$2"

--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -33,7 +33,11 @@ if ! grep -Eq "^notifyMailTo=.*" /mnt/hdd/raspiblitz.conf; then
 fi
 
 if ! grep -Eq "^notifyMailServer=.*" /mnt/hdd/raspiblitz.conf; then
-    echo "notifyMailServer=mail@example.com" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
+    echo "notifyMailServer=mail.example.com" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
+fi
+
+if ! grep -Eq "^notifyMailHostname=.*" /mnt/hdd/raspiblitz.conf; then
+    echo "notifyMailHostname=$(hostname)" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
 fi
 
 if ! grep -Eq "^notifyMailUser=.*" /mnt/hdd/raspiblitz.conf; then
@@ -81,13 +85,13 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 #
 # The person who gets all mail for userids < 1000
 # Make this empty to disable rewriting.
-root=${notifyMailTo}
+Root=${notifyMailTo}
 
 # hostname of this system
-hostname=${hostname}
+Hostname=${notifyMailHostname}
 
 # relay/smarthost server settings
-mailhub=${notifyMailServer}
+Mailhub=${notifyMailServer}
 AuthUser=${notifyMailUser}
 AuthPass=${notifyMailPass}
 UseSTARTTLS=YES
@@ -141,7 +145,7 @@ if [ "$1" = "send" ]; then
   elif [ "${notifyMethod}" = "slack" ]; then
     /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py slack -h "$2"
   else
-    echo "unknown notification method - check /mnt/hdd/raspiblitz.con"
+    echo "unknown notification method - check /mnt/hdd/raspiblitz.conf"
   fi
 
   exit 0

--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -95,6 +95,7 @@ Mailhub=${notifyMailServer}
 AuthUser=${notifyMailUser}
 AuthPass=${notifyMailPass}
 UseSTARTTLS=YES
+FromLineOverride=YES
 EOF
 
   # edit raspi blitz config

--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 # https://github.com/cryptoadvance/specter-desktop  
 # ~/.config/btc-rpc-explorer.env
 # https://github.com/janoside/btc-rpc-explorer/blob/master/.env-sample
@@ -76,27 +76,23 @@ if [ "$1" = "status" ]; then
   exit 0
 fi
 
-# stop service
-echo "making sure services are not running"
-sudo systemctl stop cryptoadvance-specter 2>/dev/null
-
 # switch on
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
-  echo "*** INSTALL Cryptoadvance Specter ***"
+  echo "    --> INSTALL Cryptoadvance Specter ***"
 
-  isInstalled=$(sudo ls /etc/systemd/system/cryptoadvance-specter.service 2>/dev/null | grep -c 'cryptoadvance-specter.service')
+  isInstalled=$(sudo ls /etc/systemd/system/cryptoadvance-specter.service 2>/dev/null | grep -c 'cryptoadvance-specter.service' || /bin/true)
   if [ ${isInstalled} -eq 0 ]; then
 
-    echo "*** Enable wallets in Bitcoin Core ***"
+    echo "    --> Enable wallets in Bitcoin Core"
     sudo sed -i "s/^disablewallet=.*/disablewallet=0/g" /home/bitcoin/.bitcoin/bitcoin.conf
     sudo service bitcoind stop
     sudo service bitcoind start
 
-    echo "*** Installing prerequisites ***"
-    sudo apt install -y libusb-1.0.0-dev libudev-dev virtualenv libssl-dev
+    echo "    --> Installing prerequisites"
+    sudo apt install -y libusb-1.0.0-dev libudev-dev virtualenv
 
     # activating Authentication here ...
-    echo "*** creating App-config ***"
+    echo "    --> creating App-config"
     cat > /home/admin/config.json <<EOF
 {
 	"auth":"rpcpasswordaspin"
@@ -106,16 +102,15 @@ EOF
     sudo mv /home/admin/config.json /home/bitcoin/.specter/config.json
     sudo chown -R bitcoin:bitcoin /home/bitcoin/.specter
 
-    echo "*** creating a virtualenv ***"
+    echo "    --> creating a virtualenv"
     sudo -u bitcoin virtualenv --python=python3 /home/bitcoin/.specter/.env
 
-    echo "*** installing specter ***"
+    echo "    --> pip-installing specter"
     sudo -u bitcoin /home/bitcoin/.specter/.env/bin/python3 -m pip install --upgrade cryptoadvance.specter
     
     
-    # Creating self-signed-certificate
     # Mandatory as the camera doesn't work without https
-    echo "*** Creating self-signed certificate ***"
+    echo "    --> Creating self-signed certificate"
    openssl req -x509 -newkey rsa:4096 -nodes -out /tmp/cert.pem -keyout /tmp/key.pem -days 365 -subj "/C=US/ST=Nooneknows/L=Springfield/O=Dis/CN=www.fakeurl.com"
     sudo mv /tmp/cert.pem /home/bitcoin/.specter
     sudo chown -R bitcoin:bitcoin /home/bitcoin/.specter/cert.pem
@@ -123,12 +118,12 @@ EOF
     sudo chown -R bitcoin:bitcoin /home/bitcoin/.specter/key.pem
 
     # open firewall
-    echo "*** Updating Firewall ***"
+    echo "    --> Updating Firewall"
     sudo ufw allow 25441 comment 'cryptoadvance-specter'
     sudo ufw --force enable
     echo ""
 
-    echo "*** Installing udev-rules for hardware-wallets ***"
+    echo "    --> Installing udev-rules for hardware-wallets"
     cat > /home/admin/20-hw1.rules <<EOF
  HW.1 / Nano
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl"
@@ -197,11 +192,11 @@ EOF
     sudo chown root:root /etc/udev/rules.d/*
     sudo udevadm trigger
     sudo udevadm control --reload-rules
-    sudo groupadd plugdev
+    sudo groupadd plugdev || /bin/true
     sudo usermod -aG plugdev bitcoin
 
     # install service
-    echo "*** Install cryptoadvance-specter systemd service ***"
+    echo "    --> Install cryptoadvance-specter systemd service"
     cat > /home/admin/cryptoadvance-specter.service <<EOF
 # systemd unit for Cryptoadvance Specter
 
@@ -213,7 +208,7 @@ After=${network}d.service
 [Service]
 ExecStart=/home/bitcoin/.specter/.env/bin/python3 -m cryptoadvance.specter server --host 0.0.0.0 --cert=/home/bitcoin/.specter/cert.pem --key=/home/bitcoin/.specter/key.pem
 User=bitcoin
-Environment=PATH=/home/bitcoin/.specter/.env/bin:/home/bitcoin/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/bin
+Environment=PATH=/home/bitcoin/.specter.env/bin:/home/bitcoin/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin:/bin
 Restart=always
 TimeoutSec=120
 RestartSec=30
@@ -228,22 +223,18 @@ EOF
     sudo systemctl enable cryptoadvance-specter
     sudo systemctl start cryptoadvance-specter
 
-    echo "OK - the cryptoadvance-specter service is now enabled and started"
+    echo "    --> OK - the cryptoadvance-specter service is now enabled and started"
   else 
-    echo "cryptoadvance-specter already installed."
+    echo "    --> cryptoadvance-specter already installed."
   fi
 
   # setting value in raspi blitz config
   sudo sed -i "s/^specter=.*/specter=on/g" /mnt/hdd/raspiblitz.conf
   
-  ## Enable BTCEXP_ADDRESS_API if BTC-RPC-Explorer is active
-  # see /home/admin/config.scripts/bonus.electrsexplorer.sh
-  # run every 10 min by _background.sh
-
-  # Hidden Service for BTC-RPC-explorer if Tor is active
+  # Hidden Service for SERVICE if Tor is active
   source /mnt/hdd/raspiblitz.conf
   if [ "${runBehindTor}" = "on" ]; then
-    # correct old Hidden Service with port
+    echo "    --> correct old Hidden Service with port"
     sudo sed -i "s/^HiddenServicePort 25441 127.0.0.1:25441/HiddenServicePort 80 127.0.0.1:25441/g" /etc/tor/torrc
     /home/admin/config.scripts/internet.hiddenservice.sh cryptoadvance-specter 80 25441
   fi
@@ -258,13 +249,13 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
 
   isInstalled=$(sudo ls /etc/systemd/system/cryptoadvance-specter.service 2>/dev/null | grep -c 'cryptoadvance-specter.service')
   if [ ${isInstalled} -eq 1 ]; then
-    echo "*** REMOVING Cryptoadvance Specter ***"
+    echo "    --> REMOVING Cryptoadvance Specter"
     sudo systemctl stop cryptoadvance-specter
     sudo systemctl disable cryptoadvance-specter
     sudo rm /etc/systemd/system/cryptoadvance-specter.service
 
     if whiptail --defaultno --yesno "Do you want to delete all Data related to specter? This includes also Bitcoin-Core-Wallets managed by specter?" 0 0; then
-      echo "*** Removing wallets in core ***"
+      echo "    --> Removing wallets in core"
       bitcoin-cli listwallets | jq -r .[] | tail -n +2
       for i in $(bitcoin-cli listwallets | jq -r .[] | tail -n +2) 
       do  
@@ -273,13 +264,13 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
       done
       sudo rm -rf /home/bitcoin/.bitcoin/specter
 
-      echo "*** Removing /home/bitcoin/.specter ***"
+      echo "    --> Removing /home/bitcoin/.specter"
       sudo rm -rf /home/bitcoin/.specter
     fi
 
-    echo "OK Cryptoadvance Specter removed."
+    echo "    --> OK Cryptoadvance Specter removed."
   else 
-    echo "Cryptoadvance Specter is not installed."
+    echo "    --> Cryptoadvance Specter is not installed."
   fi
   exit 0
 fi

--- a/home.admin/config.scripts/lnd.rescue.sh
+++ b/home.admin/config.scripts/lnd.rescue.sh
@@ -54,16 +54,16 @@ if [ ${mode} = "backup" ]; then
   # offer SCP for download
   clear
   echo
-  echo "*****************************"
-  echo "* DOWNLOAD THE REASCUE FILE *"
-  echo "*****************************"
+  echo "****************************"
+  echo "* DOWNLOAD THE RESCUE FILE *"
+  echo "****************************"
   echo 
   echo "ON YOUR LAPTOP - RUN IN NEW TERMINAL:"
   echo "scp -r 'admin@${localip}:/home/admin/lnd-rescue-*.tar.gz' ./"
   echo ""
   echo "Use password A to authenticate file transfer."
   echo
-  echo "BEWARE: Your Lightning node is now stopped. Its safe to backup the data and"
+  echo "BEWARE: Your Lightning node is now stopped. It's safe to backup the data and"
   echo "restore it on a fresh RaspiBlitz. But once this Lightning node gets started"
   echo "again or rebooted its not adviced to restore the backup file anymore because"
   echo "it cointains then outdated channel data & can lead to loss of channel funds."
@@ -129,8 +129,8 @@ elif [ ${mode} = "restore" ]; then
           echo "OK -> checksum looks good: ${md5checksum}"
         else
           echo "!!! FAIL -> Checksum not correct."
-          echo "Maybe transfer failed? Continue on your own risk!"
-          echo "Recommend to abort and upload again!"
+          echo "Maybe transfer failed? Continue at your own risk!"
+          echo "It is recommended to abort and upload again!"
         fi
 
         # overrride test


### PR DESCRIPTION
Some things I found while working on the integration with my mail server:

- Added the `notifyMailHostname` because my mailserver required a fully qualified domain for authentication. It falls back to the hostname (as before) when initializing the config option. This is an optional flag, so it should not hurt users who already activated notifications.
- Allowed to pass through additional flags from the `config.scripts/blitz.notify.sh send` call to `XXsendNotification.py`, which is useful for configuring individual mails one might want to send. (e.g. with different subjects or with custom from addresses)
- Allow [setting a custom `From` header](https://tosbourn.com/allowing-your-own-from-header-with-ssmtp/)
- Uppercased the sSMTP config options for consistency