### PR TITLE
#560 back-restore wifi settings without reboot

### DIFF
--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -357,16 +357,8 @@ if [ ${isMounted} -eq 0 ]; then
   echo "Refreshing links between directories/drives .." >> $logFile
   sudo /home/admin/config.scripts/blitz.datadrive.sh link
 
-  # check if there is a WIFI configuration to restore
-  configWifiExists=$(sudo cat /etc/wpa_supplicant/wpa_supplicant.conf 2>/dev/null| grep -c "network=")
-  configWifiHDD=$(sudo cat /mnt/hdd/app-data/wpa_supplicant.conf 2>/dev/null| grep -c "network=")
-  if [ ${configWifiExists} -eq 0 ] && [ ${configWifiHDD} -eq 1 ]; then
-    echo "Restoring WIFI setting & rebooting .." >> $logFile
-    sudo cp /mnt/hdd/app-data/wpa_supplicant.conf /boot/wpa_supplicant.conf
-    sudo chmod 755 /boot/wpa_supplicant.conf
-    sudo reboot now
-    exit 0
-  fi
+  # check if there is a WIFI configuration to backup or restore
+  sudo /home/admin/config.scripts/internet.wifi.sh backup-restore
 
   # make sure at this point local network is connected
   wait_for_local_network

--- a/home.admin/config.scripts/internet.wifi.sh
+++ b/home.admin/config.scripts/internet.wifi.sh
@@ -99,7 +99,9 @@ elif [ "$1" == "backup-restore" ]; then
   elif [ -f /mnt/hdd/app-data/wpa_supplicant.conf ]; then
     # RESTORE backuped wifi settings from HDD to RaspiBlitz
     sudo cp /mnt/hdd/app-data/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
+    echo "# restoring old wifi settings ... wait 4 secounds to connect"
     sudo wpa_cli -i wlan0 reconfigure 1>/dev/null
+    sleep 4
     echo "wifiRestore=1"
     echo "wifiBackup=0"
     exit 0

--- a/home.admin/config.scripts/internet.wifi.sh
+++ b/home.admin/config.scripts/internet.wifi.sh
@@ -50,11 +50,11 @@ network={
 }"
   echo "${wifiConfig}" > "/home/admin/wpa_supplicant.conf"
   sudo chown root:root /home/admin/wpa_supplicant.conf
-  sudo mv /home/admin/wpa_supplicant.conf /boot/wpa_supplicant.conf
-  sudo chmod 755 /boot/wpa_supplicant.conf
+  sudo mv /home/admin/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
+  sudo chmod 755 /etc/wpa_supplicant/wpa_supplicant.conf
 
   # activate new wifi settings
-  sudo wpa_cli -i wlan0 reconfigure
+  sudo wpa_cli -i wlan0 reconfigure 1>/dev/null
   echo "# OK - changes should be actrive now - maybe reboot needed"
   exit 0
 
@@ -72,7 +72,7 @@ update_config=1"
 
 
   # activate new wifi settings
-  sudo wpa_cli -i wlan0 reconfigure
+  sudo wpa_cli -i wlan0 reconfigure 1>/dev/null
   echo "# OK - changes should be actrive now - maybe reboot needed"
   exit 0
 
@@ -99,7 +99,7 @@ elif [ "$1" == "backup-restore" ]; then
   elif [ -f /mnt/hdd/app-data/wpa_supplicant.conf ]; then
     # RESTORE backuped wifi settings from HDD to RaspiBlitz
     sudo cp /mnt/hdd/app-data/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
-    sudo wpa_cli -i wlan0 reconfigure
+    sudo wpa_cli -i wlan0 reconfigure 1>/dev/null
     echo "wifiRestore=1"
     echo "wifiBackup=0"
     exit 0

--- a/home.admin/config.scripts/internet.wifi.sh
+++ b/home.admin/config.scripts/internet.wifi.sh
@@ -6,6 +6,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  echo "# internet.wifi.sh status"
  echo "# internet.wifi.sh on SSID PASSWORD"
  echo "# internet.wifi.sh off"
+ echo "# internet.wifi.sh backup-restore"
  exit 1
 fi
 
@@ -52,7 +53,9 @@ network={
   sudo mv /home/admin/wpa_supplicant.conf /boot/wpa_supplicant.conf
   sudo chmod 755 /boot/wpa_supplicant.conf
 
-  echo "# OK - reboot needed to activate new WIFI settings - use command: restart"
+  # activate new wifi settings
+  sudo wpa_cli -i wlan0 reconfigure
+  echo "# OK - changes should be actrive now - maybe reboot needed"
   exit 0
 
 elif [ "$1" == "off" ]; then
@@ -67,8 +70,45 @@ update_config=1"
   sudo rm /boot/wpa_supplicant.conf 2>/dev/null
   sudo rm /mnt/hdd/app-data/wpa_supplicant.conf 2>/dev/null
 
-  echo "# OK - reboot needed to turn WIFI off - use command: restart"
+
+  # activate new wifi settings
+  sudo wpa_cli -i wlan0 reconfigure
+  echo "# OK - changes should be actrive now - maybe reboot needed"
   exit 0
+
+# https://github.com/rootzoll/raspiblitz/issues/560
+# when calling this it will backup wpa_supplicant.conf to HDD (if WIFI is active)
+# or when WIFI is inactive but a wpa_supplicant.conf exists restore this
+elif [ "$1" == "backup-restore" ]; then
+
+  # check if HDD already exists
+  if [ -d /mnt/hdd/app-data ]; then
+    echo "# running backup/restore wifi settings"
+  else
+    echo "error='no hdd'"
+    exit 1
+  fi
+
+  wifiBackUpExists=$()
+  if [ ${wifiIsSet} -eq 1 ]; then
+    # BACKUP latest wifi settings to HDD
+    sudo cp /etc/wpa_supplicant/wpa_supplicant.conf /mnt/hdd/app-data/wpa_supplicant.conf 
+    echo "wifiRestore=0"
+    echo "wifiBackup=1"
+    exit 0
+  elif [ -f /mnt/hdd/app-data/wpa_supplicant.conf ]
+    # RESTORE backuped wifi settings from HDD to RaspiBlitz
+    sudo cp /mnt/hdd/app-data/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
+    sudo wpa_cli -i wlan0 reconfigure
+    echo "wifiRestore=1"
+    echo "wifiBackup=0"
+    exit 0
+  else
+    # noting to backup or restore
+    echo "wifiRestore=0"
+    echo "wifiBackup=0"
+    exit 0
+  fi
 
 else
   echo "err='parameter not known - run with -help'"

--- a/home.admin/config.scripts/internet.wifi.sh
+++ b/home.admin/config.scripts/internet.wifi.sh
@@ -96,7 +96,7 @@ elif [ "$1" == "backup-restore" ]; then
     echo "wifiRestore=0"
     echo "wifiBackup=1"
     exit 0
-  elif [ -f /mnt/hdd/app-data/wpa_supplicant.conf ]
+  elif [ -f /mnt/hdd/app-data/wpa_supplicant.conf ]; then
     # RESTORE backuped wifi settings from HDD to RaspiBlitz
     sudo cp /mnt/hdd/app-data/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf
     sudo wpa_cli -i wlan0 reconfigure


### PR DESCRIPTION
moving backup-restore of wifi settings for updates into script `internet.wifi.sh` and removing the need for reboot while making the approch more universial for also other platforms