### PR TITLE
Fixing detection of HDD/SSD without partition 

### DIFF
--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -86,7 +86,7 @@ if [ "$1" = "status" ]; then
       # cut line info into different informations
       testname=$(echo $line | cut -d " " -f 1 | sed 's/[^a-z0-9]*//g')
       testdevice=$(echo $testname | sed 's/[^a-z]*//g')
-      testpartition=$(echo $testname | sed 's/[^a-z]*[^0-9]//g')
+      testpartition=$(echo $testname | grep -P '[a-z]{3,5}[0-9]{1}')
       testsize=$(echo $line | sed "s/  */ /g" | cut -d " " -f 2 | sed 's/[^0-9]*//g')
       echo "# line($line)"
       echo "# testname(${testname}) testdevice(${testdevice}) testpartition(${testpartition}) testsize(${testsize})"

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -80,7 +80,7 @@ if [ "$1" = "status" ]; then
 
     # find the HDD (biggest single partition)
     sizeDataPartition=0
-    lsblk -o NAME,SIZE -b | grep "[^|*][s|v]d[a-z][0-9]" > .lsblk.tmp
+    lsblk -o NAME,SIZE -b | grep "[s|v]d[a-z][0-9]?" > .lsblk.tmp
     while read line; do
       testdevice=$(echo $line | cut -d " " -f 1)
       testsize=$(echo $line | cut -d " " -f 2)

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -83,7 +83,7 @@ if [ "$1" = "status" ]; then
     lsblk -o NAME,SIZE -b | grep -P "[s|v]d[a-z][0-9]?" > .lsblk.tmp
     while read line; do
       testdevice=$(echo $line | cut -d " " -f 1)
-      testsize=$(echo $line | cut -d " " -f 2)
+      testsize=$(echo $line | sed "s/  */ /g" | cut -d " " -f 2)
       if [ ${testsize} -gt ${sizeDataPartition} ]; then
         sizeDataPartition=${testsize}
         hddDataPartition="${testdevice:2:4}"

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -80,7 +80,7 @@ if [ "$1" = "status" ]; then
 
     # find the HDD (biggest single partition)
     sizeDataPartition=0
-    lsblk -o NAME,SIZE -b | grep "[s|v]d[a-z][0-9]?" > .lsblk.tmp
+    lsblk -o NAME,SIZE -b | grep -P "[s|v]d[a-z][0-9]?" > .lsblk.tmp
     while read line; do
       testdevice=$(echo $line | cut -d " " -f 1)
       testsize=$(echo $line | cut -d " " -f 2)

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -83,23 +83,27 @@ if [ "$1" = "status" ]; then
     sizeDataPartition=0
     lsblk -o NAME,SIZE -b | grep -P "[s|v]d[a-z][0-9]?" > .lsblk.tmp
     while read line; do
+
       # cut line info into different informations
       testname=$(echo $line | cut -d " " -f 1 | sed 's/[^a-z0-9]*//g')
       testdevice=$(echo $testname | sed 's/[^a-z]*//g')
       testpartition=$(echo $testname | grep -P '[a-z]{3,5}[0-9]{1}')
       testsize=$(echo $line | sed "s/  */ /g" | cut -d " " -f 2 | sed 's/[^0-9]*//g')
-      echo "# line($line)"
-      echo "# testname(${testname}) testdevice(${testdevice}) testpartition(${testpartition}) testsize(${testsize})"
+      #echo "# line($line)"
+      #echo "# testname(${testname}) testdevice(${testdevice}) testpartition(${testpartition}) testsize(${testsize})"
+      
       # if no matching device found yet - take first for the beginning (just in case no partions at all)
       if [ ${#hdd} -eq 0 ]; then
         hdd="${testdevice}"
       fi
+      
       # if a partition was found - make sure to use the biggest
       if [ ${#testpartition} -gt 0 ] && [ ${testsize} -gt ${sizeDataPartition} ]; then
         sizeDataPartition=${testsize}
         hddDataPartition="${testpartition}"
         hdd="${testdevice}"
       fi
+      
     done < .lsblk.tmp
     rm -f .lsblk.tmp 1>/dev/null 2>/dev/null
     if [ ${#hddDataPartition} -lt 4 ]; then

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -144,7 +144,7 @@ if [ "$1" = "status" ]; then
         mountError=""
         sudo mkdir -p /mnt/hdd
         if [ "${hddFormat}" = "ext4" ]; then
-	  hddDataPartitionExt4=$hddDataPartition
+	        hddDataPartitionExt4=$hddDataPartition
           mountError=$(sudo mount /dev/${hddDataPartitionExt4} /mnt/hdd 2>&1)
           isTempMounted=$(df | grep /mnt/hdd | grep -c ${hddDataPartitionExt4})
         fi


### PR DESCRIPTION
fixing that after #1297 the `blitz.datadrive.sh` script was not detecting hdd/ssd without any partiotion anymore