### PR TITLE
 LCD: show JoinMarket stats if the Yield Generator is running 

### DIFF
--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -281,6 +281,22 @@ else
   fi
 fi
 
+if [ $JMstatsLCD = on ]; then
+  JMstats=$(mktemp 2>/dev/null)
+  sudo -u joinmarket /home/joinmarket/info.stats.sh > $JMstats
+  JMstatsL1=$(sed -n 1p < "$JMstats")
+  JMstatsL2=$(sed -n 2p < "$JMstats")
+  JMstatsL3=$(sed -n 3p < "$JMstats")
+  JMstatsL4=$(sed -n 4p < "$JMstats")
+  lastLine="\
+${color_gray}               ${color_gray}$JMstatsL1
+${color_gray}               ${color_gray}$JMstatsL2
+${color_gray}               ${color_gray}$JMstatsL3
+${color_gray}               ${color_gray}$JMstatsL4"
+else
+  lastLine="${color_yellow}${ln_publicColor}${ln_external}${color_gray}"
+fi
+
 sleep 5
 
 ## get uptime and current date & time
@@ -307,7 +323,7 @@ ${color_yellow}               ${color_gray}LND ${color_green}${ln_version} ${ln_
 ${color_yellow}               ${color_gray}${ln_channelInfo} ${ln_peersInfo}
 ${color_yellow}               ${color_gray}${ln_feeReport}
 ${color_yellow}
-${color_yellow}${ln_publicColor}${ln_external}${color_gray}
+$lastLine
 " \
 "RaspiBlitz v${codeVersion}" \
 "-------------------------------------------" \

--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -281,7 +281,9 @@ else
   fi
 fi
 
-if [ $JMstatsLCD = on ]; then
+# show JoinMarket stats in place of the LND URI only if the Yield Generator is running
+source /home/joinmarket/joinin.conf
+if [ $(sudo -u joinmarket pgrep -f "python yg-privacyenhanced.py $YGwallet --wallet-password-stdin" | wc -l) -gt 2 ]; then
   JMstats=$(mktemp 2>/dev/null)
   sudo -u joinmarket /home/joinmarket/info.stats.sh > $JMstats
   JMstatsL1=$(sed -n 1p < "$JMstats")

--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -283,7 +283,7 @@ fi
 
 # show JoinMarket stats in place of the LND URI only if the Yield Generator is running
 source /home/joinmarket/joinin.conf
-if [ $(sudo -u joinmarket pgrep -f "python yg-privacyenhanced.py $YGwallet --wallet-password-stdin" | wc -l) -gt 2 ]; then
+if [ $(sudo -u joinmarket pgrep -f "python yg-privacyenhanced.py $YGwallet --wallet-password-stdin" 2>/dev/null | wc -l) -gt 2 ]; then
   JMstats=$(mktemp 2>/dev/null)
   sudo -u joinmarket /home/joinmarket/info.stats.sh > $JMstats
   JMstatsL1=$(sed -n 1p < "$JMstats")

--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -125,7 +125,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo -u joinmarket git clone https://github.com/openoms/joininbox.git /home/joinmarket/joininbox
     # check the latest at:
     # https://github.com/openoms/joininbox/releases/
-    sudo -u joinmarket git reset --hard v0.1.6
+    sudo -u joinmarket git reset --hard v0.1.7
     sudo -u joinmarket cp /home/joinmarket/joininbox/scripts/* /home/joinmarket/
     sudo -u joinmarket cp /home/joinmarket/joininbox/scripts/.* /home/joinmarket/ 2>/dev/null
     sudo chmod +x /home/joinmarket/*.sh


### PR DESCRIPTION
* Updating joininBox to 0.1.7
* shows the JMstats only if JM installed and YG running. Otherwise display the LND URI as before.
Example (masked):
![image](https://user-images.githubusercontent.com/43343391/94695491-e4aeba80-032d-11eb-9dc5-25ff2934258b.png)
