### PR TITLE
Fix NGINX BTCPay websocket Notifications requests 

### DIFF
--- a/home.admin/assets/nginx/sites-available/btcpay_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_ssl.conf
@@ -14,6 +14,12 @@ server {
     location / {
         proxy_pass http://127.0.0.1:23000;
 
+
+        # For websockets
+        proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection $http_connection;
+
+
         include /etc/nginx/snippets/ssl-proxy-params.conf;
     }
 

--- a/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
@@ -14,6 +14,11 @@ server {
     location / {
         proxy_pass http://127.0.0.1:23000;
 
+	# For websockets
+        proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection $http_connection;
+
+
         include /etc/nginx/snippets/ssl-proxy-params.conf;
     }
 


### PR DESCRIPTION
Fix also BTCPayServer Vault request (Working only on clearnet).

- Open Tor browser or Clearnet browser debug tools, go to your Btcayserver website, you will see websockets requests failing .../Notifications/SubscribeUpdates
- Open Clearnet browser debug tools and try to use BTCPayServer Vault,connecting your hardware wallet xpub with btcpay, it will fail.

This patch fixes both issues.

_Issue resolved with the help of Google and @sbrudenell in https://github.com/dotnet/aspnetcore/issues/17081#issuecomment-553741407_