### PR TITLE
use alias for tmux status bar

### DIFF
--- a/home.admin/_tmux_alias.sh
+++ b/home.admin/_tmux_alias.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# script for custom tmux status bar
+
+configFile="/mnt/hdd/raspiblitz.conf"
+
+if [ -f "$configFile" ]; then
+    source ${configFile} 2>/dev/null
+    echo "${hostname}"
+else
+    #echo "$configFile does not exist"
+    echo "unknown"
+fi

--- a/home.admin/assets/tmux.conf.local
+++ b/home.admin/assets/tmux.conf.local
@@ -180,7 +180,7 @@ tmux_conf_theme_right_separator_sub='|'
 #     - #{username}
 #     - #{username_ssh}
 tmux_conf_theme_status_left=' ❐ #S | ↑#{?uptime_y, #{uptime_y}y,}#{?uptime_d, #{uptime_d}d,}#{?uptime_h, #{uptime_h}h,}#{?uptime_m, #{uptime_m}m,} '
-tmux_conf_theme_status_right='#{prefix}#{pairing}#{synchronized} #{?battery_status, #{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #{hostname} |#[bg=brightblue]#[fg=yellow]#(~/_tmux_network.sh)|#[bg=yellow]#[fg=brightblue]#(~/_tmux_chain.sh)'
+tmux_conf_theme_status_right='#{prefix}#{pairing}#{synchronized} #{?battery_status, #{battery_status},}#{?battery_bar, #{battery_bar},}#{?battery_percentage, #{battery_percentage},} , %R , %d %b | #{username}#{root} | #(~/_tmux_alias.sh) |#[bg=brightblue]#[fg=yellow]#(~/_tmux_network.sh)|#[bg=yellow]#[fg=brightblue]#(~/_tmux_chain.sh)'
 
 # status left style
 tmux_conf_theme_status_left_fg='#000000,#e4e4e4,#e4e4e4'  # black, white , white


### PR DESCRIPTION
This makes sense when the hostname is left as `raspberrypi`. Using alias in tmux status bar will then help you to see on which host you are working on.