### PR TITLE
Run tor with the default user

### DIFF
--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -184,7 +184,7 @@ case $CHOICE in
             fi
             ;;
         TOR)
-            sudo -u bitcoin nyx
+            sudo -u debian-tor nyx
             ;;
         SCREEN)
             dialog --title 'Touchscreen Calibration' --msgbox 'Choose OK and then follow the instructions on touchscreen for calibration.\n\nBest is to use a stylus for accurate touchscreen interaction.' 9 48

--- a/home.admin/config.scripts/blitz.setpassword.sh
+++ b/home.admin/config.scripts/blitz.setpassword.sh
@@ -293,6 +293,21 @@ EOF
     sed -i "s/^masterPassword:.*/masterPassword: '${newPassword}'/g" /mnt/hdd/app-data/thunderhub/thubConfig.yaml
   fi
 
+  # Tor
+  if [ "${runBehindTor}" == "on" ]; then
+      echo "# changing the password for Tor"
+
+      hashedPassword=$(tor --hash-password "${newPassword}")
+      sed -i "s/^HashedControlPassword .*/HashedControlPassword ${hashedPassword}/g" /etc/tor/torrc 2>/dev/null
+      sed -i "s/^password .*/password ${newPassword}/g" /home/bitcoin/.nyx/config 2>/dev/null
+
+      sed -i "s/^torpassword=.*/torpassword=${newPassword}/g" /mnt/hdd/${network}/${network}.conf 2>/dev/null
+      sed -i "s/^torpassword=.*/torpassword=${newPassword}/g" /home/admin/.${network}/${network}.conf 2>/dev/null
+
+      sed -i "s/^tor.password=.*/tor.password=${newPassword}/g" /mnt/hdd/lnd/lnd.conf 2>/dev/null
+      sed -i "s/^tor.password=.*/tor.password=${newPassword}/g" /home/admin/.lnd/lnd.conf 2>/dev/null
+  fi
+
   echo "# OK -> RPC Password B changed"
   echo "# Reboot is needed"
   exit 0

--- a/home.admin/config.scripts/blitz.setpassword.sh
+++ b/home.admin/config.scripts/blitz.setpassword.sh
@@ -297,9 +297,8 @@ EOF
   if [ "${runBehindTor}" == "on" ]; then
       echo "# changing the password for Tor"
 
-      hashedPassword=$(tor --hash-password "${newPassword}")
+      hashedPassword=$(sudo -u debian-tor tor --hash-password "${newPassword}")
       sed -i "s/^HashedControlPassword .*/HashedControlPassword ${hashedPassword}/g" /etc/tor/torrc 2>/dev/null
-      sed -i "s/^password .*/password ${newPassword}/g" /home/bitcoin/.nyx/config 2>/dev/null
 
       sed -i "s/^torpassword=.*/torpassword=${newPassword}/g" /mnt/hdd/${network}/${network}.conf 2>/dev/null
       sed -i "s/^torpassword=.*/torpassword=${newPassword}/g" /home/admin/.${network}/${network}.conf 2>/dev/null

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -402,9 +402,8 @@ EOF
   fi
 
   echo "Setup logrotate"
-  if ! grep -Eq "^/mnt/hdd/tor/" /etc/logrotate.d/tor; then
-    # add logrotate config for modified Tor dir on ext. disk
-    cat << EOF | sudo tee -a /etc/logrotate.d/tor >/dev/null
+  # add logrotate config for modified Tor dir on ext. disk
+  sudo tee /etc/logrotate.d/raspiblitz-tor >/dev/null <<EOF
 /mnt/hdd/tor/*log {
         daily
         rotate 5
@@ -412,7 +411,7 @@ EOF
         delaycompress
         missingok
         notifempty
-        create 0640 bitcoin bitcoin
+        create 0640 debian-tor debian-tor
         sharedscripts
         postrotate
                 if invoke-rc.d tor status > /dev/null; then
@@ -421,7 +420,8 @@ EOF
         endscript
 }
 EOF
-  fi
+
+  sudo systemctl restart tor@default
 
   echo "OK - TOR is now ON"
   echo "needs reboot to activate new setting"
@@ -451,6 +451,10 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
 
   sudo systemctl enable lnd
   echo "OK"
+  echo ""
+
+  echo "*** Stop TOR service ***"
+  sudo systemctl stop tor@default
   echo ""
 
   echo "needs reboot to activate new setting"

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -285,7 +285,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo chmod -R 700 /mnt/hdd/tor
     sudo chown -R debian-tor:debian-tor /mnt/hdd/tor
     PASSWORD_B=$(sudo cat /mnt/hdd/${network}/${network}.conf | grep rpcpassword | cut -c 13-)
-    HASHED_PASSWORD=$(tor --hash-password "$PASSWORD_B")
+    HASHED_PASSWORD=$(sudo -u debian-tor tor --hash-password "$PASSWORD_B")
 
     cat > ./torrc <<EOF
 ### See 'man tor', or https://www.torproject.org/docs/tor-manual.html
@@ -354,11 +354,6 @@ EOF
 [Service]
 ReadWriteDirectories=-/mnt/hdd/tor
 EOF
-
-    sudo -u bitcoin mkdir -p /home/bitcoin/.nyx
-    sudo -u bitcoin touch /home/bitcoin/.nyx/config
-    sudo -u bitcoin sed -i "s/^password .*//g" /home/bitcoin/.nyx/config
-    echo "password $PASSWORD_B" | sudo -u bitcoin tee -a /home/bitcoin/.nyx/config >/dev/null
 
   else
     echo "TOR package/service is installed and was prepared earlier .. just activating again"

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -115,11 +115,6 @@ activateBitcoinOverTOR()
       fi
       sudo chmod 444 /home/bitcoin/.${network}/${network}.conf
 
-      sudo -u bitcoin mkdir -p /home/bitcoin/.nyx
-      sudo -u bitcoin touch /home/bitcoin/.nyx/config
-      sudo -u bitcoin sed -i "s/^password .*//g" /home/bitcoin/.nyx/config
-      echo "password $PASSWORD_B" | sudo -u bitcoin tee -a /home/bitcoin/.nyx/config >/dev/null
-
       # copy new bitcoin.conf to admin user for cli access
       sudo cp /home/bitcoin/.${network}/${network}.conf /home/admin/.${network}/${network}.conf
       sudo chown admin:admin /home/admin/.${network}/${network}.conf
@@ -287,13 +282,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     #sudo rm -r -f /mnt/hdd/tor 2>/dev/null
     sudo mkdir -p /mnt/hdd/tor
     sudo mkdir -p /mnt/hdd/tor/sys
-    sudo mkdir -p /mnt/hdd/tor/web80
-    sudo mkdir -p /mnt/hdd/tor/lnd9735
-    sudo mkdir -p /mnt/hdd/tor/lndrpc9735
-    sudo mkdir -p /mnt/hdd/tor/lndrest8080
-    sudo mkdir -p /mnt/hdd/tor/lndrpc9735fallback
-    sudo mkdir -p /mnt/hdd/tor/lndrest8080fallback
-    sudo mkdir -p /mnt/hdd/tor/bitcoin8332
     sudo chmod -R 700 /mnt/hdd/tor
     sudo chown -R debian-tor:debian-tor /mnt/hdd/tor
     PASSWORD_B=$(sudo cat /mnt/hdd/${network}/${network}.conf | grep rpcpassword | cut -c 13-)
@@ -366,6 +354,11 @@ EOF
 [Service]
 ReadWriteDirectories=-/mnt/hdd/tor
 EOF
+
+    sudo -u bitcoin mkdir -p /home/bitcoin/.nyx
+    sudo -u bitcoin touch /home/bitcoin/.nyx/config
+    sudo -u bitcoin sed -i "s/^password .*//g" /home/bitcoin/.nyx/config
+    echo "password $PASSWORD_B" | sudo -u bitcoin tee -a /home/bitcoin/.nyx/config >/dev/null
 
   else
     echo "TOR package/service is installed and was prepared earlier .. just activating again"

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -362,6 +362,7 @@ EOF
 
     sudo mkdir -p /etc/systemd/system/tor@default.service.d
     sudo tee /etc/systemd/system/tor@default.service.d/raspiblitz.conf >/dev/null <<EOF
+    # DO NOT EDIT! This file is generate by raspiblitz and will be overwritten
 [Service]
 ReadWriteDirectories=-/mnt/hdd/tor
 EOF


### PR DESCRIPTION
This PR run tor as the default user and make use of hashed password for LND and bitcoind.

It fixes some of concerns in https://github.com/rootzoll/raspiblitz/issues/998