### PR TITLE
skip pause when status is called

### DIFF
--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -100,7 +100,8 @@ function torthistx() {
 # command: status
 # start the status screen in the terminal
 function status() {
-  sudo -u pi /home/admin/00infoLCD.sh
+  echo "Gathering data - please wait a moment..."
+  sudo -u pi /home/admin/00infoLCD.sh --pause 0
 }
 
 # command: balance


### PR DESCRIPTION
The wait screen doesn't make sense when `$ status` is called.