### PR TITLE
Use wallet.dat for consistent multiwallet support

### DIFF
--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -85,6 +85,11 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     chown -R joinmarket:joinmarket /mnt/hdd/app-data/.joinmarket
     ln -s /mnt/hdd/app-data/.joinmarket /home/joinmarket/ 2>/dev/null
     chown -R joinmarket:joinmarket /home/joinmarket/.joinmarket
+    # specify wallet.dat in old config for multiwallet for multiwallet support
+    if [ -f "/home/joinmarket/.joinmarket/joinmarket.cfg" ] ; then
+      sudo -u joinmarket sed -i "s/^rpc_wallet_file =.*/rpc_wallet_file = wallet.dat/g" /home/joinmarket/.joinmarket/joinmarket.cfg
+      echo "Specified to use wallet.dat in the recovered joinmarket.cfg"
+    fi
 
     # install joinmarket
     cd /home/joinmarket
@@ -169,6 +174,8 @@ if [ ! -f "/home/joinmarket/.joinmarket/joinmarket.cfg" ] ; then
   PASSWORD_B=\$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcpassword | cut -c 13-)
   sed -i "s/^rpc_password =.*/rpc_password = \$PASSWORD_B/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   echo "Filled the bitcoin RPC password (PASSWORD_B)"
+  sed -i "s/^rpc_wallet_file =.*/rpc_wallet_file = wallet.dat/g" /home/joinmarket/.joinmarket/joinmarket.cfg
+  echo "Using the bitcoind wallet: wallet.dat"
   #communicate with IRC servers via Tor
   sed -i "s/^host = irc.darkscience.net/#host = irc.darkscience.net/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   sed -i "s/^#host = darksci3bfoka7tw.onion/host = darksci3bfoka7tw.onion/g" /home/joinmarket/.joinmarket/joinmarket.cfg

--- a/home.admin/config.scripts/network.wallet.sh
+++ b/home.admin/config.scripts/network.wallet.sh
@@ -34,15 +34,27 @@ fi
 # switch on
 ###################
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+  
+  if ! grep -Eq "^wallet=wallet.dat" /mnt/hdd/${network}/${network}.conf; then
+    echo "Enable the multiwallet feature in ${network} core and specify wallet.dat" 
+    echo "wallet=wallet.dat" | sudo tee -a /mnt/hdd/${network}/${network}.conf >/dev/null
+    restartService=1
+  else
+    echo "Multiwallet is active and wallet.dat is used." 
+    restartService=0
+  fi
   if [ ${disablewallet} == 1 ]; then
     sudo sed -i "s/^disablewallet=.*/disablewallet=0/g" /mnt/hdd/${network}/${network}.conf
-    echo "switching the ${network} core wallet on and restarting ${network}d"
-    sudo systemctl restart ${network}d
-    exit 0
+    echo "Switching the ${network} core wallet on"
+    restartService=1
   else
     echo "The ${network} core wallet is already on"    
-    exit 0
   fi
+  if [ ${restartService} == 1 ]; then
+    echo "Restarting ${network}d"
+    sudo systemctl restart ${network}d
+  fi
+  exit 0
 fi
 
 


### PR DESCRIPTION
the `wallet.dat` will be specified in bitcoin.conf when the `network.wallet.sh on` is called.
New joinmarket installs and recovery sets JM to use wallet.dat.

fixing: https://github.com/rootzoll/raspiblitz/issues/1273