### PR TITLE
Add vagrant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ home.admin/.DS_Store
 __pycache__
 rpc_pb2.pyc
 rpc_pb2_grpc.pyc
+/.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# in order to attach a secondary disk we need to enable vagrant disk experimental feature
+if ENV['VAGRANT_EXPERIMENTAL'] != 'disks'
+  ENV['VAGRANT_EXPERIMENTAL'] = 'disks'
+end
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'raspiblitz'
+
+  config.ssh.username = 'admin'
+  config.ssh.password = 'raspiblitz'
+  config.ssh.insert_key = true
+
+  config.vm.disk :disk, size: '16GB', primary: true
+  config.vm.disk :disk, size: '500GB', name: 'external_disk'
+
+  config.vm.provision 'shell',
+                      privileged: false,
+                      path: 'alternative.platforms/amd64/packer/scripts/init_vagrant.sh'
+end

--- a/alternative.platforms/amd64/README.md
+++ b/alternative.platforms/amd64/README.md
@@ -1,0 +1,26 @@
+# ⚡️ RaspiBlitz-on-amd64 ⚡️
+
+This guide was tested on vagrant
+
+---
+
+This feature is very experimental and not supported.
+
+In order to run raspiblitz on `vagrant` you need `packer` to build the base box.
+
+```sha
+cd alternative.platforms/amd64/packer
+packer build raspiblitz.json
+
+vagrant box add --force raspiblitz output/raspiblitz.box
+cd ../../..
+```
+
+With the base box built, you can start a development environment with `vagrant up` and login with `vagrant ssh**.
+
+
+**Note**
+
+Every file in `home.admin` will be linked to `/home/admin` inside the VM,
+if you add a new file you should run `vagrant provision` to make sure it gets linked inside the VM.
+

--- a/alternative.platforms/amd64/packer/http/preseed.cfg
+++ b/alternative.platforms/amd64/packer/http/preseed.cfg
@@ -1,0 +1,107 @@
+# To see all available options execute this command once the install is done:
+# sudo less /var/log/installer/cdebconf/questions.dat
+# If you need information about an option use the command below (example for keymap):
+# grep -A 4 "keyboard-configuration/xkb-keymap" /var/log/installer/cdebconf/templates.dat
+
+# Use network mirror for package installation
+# d-i apt-setup/use_mirror boolean true
+
+# Automatic installation
+d-i auto-install/enable boolean true
+
+# "linux-server" is substituted by "linux-image-amd64"
+# Possible options : "linux-image-amd64"(default) or "linux-image-rt-amd64"
+d-i base-installer/kernel/override-image string linux-server
+
+# Configure hardware clock
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+
+# d-i console-setup/ask_detect boolean false
+
+# d-i debconf/frontend select noninteractive
+
+# Set OS locale
+d-i debian-installer/language string en
+d-i debian-installer/country string US
+d-i debian-installer/locale string en_US.UTF-8
+
+# d-i debian-installer/framebuffer boolean false
+
+# Reboot once the install is done
+d-i finish-install/reboot_in_progress note
+
+# Bootloader options
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i grub-installer/bootdev string /dev/sda
+
+# Set the keyboard layout
+d-i keyboard-configuration/xkb-keymap select us
+
+# Mirror from which packages will be downloaded
+d-i mirror/country string manual
+d-i mirror/http/directory string /debian
+d-i mirror/http/hostname string httpredir.debian.org
+
+# Configure http proxy if needed "http://[[user][:pass]@]host[:port]/"
+d-i mirror/http/proxy string
+
+# Set the hostname and DNS suffix
+d-i netcfg/get_hostname string debian-packer
+d-i netcfg/get_domain string localdomain
+
+# Disk configuration
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string regular
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+
+# User configuration
+d-i passwd/root-login boolean true
+d-i passwd/root-password-again password packer
+d-i passwd/root-password password packer
+# Create vagrant user account.
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/allow-password-weak boolean true
+d-i passwd/user-default-groups vagrant sudo
+d-i passwd/user-uid string 900
+
+# Extra packages to be installed
+d-i pkgsel/include string sudo
+
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+
+# Whether to upgrade packages after debootstrap
+d-i pkgsel/upgrade select full-upgrade
+
+# Set timezone
+d-i time/zone string UTC
+
+# Allow weak user password
+d-i user-setup/allow-password-weak boolean true
+
+# Home folder encryption
+d-i user-setup/encrypt-home boolean false
+
+# Do not scan additional CDs
+apt-cdrom-setup apt-setup/cdrom/set-first boolean false
+
+# Use network mirror
+apt-mirror-setup apt-setup/use_mirror boolean true
+
+# Disable polularity contest
+popularity-contest popularity-contest/participate boolean false
+
+# Select base install
+tasksel tasksel/first multiselect standard, ssh-server
+
+# Setup passwordless sudo for packer user
+# d-i preseed/late_command string \
+#   echo "packer ALL=(ALL:ALL) NOPASSWD:ALL" > /target/etc/sudoers.d/packer && chmod 0440 /target/etc/sudoers.d/packer

--- a/alternative.platforms/amd64/packer/raspiblitz.json
+++ b/alternative.platforms/amd64/packer/raspiblitz.json
@@ -1,0 +1,58 @@
+{
+  "variables": {
+      "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-10.5.0-amd64-netinst.iso",
+      "iso_checksum_type": "sha256",
+      "iso_checksum": "93863e17ac24eeaa347dfb91dddac654f214c189e0379d7c28664a306e0301e7"
+    },
+    "builders": [
+      {
+        "type": "virtualbox-iso",
+        "boot_command": [
+          "<esc><wait>",
+          "auto ",
+          "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+          "<enter>"
+        ],
+        "boot_wait": "5s",
+        "disk_size": "16384",
+        "headless": false,
+        "guest_os_type": "Debian_64",
+        "http_directory": "http",
+        "iso_checksum_type": "{{ user `iso_checksum_type` }}",
+        "iso_checksum": "{{ user `iso_checksum` }}",
+        "iso_url": "{{ user `iso_url` }}",
+        "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_username": "vagrant",
+        "ssh_timeout": "30m",
+        "vm_name": "raspiblitz-amd64",
+        "vboxmanage": [
+          ["modifyvm", "{{.Name}}", "--memory", "1024"],
+          ["modifyvm", "{{.Name}}", "--cpus", "1"]
+        ]
+      }
+  ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "script": "scripts/init.sh",
+            "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+        },
+        {
+            "type": "shell",
+            "script": "../../../build_sdcard.sh",
+            "execute_command": "echo 'yes' | {{.Vars}} bash '{{.Path}}' adevoss-more-datadrive-options-ext4 adevoss /dev/sda1 false false"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/cleanup.sh",
+            "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+        }
+  ],
+  "post-processors": [{
+      "type": "vagrant",
+      "compression_level": "8",
+      "output": "output/raspiblitz.box"
+  }]
+}

--- a/alternative.platforms/amd64/packer/scripts/cleanup.sh
+++ b/alternative.platforms/amd64/packer/scripts/cleanup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+# Apt cleanup.
+apt autoremove
+apt update
+
+# Delete unneeded files.
+rm -f /home/vagrant/*.sh
+rm /home/vagrant/VBoxGuestAdditions.iso
+
+# Zero out the rest of the free space using dd, then delete the written file.
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY
+
+# Add `sync` so Packer doesn't quit too early, before the large file is deleted.
+sync

--- a/alternative.platforms/amd64/packer/scripts/init.sh
+++ b/alternative.platforms/amd64/packer/scripts/init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eux
+
+# Add vagrant user to sudoers.
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+# Disable daily apt unattended updates.
+echo 'APT::Periodic::Enable "0";' >> /etc/apt/apt.conf.d/10periodic
+
+apt update
+apt upgrade -y
+
+apt install -y dkms make linux-headers-amd64 parted
+mkdir -p /mnt/vbox/
+mount  /home/vagrant/VBoxGuestAdditions.iso /mnt/vbox
+/mnt/vbox/VBoxLinuxAdditions.run --nox11
+
+mkdir -p /home/vagrant/.ssh
+chmod 0700 /home/vagrant/.ssh
+wget --no-check-certificate \
+     https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub \
+     -O /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+

--- a/alternative.platforms/amd64/packer/scripts/init_vagrant.sh
+++ b/alternative.platforms/amd64/packer/scripts/init_vagrant.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+echo "************* Vagrant provisioning ********************"
+
+
+if ! [ -e /dev/sdb1 ]; then
+    echo 'Data drive partitioning'
+
+    echo 'type=83' | sudo sfdisk /dev/sdb
+fi
+
+
+echo 'linking development files'
+source_dir=/vagrant/home.admin
+dest_dir=$HOME
+
+cd $source_dir
+for f in *; do
+    source_file="$source_dir/$f"
+    dest_file="$dest_dir/$f"
+
+    if [ -L $dest_file ] && [ "$(readlink "$dest_file")" = "$source_file" ]; then
+            continue
+    fi
+
+    rm -rf "$dest_file"
+    ln -s "$source_file" "$dest_file"
+done


### PR DESCRIPTION
This will allow building a raspiblitz base image with packer and spin up
a development environment in a VM.

This is designed to work on top of https://github.com/rootzoll/raspiblitz/pull/1297