### PR TITLE
use 'ip route get' over 'ip addr' for interface check

### DIFF
--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -85,7 +85,7 @@ else
 fi
 
 # get name of active interface (eth0 or wlan0)
-network_active_if=$(ip addr | grep -v "lo:" | grep 'state UP' | tr -d " " | cut -d ":" -f2 | head -n 1)
+network_active_if=$(ip route get 255.255.255.255 | awk -- '{print $5}')
 
 # get network traffic
 # ifconfig does not show eth0 on Armbian or in a VM - get first traffic info

--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -85,7 +85,7 @@ else
 fi
 
 # get name of active interface (eth0 or wlan0)
-network_active_if=$(ip route get 255.255.255.255 | awk -- '{print $5}')
+network_active_if=$(ip route get 255.255.255.255 | awk -- '{print $4}')
 
 # get network traffic
 # ifconfig does not show eth0 on Armbian or in a VM - get first traffic info

--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -85,7 +85,7 @@ else
 fi
 
 # get name of active interface (eth0 or wlan0)
-network_active_if=$(ip route get 255.255.255.255 | awk -- '{print $4}')
+network_active_if=$(ip route get 255.255.255.255 | awk -- '{print $4}' | head -n 1)
 
 # get network traffic
 # ifconfig does not show eth0 on Armbian or in a VM - get first traffic info


### PR DESCRIPTION
should be a more generic, more safe and faster solution without any port forwarding or firewall dependencies. Will support virtual and tunneled network interfaces (tun0 for OpenVPN)