### PR TITLE
Mail notification improvements

### DIFF
--- a/home.admin/XXsendNotification.py
+++ b/home.admin/XXsendNotification.py
@@ -93,6 +93,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
         print("send mail")
         print("msg: {}".format(message))
         print("to: {}".format(recipient))
+        print("from: {} <{}>".format(from_name, from_address))
         print("subject: {}".format(subject))
         print("cert: {}".format(cert))
         print("encrypt: {}".format(encrypt))
@@ -103,7 +104,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
 
         msg_content = [
             "To: {}".format(recipient),
-            'From: "{} <{}>'.format(from_name, from_address),
+            'From: {} <{}>'.format(from_name, from_address),
             "Subject: {}".format(subject),
             "",
             "{}".format(message)
@@ -118,7 +119,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
         msg = EmailMessage()
 
         msg['Subject'] = "{}".format(subject)
-        msg['From'] = '"{} <{}>'.format(from_name, from_address),
+        msg['From'] = '{} <{}>'.format(from_name, from_address),
         msg['To'] = recipient
 
         msg.set_payload(message)

--- a/home.admin/XXsendNotification.py
+++ b/home.admin/XXsendNotification.py
@@ -107,7 +107,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
             'From: {} <{}>'.format(from_name, from_address),
             "Subject: {}".format(subject),
             "",
-            "{}".format(message)
+            "{}".format(message.encode('utf8'))
         ]
 
         with open(cert, 'rb') as pem:
@@ -122,7 +122,7 @@ def mail(recipient=None, message=None, subject=None, cert=None, encrypt=False,
         msg['From'] = '{} <{}>'.format(from_name, from_address),
         msg['To'] = recipient
 
-        msg.set_payload(message)
+        msg.set_payload(message.encode('utf8'))
         msg_to_send = msg.as_bytes()
 
     # send message via e-Mail

--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -138,9 +138,9 @@ if [ "$1" = "send" ]; then
     /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py ext ${notifyExtCmd} "$2"
   elif [ "${notifyMethod}" = "mail" ]; then
     if [ "${notifyMailEncrypt}" = "on" ]; then
-      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail --cert ${notifyMailToCert} --encrypt ${notifyMailTo} "$2"
+      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail "${@:3}" --cert ${notifyMailToCert} --encrypt ${notifyMailTo} "$2"
     else
-      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail ${notifyMailTo} "$2"
+      /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py mail "${@:3}" ${notifyMailTo} "$2"
     fi
   elif [ "${notifyMethod}" = "slack" ]; then
     /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py slack -h "$2"

--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -33,7 +33,11 @@ if ! grep -Eq "^notifyMailTo=.*" /mnt/hdd/raspiblitz.conf; then
 fi
 
 if ! grep -Eq "^notifyMailServer=.*" /mnt/hdd/raspiblitz.conf; then
-    echo "notifyMailServer=mail@example.com" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
+    echo "notifyMailServer=mail.example.com" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
+fi
+
+if ! grep -Eq "^notifyMailHostname=.*" /mnt/hdd/raspiblitz.conf; then
+    echo "notifyMailHostname=$(hostname)" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
 fi
 
 if ! grep -Eq "^notifyMailUser=.*" /mnt/hdd/raspiblitz.conf; then
@@ -81,13 +85,13 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 #
 # The person who gets all mail for userids < 1000
 # Make this empty to disable rewriting.
-root=${notifyMailTo}
+Root=${notifyMailTo}
 
 # hostname of this system
-hostname=${hostname}
+Hostname=${notifyMailHostname}
 
 # relay/smarthost server settings
-mailhub=${notifyMailServer}
+Mailhub=${notifyMailServer}
 AuthUser=${notifyMailUser}
 AuthPass=${notifyMailPass}
 UseSTARTTLS=YES
@@ -141,7 +145,7 @@ if [ "$1" = "send" ]; then
   elif [ "${notifyMethod}" = "slack" ]; then
     /home/admin/python3-env-lnd/bin/python3 /home/admin/XXsendNotification.py slack -h "$2"
   else
-    echo "unknown notification method - check /mnt/hdd/raspiblitz.con"
+    echo "unknown notification method - check /mnt/hdd/raspiblitz.conf"
   fi
 
   exit 0

--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -95,6 +95,7 @@ Mailhub=${notifyMailServer}
 AuthUser=${notifyMailUser}
 AuthPass=${notifyMailPass}
 UseSTARTTLS=YES
+FromLineOverride=YES
 EOF
 
   # edit raspi blitz config


### PR DESCRIPTION
As #1296, but with the correct target branch :)

Some things I found while working on the integration with my mail server:

- Added the `notifyMailHostname` because my mailserver required a fully qualified domain for authentication. It falls back to the hostname (as before) when initializing the config option. This is an optional flag, so it should not hurt users who already activated notifications.
- Allowed to pass through additional flags from the `config.scripts/blitz.notify.sh send` call to `XXsendNotification.py`, which is useful for configuring individual mails one might want to send. (e.g. with different subjects or with custom from addresses)
- Allow [setting a custom `From` header](https://tosbourn.com/allowing-your-own-from-header-with-ssmtp/)
- Uppercased the sSMTP config options for consistency