### PR TITLE
Fix: "service is not running" error upon boot

### DIFF
--- a/home.admin/80scanLND.sh
+++ b/home.admin/80scanLND.sh
@@ -63,9 +63,11 @@ if [ ${bitcoinActive} -eq 0 ] || [ ${#bitcoinErrorFull} -gt 0 ] || [ "${1}" == "
   else
 
     # output when user login in as admin and bitcoind is not running
-
-    if [ ${uptime} -gt 600 ] || [ ${#bitcoinErrorFull} -gt 0 ] || [ "${bitcoinErrorShort}" == "Error found in Logs" ] || [ "${1}" == "blockchain-error" ]; then
-
+    if [ ${uptime} -lt 600 ]; then
+      infoStr=" The ${network}d service is starting:\n ${bitcoinErrorShort}\n Please wait at least 10min ..."
+    elif [[ "${bitcoinErrorFull}" == *"error code: -28"* ]]; then
+      infoStr=" The ${network}d service is warming up:\n ${bitcoinErrorShort}\n Please wait ..."
+    elif [ ${#bitcoinErrorFull} -gt 0 ] || [ "${bitcoinErrorShort}" == "Error found in Logs" ] || [ "${1}" == "blockchain-error" ]; then
       clear
       echo ""
       echo "*****************************************"
@@ -95,9 +97,6 @@ if [ ${bitcoinActive} -eq 0 ] || [ ${#bitcoinErrorFull} -gt 0 ] || [ "${1}" == "
       echo "-> Have you tried to turn it off and on again? Use command 'restart'"
       echo ""
       exit 1
-
-    else
-      infoStr=" The ${network}d service is starting:\n ${bitcoinErrorShort}\n Please wait up to 10min ..."
     fi
 
   fi
@@ -114,7 +113,7 @@ elif [ ${lndActive} -eq 0 ] || [ ${#lndErrorFull} -gt 0 ] || [ "${1}" == "lightn
   title="Lightning Info"
   if [ ${uptime} -gt 600 ] || [ "${1}" == "lightning-error" ]; then
     if [ ${#lndErrorShort} -gt 0 ]; then
-       height=6
+      height=6
       lndErrorShort=" ${lndErrorShort}\n"
     fi
     if [ ${lndActive} -eq 0 ]; then
@@ -215,7 +214,6 @@ else
   else
     syncProgress="${syncProgress} %"
   fi
-
 
   # formatting LIGHTNING SCAN PROGRESS  
   if [ ${#scanProgress} -eq 0 ]; then


### PR DESCRIPTION
As mentioned in https://github.com/rootzoll/raspiblitz/issues/1467 and https://github.com/rootzoll/raspiblitz/issues/1466 there's an issue regarding a falsely reported error (service is not running) upon boot if the bitcoind service hasn't finished warming up within 10min. This PR fixes that problem by checking if the variable `bitcoinErrorFull` contains the `error code: -28`, after the 10min threshold has been surpassed.

This has been tested on two devices (Pi4/P3) several times now. In fact it is now possible to lower the 10min uptime check: https://github.com/rootzoll/raspiblitz/blob/80de4054c66e4083055a1f7148eda4b7e831c8db/home.admin/80scanLND.sh#L66 In my experience there shouldn't be a problem halving (yay another one) it down to 5min.