### PR TITLE
Surpress error while deleting old backups

### DIFF
--- a/home.admin/config.scripts/blitz.migration.sh
+++ b/home.admin/config.scripts/blitz.migration.sh
@@ -76,7 +76,7 @@ if [ "$1" = "export" ]; then
   fi
 
   # clean old backups from temp
-  rm /hdd/temp/raspiblitz-*.tar.gz 2>/dev/null
+  rm -f /hdd/temp/raspiblitz-*.tar.gz 2>/dev/null
 
   # get date stamp
   datestamp=$(date "+%y-%m-%d-%H-%M")


### PR DESCRIPTION
Added the -f option to the rm of old backups, as the resulting error message "No such file or directory" (if no files were deleted) might be confusing to others and seen as a problem.