### PR TITLE
Checkout a PR thru PATCH-MENU

### DIFF
--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -125,7 +125,8 @@ patch()
   # Patch Options
   OPTIONS=(PATCH "Patch/Sync RaspiBlitz with GitHub Repo" \
            REPO "Change GitHub Repo to sync with" \
-           BRANCH "Change GitHub Branch to sync with"
+           BRANCH "Change GitHub Branch to sync with" \
+           PR "Checkout a PullRequest to test"
 	)
 
   CHOICE=$(whiptail --clear --title "GitHub-User: ${activeGitHubUser} Branch: ${activeBranch}" --menu "" 10 55 3 "${OPTIONS[@]}" 2>&1 >/dev/tty)
@@ -183,6 +184,23 @@ patch()
         fi
       fi
       patch
+      exit 1
+      ;;
+    PR)
+      clear
+      echo "..."
+      pullRequestID=$(whiptail --inputbox "\nPlease enter the NUMBER of the PullRequest on RaspiBlitz Repo '${activeGitHubUser}'?" 10 38 --title "Checkout PullRequest ID" 3>&1 1>&2 2>&3)
+      exitstatus=$?
+      if [ $exitstatus = 0 ]; then
+        pullRequestID=$(echo "${pullRequestID}" | cut -d " " -f1)
+        echo "--> " $pullRequestID
+        git fetch origin pull/${pullRequestID}/head:${pullRequestID}pr
+        error=""
+        source <(sudo -u admin /home/admin/XXsyncScripts.sh ${pullRequestID}pr)
+        if [ ${#error} -gt 0 ]; then
+          whiptail --title "ERROR" --msgbox "${error}" 8 30
+        fi
+      fi
       exit 1
       ;;
   esac

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -129,7 +129,7 @@ patch()
            PR "Checkout a PullRequest to test"
 	)
 
-  CHOICE=$(whiptail --clear --title "GitHub-User: ${activeGitHubUser} Branch: ${activeBranch}" --menu "" 10 55 3 "${OPTIONS[@]}" 2>&1 >/dev/tty)
+  CHOICE=$(whiptail --clear --title "GitHub-User: ${activeGitHubUser} Branch: ${activeBranch}" --menu "" 11 55 4 "${OPTIONS[@]}" 2>&1 >/dev/tty)
 
   clear
   case $CHOICE in
@@ -189,7 +189,7 @@ patch()
     PR)
       clear
       echo "..."
-      pullRequestID=$(whiptail --inputbox "\nPlease enter the NUMBER of the PullRequest on RaspiBlitz Repo '${activeGitHubUser}'?" 10 38 --title "Checkout PullRequest ID" 3>&1 1>&2 2>&3)
+      pullRequestID=$(whiptail --inputbox "\nPlease enter the NUMBER of the PullRequest on RaspiBlitz Repo '${activeGitHubUser}'?" 10 46 --title "Checkout PullRequest ID" 3>&1 1>&2 2>&3)
       exitstatus=$?
       if [ $exitstatus = 0 ]; then
         pullRequestID=$(echo "${pullRequestID}" | cut -d " " -f1)

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -194,6 +194,7 @@ patch()
       if [ $exitstatus = 0 ]; then
         pullRequestID=$(echo "${pullRequestID}" | cut -d " " -f1)
         echo "--> " $pullRequestID
+        cd /home/admin/raspiblitz
         git fetch origin pull/${pullRequestID}/head:${pullRequestID}pr
         error=""
         source <(sudo -u admin /home/admin/XXsyncScripts.sh ${pullRequestID}pr)

--- a/home.admin/XXsyncScripts.sh
+++ b/home.admin/XXsyncScripts.sh
@@ -94,6 +94,7 @@ if [ ${#wantedBranch} -gt 0 ]; then
     localBranch=$(git branch | grep -c "${wantedBranch}")
     if [ ${localBranch} -eq 0 ]; then
       echo "# checkout/changing branch .."
+      git fetch
       git checkout -b ${wantedBranch} origin/${wantedBranch}
     else
       echo "# changing branch .."

--- a/home.admin/XXsyncScripts.sh
+++ b/home.admin/XXsyncScripts.sh
@@ -83,16 +83,15 @@ if [ ${#wantedBranch} -gt 0 ]; then
     echo "# OK"
   else
 
-    echo "# checking branch exists .."
-    branchExists=$(curl -s https://api.github.com/repos/${activeGitHubUser}/raspiblitz/branches/${wantedBranch} | jq -r '.name' | grep -c ${wantedBranch})
-    if [ ${branchExists} -eq 0 ]; then
-      echo "error='branch not found'"
-      exit 1
-    fi
-
     echo "# checking if branch is locally available"
     localBranch=$(git branch | grep -c "${wantedBranch}")
     if [ ${localBranch} -eq 0 ]; then
+      echo "# checking branch exists .."
+      branchExists=$(curl -s https://api.github.com/repos/${activeGitHubUser}/raspiblitz/branches/${wantedBranch} | jq -r '.name' | grep -c ${wantedBranch})
+      if [ ${branchExists} -eq 0 ]; then
+        echo "error='branch not found'"
+        exit 1
+      fi
       echo "# checkout/changing branch .."
       git fetch
       git checkout -b ${wantedBranch} origin/${wantedBranch}


### PR DESCRIPTION
To make it easier to test pending PRs on RaspiBlitz this adds a menu item `PR Checkout RullRequest` to the PatchMenu. The. the user just enters the number of the PR and it gets checkout as a local branch for the user to test. 