### PR TITLE
Update internet.hiddenservice.sh

### DIFF
--- a/home.admin/config.scripts/internet.hiddenservice.sh
+++ b/home.admin/config.scripts/internet.hiddenservice.sh
@@ -76,8 +76,9 @@ if [ "${runBehindTor}" = "on" ]; then
 HiddenServiceDir /mnt/hdd/tor/$service
 HiddenServiceVersion 3
 HiddenServicePort $toPort 127.0.0.1:$fromPort" | sudo tee -a /etc/tor/torrc
+
   # remove double lines  
-  sudo awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' /etc/tor/torrc > /mnt/hdd/temp/tmp && sudo mv /mnt/hdd/temp/tmp /etc/tor/torrc
+  awk 'NF > 0 {blank=0} NF == 0 {blank++} blank < 2' /etc/tor/torrc | sudo tee /mnt/hdd/temp/tmp >/dev/null && sudo mv /mnt/hdd/temp/tmp /etc/tor/torrc
 
   # check and insert second port pair
   if [ ${#toPort2} -gt 0 ]; then


### PR DESCRIPTION
@openoms can you check this.

I am getting this on a restore:

```
...
# Hidden Service for lnbits
HiddenServiceDir /mnt/hdd/tor/lnbits
HiddenServiceVersion 3
HiddenServicePort 80 127.0.0.1:5002
/home/admin/config.scripts/internet.hiddenservice.sh: line 80: /mnt/hdd/temp/tmp: Permission denied
HiddenServicePort 443 127.0.0.1:5003
...
```

My PR fixes the error case... but I have to admit that I don't understand what the line does. Can you check it's doin what it's supposed to?