### PR TITLE
Remove vlc from default build

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -159,7 +159,7 @@ if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "dietpi" ] ; then
 fi
 
 # remove some (big) packages that are not needed
-sudo apt remove -y --purge libreoffice* oracle-java* chromium-browser nuscratch scratch sonic-pi minecraft-pi plymouth python2
+sudo apt remove -y --purge libreoffice* oracle-java* chromium-browser nuscratch scratch sonic-pi minecraft-pi plymouth python2 vlc
 sudo apt clean
 sudo apt -y autoremove
 


### PR DESCRIPTION
Remove VLC from default build - this should also due to the remove that runs after remove the dependencies.

This should reduce the image size  (230kb directly and 67MB in supporting packages)
Reduce any security attack vector


The following packages will be REMOVED:
  liba52-0.7.4 libarchive13 libaribb24-0 libbasicusageenvironment1 libbluetooth3 libcddb2 libdav1d3 libdvbpsi10 libebml4v5 libgroupsock8 libixml10 liblirc-client0 liblivemedia64 liblua5.2-0 libmatroska6v5 libmpeg2-4 libnfs12 libopenmpt-modplug1 libplacebo7 libprotobuf-lite17 libproxy-tools libqt5x11extras5
  libresid-builder0c2a libsidplay2 libspatialaudio0 libspeexdsp1 libupnp13 libusageenvironment3 libvlc-bin libvlc5 libvlccore9 libxcb-xv0 vlc-bin vlc-data vlc-l10n vlc-plugin-base vlc-plugin-notify vlc-plugin-qt vlc-plugin-skins2 vlc-plugin-video-output vlc-plugin-video-splitter vlc-plugin-visualization
0 upgraded, 0 newly installed, 42 to remove and 5 not upgraded.
After this operation, 67.0 MB disk space will be freed.

