### PR TITLE
add nginx snippet for extra tor cert

### DIFF
--- a/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
@@ -6,7 +6,7 @@ server {
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
-    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
 
     access_log /var/log/nginx/access_btcpay.log;
     error_log /var/log/nginx/error_btcpay.log;

--- a/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor_ssl.conf
@@ -6,7 +6,7 @@ server {
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
-    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
 
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;

--- a/home.admin/assets/nginx/sites-available/lnbits_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/lnbits_tor_ssl.conf
@@ -6,7 +6,7 @@ server {
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
-    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
 
     access_log /var/log/nginx/access_lnbits.log;
     error_log /var/log/nginx/error_lnbits.log;

--- a/home.admin/assets/nginx/sites-available/rtl_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/rtl_tor_ssl.conf
@@ -6,7 +6,7 @@ server {
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
-    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
 
     access_log /var/log/nginx/access_rtl.log;
     error_log /var/log/nginx/error_rtl.log;

--- a/home.admin/assets/nginx/sites-available/thub_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/thub_tor_ssl.conf
@@ -6,7 +6,7 @@ server {
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
-    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
 
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;

--- a/home.admin/assets/nginx/snippets/ssl-certificate-app-data-tor.conf
+++ b/home.admin/assets/nginx/snippets/ssl-certificate-app-data-tor.conf
@@ -1,0 +1,5 @@
+# ssl-certificate-app-data-tor.conf
+
+ssl_certificate /mnt/hdd/app-data/nginx/tor_tls.cert;
+ssl_certificate_key /mnt/hdd/app-data/nginx/tor_tls.key;
+

--- a/home.admin/config.scripts/blitz.web.sh
+++ b/home.admin/config.scripts/blitz.web.sh
@@ -182,6 +182,8 @@ elif [ "$1" = "1" ] || [ "$1" = "on" ]; then
   sudo mkdir /mnt/hdd/app-data/nginx/ 2>/dev/null
   sudo ln -sf /mnt/hdd/lnd/tls.cert /mnt/hdd/app-data/nginx/tls.cert
   sudo ln -sf /mnt/hdd/lnd/tls.key /mnt/hdd/app-data/nginx/tls.key
+  sudo ln -sf /mnt/hdd/lnd/tls.cert /mnt/hdd/app-data/nginx/tor_tls.cert
+  sudo ln -sf /mnt/hdd/lnd/tls.key /mnt/hdd/app-data/nginx/tor_tls.key
 
   # config
   sudo cp /home/admin/assets/blitzweb.conf /etc/nginx/sites-available/blitzweb.conf


### PR DESCRIPTION
I recall having commented on an issue/a question recently but can't find it right now.

The reason that e.g. LNbits is listening on both 5001 and 5003 with TLS is that in some cases using separate certificates might be useful.

With this PR the default is that there are two symlinks for each of the cert+key pairs which point to the same files (the LND generated cert+key). By pointing the `/mnt/hdd/app-data/nginx/tor_tls.cert` and `/mnt/hdd/app-data/nginx/tor_tls.key` links to e.g. the right files in `/mnt/hdd/app-data/letsencrypt/certs/` I can use a different domain/SAN to access the tor hidden service.

Makes sense?

