### PR TITLE
switch nginx proxy header Host

### DIFF
--- a/home.admin/assets/nginx/snippets/ssl-proxy-params.conf
+++ b/home.admin/assets/nginx/snippets/ssl-proxy-params.conf
@@ -1,7 +1,7 @@
 # ssl-proxy-params.conf
 
 proxy_redirect off;
-proxy_set_header Host $host;
+proxy_set_header Host $http_host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
Nginx is acting as a reverse proxy. There it needs to take care to set/change some headers during the communication. I ran into an issue with `LNbits` that the port was stripped (while using IP2Tor). Changing the setting to use the `$http_host` should include both the `hostname` and the `port` from the initial request: https://stackoverflow.com/questions/15414810/whats-the-difference-of-host-and-http-host-in-nginx

This should not break any of the apps when using the Nginx port (either with or without Tor).

As mentioned in: https://github.com/rootzoll/raspiblitz/issues/1258#issuecomment-657225926

