### PR TITLE
add gettx and watchtx command

### DIFF
--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -170,3 +170,15 @@ function watchtx() {
 
     done
 }
+
+# command: notifyme
+# A wrapper for blitz.notify.sh that will send a notification using the configured 
+# method and settings. 
+# This makes sense when waiting for commands to finish and then sending a notification.
+# $ notifyme "Hello there..!"
+# $ ./run_job_which_takes_long.sh && notifyme "I'm done."
+# $ ./run_job_which_takes_long.sh && notifyme "success" || notifyme "fail"
+function notifyme() {
+    content="${1:-Notified}"
+    /home/admin/config.scripts/blitz.notify.sh send "${content}"
+}

--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -133,7 +133,7 @@ function gettx() {
     if result=$(bitcoin-cli getrawtransaction "${tx_id}" 1 2>/dev/null); then
         echo "${result}"
     else
-        echo "{\"error\": \"unable to find TX\", \"tx_hash\": \"${tx_id}\"}"
+        echo "{\"error\": \"unable to find TX\", \"tx_id\": \"${tx_id}\"}"
         return 1
     fi
 }

--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -155,7 +155,7 @@ function watchthistx() {
         confirmations=$(echo "${result}" | jq .confirmations)
 
         if [[ "${confirmations}" -ge "${wait_n_confirmations}" ]]; then
-          printf "confirmations: ${confirmations} -target reached!\n"
+          printf "confirmations: ${confirmations} - target reached!\n"
           return 0
         else
           printf "confirmations: ${confirmations} - "

--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -125,25 +125,25 @@ function jmarket() {
   fi
 }
 
-# command: getthistx
+# command: gettx
 # retrieve transaction from mempool or blockchain and print as JSON
-# $ getthistx "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16"
-function getthistx() {
-    tx_hash="${1:-f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16}"
-    if result=$(bitcoin-cli getrawtransaction "${tx_hash}" 1 2>/dev/null); then
+# $ gettx "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16"
+function gettx() {
+    tx_id="${1:-f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16}"
+    if result=$(bitcoin-cli getrawtransaction "${tx_id}" 1 2>/dev/null); then
         echo "${result}"
     else
-        echo "{\"error\": \"unable to find TX\", \"tx_hash\": \"${tx_hash}\"}"
+        echo "{\"error\": \"unable to find TX\", \"tx_hash\": \"${tx_id}\"}"
         return 1
     fi
 }
 
-# command: watchthistx
+# command: watchtx
 # try to retrieve transaction from mempool or blockchain until certain confirmation target
-# is reached and then exit cleanly.
-# $ watchthistx "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16" 6 30
-function watchthistx() {
-    tx_hash="${1}"
+# is reached and then exit cleanly. Default is to wait for 2 confs and to sleep for 60 secs. 
+# $ watchtx "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16" 6 30
+function watchtx() {
+    tx_id="${1}"
     wait_n_confirmations="${2:-2}"
     sleep_time="${3:-60}"
 
@@ -151,7 +151,7 @@ function watchthistx() {
 
     while true; do
 
-      if result=$(bitcoin-cli getrawtransaction "${tx_hash}" 1 2>/dev/null); then
+      if result=$(bitcoin-cli getrawtransaction "${tx_id}" 1 2>/dev/null); then
         confirmations=$(echo "${result}" | jq .confirmations)
 
         if [[ "${confirmations}" -ge "${wait_n_confirmations}" ]]; then


### PR DESCRIPTION
What to you think about this?

I especially like this in combination with `tmux` and blitz notify:

```
watchthistx "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16" && ~/config.scripts/blitz.notify.sh send "TX confirmed."
```

Unless `txindex=on` the RPC `getrawtransaction` can not find all transactions. But the main idea here is to see when a mempool TX is confirmed so this use case should work all the time.