### PR TITLE
add metric collection via telegraf as new bonus service (improved version)

### DIFF
--- a/home.admin/assets/telegraf/README.md
+++ b/home.admin/assets/telegraf/README.md
@@ -1,0 +1,34 @@
+[telegraf](https://www.influxdata.com/time-series-platform/telegraf/) is a metric collection tool by influxData.
+It is opensource and works fine with [influxDB](https://www.influxdata.com/products/influxdb-overview/) as the timeseries database and [Grafana](https://grafana.com/grafana/) as the graphics front end.
+
+You may take a look [here](https://github.com/gcgarner/IOTstack) for a nice dockerized installation of influxDB and Grafana on a raspberry pi.
+
+Make sure to have a telegraf section in your `/mnt/hdd/raspiblitz.conf`
+you have to manually edit them into `/mnt/hdd/raspiblitz.conf` before calling
+
+```
+/home/admin/config.scripts/bonus.telegraf.sh on
+```
+
+You have to provide a running influxDB / Grafana infrastructure elsewhere (reachable for the RaspiBlitz)
+
+# telegraf section for raspiblitz.conf
+All telegraf switches and configuration variables. You may copy & paste them into your RaspiBlitz configuration at `/mnt/hdd/raspiblitz.conf`, after editing and providing the proper values which match your environment
+
+```
+# all telegraf switches and configuration variables
+#
+# switch telegraf service and metrics capturing on/off
+telegrafMonitoring=on
+#
+# the full url to your influxDB data ingestion point, with port
+telegrafInfluxUrl='http://192.168.2.46:8086'
+#
+# the name of your influxDB database
+telegrafInfluxDatabase='raspiblitz'
+#
+# credentials for this database
+telegrafInfluxUsername='telegraf'
+telegrafInfluxPassword='metricsmetricsmetricsmetrics'
+
+```

--- a/home.admin/assets/telegraf/etc-telegraf/getraspiblitzipinfo.sh
+++ b/home.admin/assets/telegraf/etc-telegraf/getraspiblitzipinfo.sh
@@ -227,9 +227,14 @@ for i in $( seq 0 4 ); do
     ipaddr_online=$(( ${unixTimestamp} - ${creation_ts_curr[ $i ]}))
     #
     # create influx-line-format output
-    influxLine="raspiblitz_ip_info,origin=${origin[ $i ]},ipaddr=${ip_addr_curr[$i]},ipaddr_prev=${ip_addr_prev[$i]},ipaddr_changed=${has_changed[ $i ]} created=${creation_ts_curr[ $i ]}i,uptime=${ipaddr_online}i,changed=${has_changed[ $i ]}i"
-    if [ -f "${logFile}" ]; then printf "%s: === %s\n" "$sts" "$influxLine" >> ${logFile} ; fi
-    echo "${influxLine}"
+    # only if there is a proper creation timestamp
+    if [ ${creation_ts_curr[ $i ]} -gt 1000000000 ]; then 
+        influxLine="raspiblitz_ip_info,origin=${origin[ $i ]},ipaddr=${ip_addr_curr[$i]},ipaddr_prev=${ip_addr_prev[$i]},ipaddr_changed=${has_changed[ $i ]} created=${creation_ts_curr[ $i ]}i,uptime=${ipaddr_online}i,changed=${has_changed[ $i ]}i"
+        if [ -f "${logFile}" ]; then printf "%s: === %s\n" "$sts" "$influxLine" >> ${logFile} ; fi
+        echo "${influxLine}"
+    else 
+        if [ -f "${logFile}" ]; then printf "%s: creation time ERROR for origin %s \n" "$sts" "${origin[ $i ]}" >> ${logFile} ; fi
+    fi 
 done
 
 # -eof-

--- a/home.admin/assets/telegraf/etc-telegraf/getraspiblitzipinfo.sh
+++ b/home.admin/assets/telegraf/etc-telegraf/getraspiblitzipinfo.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+#
+
+###############################################################################
+#   File:   getraspiblitzipinfo.sh
+#   Date:   2020-09-30
+###############################################################################
+
+# set the "debugLevel"
+debugLevel=0
+writeMemoryfile=1
+
+
+# get the seconds since UNIX epoch
+unixTimestamp=$(date +"%s")
+
+# get active network device (eth0 or wlan0)
+networkDevice=$(ip addr | grep -v "lo:" | grep 'state UP' | tr -d " " | cut -d ":" -f2 | head -n 1)
+
+# create the indexed array "origin" an fill it
+# this also creates the "Enumeration"
+#   0       <=>     publicIP
+#   1       <=>     bitcoind
+#   2       <=>     lnd
+#   3       <=>     IPv6
+#   4       <=>     IPv4
+#
+declare -a origin
+origin=(publicIP bitcoind lnd IPv6 IPv4)
+##
+
+#
+# further we need the arrays
+declare -a ip_addr_curr
+declare -a ip_addr_prev
+declare -a creation_ts_curr
+declare -a creation_ts_prev
+declare -a has_changed
+
+
+# load local config (but should also work if not available)
+source /mnt/hdd/raspiblitz.conf 2>/dev/null
+
+
+
+# get the "public IP addresses" from various sources/origins
+#   [0]     ->   publicIP    (remove square barckets in case of IPv6)
+#   [1]     ->   bitcoind
+#   [2]     ->   lnd
+#   [3]     ->   IPv6 at local network interface (eth0 or wlan0)
+#   [4]     ->   IPv4 at local network interface (eth0 or wlan0)
+ip_addr_curr[0]=$(echo "${publicIP}" | tr -d '[]')
+ip_addr_curr[1]=$(/usr/local/bin/bitcoin-cli  -conf=/mnt/hdd/bitcoin/bitcoin.conf  getnetworkinfo | jq -r ".localaddresses[0].address" 2>/dev/null)
+ip_addr_curr[2]=$(/usr/local/bin/lncli  --lnddir=/mnt/hdd/app-data/lnd  getinfo | jq -r ".uris[0]" 2>/dev/null | cut -d'@' -f2 | rev | cut -d':' -f2- | rev | tr -d '[]')
+ip_addr_curr[3]=$(ip -o -6 address show scope global up dev ${networkDevice} 2>/dev/null | cut -d'/' -f1 | awk '/inet6/{print $4}' | head -n 1)
+ip_addr_curr[4]=$(ip -o -4 address show scope global up dev ${networkDevice} 2>/dev/null | cut -d'/' -f1 | awk '/inet/{print $4}' | head -n 1)
+#
+if [ ${debugLevel} -gt 10 ]; then
+
+    for i in $( seq 0 4 ); do
+        printf "  %2d: %-10s  = %s\n" "$i" "${origin[ $i ]}" "${ip_addr_curr[ $i ]}" ;
+    done
+fi
+
+
+# get the values from a prior run, that file will not be changes as long as all the values stay the same
+memoryFile=/mnt/hdd/temp/raspiblitzipinfo.out
+source ${memoryFile} 2>/dev/null
+
+# prepare to count the changes
+changes=0
+
+# initialize the array of the previous IP addresses from the memory file
+for i in $( seq 0 4 ); do
+
+    # compose the name of the memory variable
+    s="${origin[ $i ]}_old"
+
+    # assign the prev address array emement with content of that variable
+    ip_addr_prev[ $i ]=${!s}
+
+    # if the variable is still empty, fill it with "N/A"
+    if [ "ip_addr_prev[ $i ]" == "" ]; then ip_addr_prev[ $i ]="N/A" ; fi 
+
+    if [ ${debugLevel} -gt 10 ]; then printf "  %2d: read into          ip_addr_prev[%d] from memoryfile variable %30s = %s\n" "$i" "$i" "$s" "${ip_addr_prev[ $i ]}" ; fi
+done
+
+
+# initialize the Creation TimeStamps with their old values from the memory file
+# so it is guaranteed that they contain a proper value if that IP does not change
+# otherwise the "unixTimestamp" will be written if a change is detected
+for i in $( seq 0 4 ); do
+
+    # compose the name of the memory variable
+    s="${origin[ $i ]}_CreationTS_old"
+
+    # get the content of that variable
+    # and sanitzie if necessary
+    val=${!s}
+    if [ "${val}" == "" ]; then val=-1 ; fi
+
+    # assign the current and prev timestamp array emements with content of that variable
+    creation_ts_curr[ $i ]=${val}
+    creation_ts_prev[ $i ]=${val}
+
+    if [ ${debugLevel} -gt 10 ]; then printf "  %2d: read into creation_ts_curr/prev[%d] from memoryfile variable %30s = %s\n" "$i" "$i" "$s" "${creation_ts_curr[ $i ]}" ; fi
+done
+
+
+# initialize the "has_changed" flag array
+for i in $( seq 0 4 ); do
+    has_changed[ $i ]=0
+done
+
+
+# check for changes...
+# whenever a change is detected the current time will be written into the respective Creation TimeStamp variable
+# Additionally the "changes" counter will be incremented
+for i in $( seq 0 4 ); do
+    if [ "${ip_addr_curr[$i]}" != "${ip_addr_prev[$i]}" ]; then
+        ((changes++))
+        has_changed[ $i ]=1
+        creation_ts_curr[ $i ]=${unixTimestamp}
+
+        if [ ${debugLevel} -gt  0 ]; then printf "  %2d: IP addr change detected for %10s: %40s (new) != %40s (old)\n" "$i" "${origin[ $i ]}" "${ip_addr_curr[$i]}" "${ip_addr_prev[$i]}" ; fi
+    else
+
+        if [ ${debugLevel} -gt 10 ]; then printf "  %2d: IP addr --NOT changed-- for %10s: %40s (new) == %40s (old)\n" "$i" "${origin[ $i ]}" "${ip_addr_curr[$i]}" "${ip_addr_prev[$i]}" ; fi
+    fi
+done
+
+
+# IF at least one value of the memory file needs to be updated, the whole file will be rewritten.
+# the "..._CreationTS" variables will contain their "..._CreationTS_old" counter part (if nothing has changed)
+# or "${unixTimestamp}" if that particular IP address has been changed
+#
+if [ ${changes} -gt 0 ]; then
+
+    if [ ${debugLevel} -gt  0 ]; then  echo "*** IP change detected, writing memoryfile ${memoryFile} ***" ; fi
+
+    if [ ${writeMemoryfile} -eq 1 ]; then
+        # truncate file and write header
+        echo "#############################################################"        >   ${memoryFile}
+        echo "# RaspiBlitz IP address memory file."                                 >>  ${memoryFile}
+        echo "# created by script %{$0}"                                            >>  ${memoryFile}
+        echo "#############################################################"        >>  ${memoryFile}
+        echo " "                                                                    >>  ${memoryFile}
+        #
+        # write a section for each entry in the "origin" array
+        for i in $( seq 0 4 ); do
+            echo "# section ${origin[ $i ]}"                                        >>  ${memoryFile}
+            echo "${origin[ $i ]}_old=${ip_addr_curr[$i]}"                          >>  ${memoryFile}
+            echo "${origin[ $i ]}_CreationTS_old=${creation_ts_curr[ $i ]}"         >>  ${memoryFile}
+            echo " "                                                                >>  ${memoryFile}
+        done
+    else
+        # display info on stdout
+        echo ""
+        echo "writeMemoryfile=off      =>  show changes"
+        echo ""
+        echo "#############################################################"
+        echo "# RaspiBlitz IP address memory file."
+        echo "# created by script %{$0}"
+        echo "#############################################################"
+        echo " "
+
+        for i in $( seq 0 4 ); do
+            echo "# section ${origin[ $i ]}"
+            echo "${origin[ $i ]}_old=${ip_addr_curr[$i]}"
+            echo "${origin[ $i ]}_CreationTS_old=${creation_ts_curr[ $i ]}"
+            echo " "
+        done
+    fi
+else
+    if [ ${debugLevel} -gt  0 ]; then  echo "*** no IP change detected, do nothing... ***" ; fi
+fi
+
+
+# now create the output for the telegraf "[[inputs.exec]]" section in influx-line-format
+#
+# measurement:  raspiblitz_ip_info
+#
+# tags
+#   *   host
+#   *   origin
+#   *   ipaddr
+#   *   ipaddr_prev
+#   *   ipaddr_changed
+#
+# fileds
+#   *   created
+#   *   uptime
+#   *   changed
+#
+for i in $( seq 0 4 ); do
+
+    ipaddr_online=$(( ${unixTimestamp} - ${creation_ts_curr[ $i ]}))
+    echo "raspiblitz_ip_info,origin=${origin[ $i ]},ipaddr=${ip_addr_curr[$i]},ipaddr_prev=${ip_addr_prev[$i]},ipaddr_changed=${has_changed[ $i ]} created=${creation_ts_curr[ $i ]}i,uptime=${ipaddr_online}i,changed=${has_changed[ $i ]}i"
+done
+
+# -eof-

--- a/home.admin/assets/telegraf/etc-telegraf/getserviceuptime.sh
+++ b/home.admin/assets/telegraf/etc-telegraf/getserviceuptime.sh
@@ -3,29 +3,32 @@
 
 ###############################################################################
 #   File:   getserviceuptime.sh
-#   Date:   2020-10-02
+#   Date:   2020-10-12
 ###############################################################################
 
 # collect the service uptimes into variables
 # some of the variables may contain "" as the pidof/pgrep may fail due to non-existens of that process
 #
- bitcoind_uptime=$(ps -p `pidof bitcoind`                   -o etimes='' 2>/dev/null | tr -d '[:space:]')
-      lnd_uptime=$(ps -p `pidof lnd`                        -o etimes='' 2>/dev/null | tr -d '[:space:]')
-  electrs_uptime=$(ps -p `pidof electrs`                    -o etimes='' 2>/dev/null | tr -d '[:space:]')
- telegraf_uptime=$(ps -p `pidof telegraf`                   -o etimes='' 2>/dev/null | tr -d '[:space:]')
-     sshd_uptime=$(ps -p `pgrep -f /usr/sbin/sshd`          -o etimes='' 2>/dev/null | tr -d '[:space:]')
-      rtl_uptime=$(ps -p `pgrep -f RTL`                     -o etimes='' 2>/dev/null | tr -d '[:space:]')
- btcrpexp_uptime=$(ps -p `pgrep -f "sh -c node ./bin/www"`  -o etimes='' 2>/dev/null | tr -d '[:space:]')
+ bitcoind_uptime=$(ps -p `pidof bitcoind`                                                   -o etimes='' 2>/dev/null | tr -d '[:space:]')
+      lnd_uptime=$(ps -p `pidof lnd`                                                        -o etimes='' 2>/dev/null | tr -d '[:space:]')
+  electrs_uptime=$(ps -p `pidof electrs`                                                    -o etimes='' 2>/dev/null | tr -d '[:space:]')
+ telegraf_uptime=$(ps -p `pidof telegraf`                                                   -o etimes='' 2>/dev/null | tr -d '[:space:]')
+     sshd_uptime=$(ps -p `pgrep -f /usr/sbin/sshd`                                          -o etimes='' 2>/dev/null | tr -d '[:space:]')
+      rtl_uptime=$(ps -p `pgrep -f RTL`                                                     -o etimes='' 2>/dev/null | tr -d '[:space:]')
+ btcrpexp_uptime=$(ps -p `pgrep -f "sh -c node ./bin/www"`                                  -o etimes='' 2>/dev/null | tr -d '[:space:]')
+  mempool_uptime=$(ps -p `pgrep -f "/usr/bin/node --max-old-space-size=2048 dist/index.js"` -o etimes='' 2>/dev/null | tr -d '[:space:]')
 
+# 
 # whenever a variable contains a valid integer...spit out a line in influx-line-format
 # (see https://stackoverflow.com/a/19116862 for details "Test whether string is a valid integer")
 #
-if [ "$bitcoind_uptime" -eq "$bitcoind_uptime" ] 2>/dev/null; then echo "service_uptime,service=bitcoind uptime=${bitcoind_uptime}i";           fi
-if [      "$lnd_uptime" -eq      "$lnd_uptime" ] 2>/dev/null; then echo "service_uptime,service=lnd uptime=${lnd_uptime}i";                     fi
-if [  "$electrs_uptime" -eq  "$electrs_uptime" ] 2>/dev/null; then echo "service_uptime,service=electrs uptime=${electrs_uptime}i";             fi
-if [ "$telegraf_uptime" -eq "$telegraf_uptime" ] 2>/dev/null; then echo "service_uptime,service=telegraf uptime=${telegraf_uptime}i";           fi
-if [     "$sshd_uptime" -eq     "$sshd_uptime" ] 2>/dev/null; then echo "service_uptime,service=sshd uptime=${sshd_uptime}i";                   fi
-if [      "$rtl_uptime" -eq      "$rtl_uptime" ] 2>/dev/null; then echo "service_uptime,service=RTL uptime=${rtl_uptime}i";                     fi
-if [ "$btcrpexp_uptime" -eq "$btcrpexp_uptime" ] 2>/dev/null; then echo "service_uptime,service=btcrpcexplorer uptime=${btcrpexp_uptime}i";     fi
+if [ "$bitcoind_uptime" -eq "$bitcoind_uptime" ] 2>/dev/null; then echo "service_uptime,service=bitcoind uptime=${bitcoind_uptime}i"            ;fi
+if [      "$lnd_uptime" -eq      "$lnd_uptime" ] 2>/dev/null; then echo "service_uptime,service=lnd uptime=${lnd_uptime}i"                      ;fi
+if [  "$electrs_uptime" -eq  "$electrs_uptime" ] 2>/dev/null; then echo "service_uptime,service=electrs uptime=${electrs_uptime}i"              ;fi
+if [ "$telegraf_uptime" -eq "$telegraf_uptime" ] 2>/dev/null; then echo "service_uptime,service=telegraf uptime=${telegraf_uptime}i"            ;fi
+if [     "$sshd_uptime" -eq     "$sshd_uptime" ] 2>/dev/null; then echo "service_uptime,service=sshd uptime=${sshd_uptime}i"                    ;fi
+if [      "$rtl_uptime" -eq      "$rtl_uptime" ] 2>/dev/null; then echo "service_uptime,service=RTL uptime=${rtl_uptime}i"                      ;fi
+if [ "$btcrpexp_uptime" -eq "$btcrpexp_uptime" ] 2>/dev/null; then echo "service_uptime,service=btcrpcexplorer uptime=${btcrpexp_uptime}i"      ;fi
+if [  "$mempool_uptime" -eq  "$mempool_uptime" ] 2>/dev/null; then echo "service_uptime,service=mempool uptime=${mempool_uptime}i"              ;fi
 
 # -eof-

--- a/home.admin/assets/telegraf/etc-telegraf/getserviceuptime.sh
+++ b/home.admin/assets/telegraf/etc-telegraf/getserviceuptime.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+
+###############################################################################
+#   File:   getserviceuptime.sh
+#   Date:   2020-10-02
+###############################################################################
+
+# collect the service uptimes into variables
+# some of the variables may contain "" as the pidof/pgrep may fail due to non-existens of that process
+#
+ bitcoind_uptime=$(ps -p `pidof bitcoind`                   -o etimes='' 2>/dev/null | tr -d '[:space:]')
+      lnd_uptime=$(ps -p `pidof lnd`                        -o etimes='' 2>/dev/null | tr -d '[:space:]')
+  electrs_uptime=$(ps -p `pidof electrs`                    -o etimes='' 2>/dev/null | tr -d '[:space:]')
+ telegraf_uptime=$(ps -p `pidof telegraf`                   -o etimes='' 2>/dev/null | tr -d '[:space:]')
+     sshd_uptime=$(ps -p `pgrep -f /usr/sbin/sshd`          -o etimes='' 2>/dev/null | tr -d '[:space:]')
+      rtl_uptime=$(ps -p `pgrep -f RTL`                     -o etimes='' 2>/dev/null | tr -d '[:space:]')
+ btcrpexp_uptime=$(ps -p `pgrep -f "sh -c node ./bin/www"`  -o etimes='' 2>/dev/null | tr -d '[:space:]')
+
+# whenever a variable contains a valid integer...spit out a line in influx-line-format
+# (see https://stackoverflow.com/a/19116862 for details "Test whether string is a valid integer")
+#
+if [ "$bitcoind_uptime" -eq "$bitcoind_uptime" ] 2>/dev/null; then echo "service_uptime,service=bitcoind uptime=${bitcoind_uptime}i";           fi
+if [      "$lnd_uptime" -eq      "$lnd_uptime" ] 2>/dev/null; then echo "service_uptime,service=lnd uptime=${lnd_uptime}i";                     fi
+if [  "$electrs_uptime" -eq  "$electrs_uptime" ] 2>/dev/null; then echo "service_uptime,service=electrs uptime=${electrs_uptime}i";             fi
+if [ "$telegraf_uptime" -eq "$telegraf_uptime" ] 2>/dev/null; then echo "service_uptime,service=telegraf uptime=${telegraf_uptime}i";           fi
+if [     "$sshd_uptime" -eq     "$sshd_uptime" ] 2>/dev/null; then echo "service_uptime,service=sshd uptime=${sshd_uptime}i";                   fi
+if [      "$rtl_uptime" -eq      "$rtl_uptime" ] 2>/dev/null; then echo "service_uptime,service=RTL uptime=${rtl_uptime}i";                     fi
+if [ "$btcrpexp_uptime" -eq "$btcrpexp_uptime" ] 2>/dev/null; then echo "service_uptime,service=btcrpcexplorer uptime=${btcrpexp_uptime}i";     fi
+
+# -eof-

--- a/home.admin/assets/telegraf/etc-telegraf/telegraf.conf
+++ b/home.admin/assets/telegraf/etc-telegraf/telegraf.conf
@@ -1,0 +1,51 @@
+# Telegraf Configuration
+#
+# raspiblitz
+
+
+# Global tags can be specified here in key="value" format.
+[global_tags]
+  ## Environment variables can be used as tags, and throughout the config file
+  # user = "$USER"
+
+
+# Configuration for telegraf agent
+[agent]
+## Default data collection interval for all inputs
+interval                    = "10s"
+round_interval              = true
+metric_batch_size           = 1000
+metric_buffer_limit         = 10000
+collection_jitter           = "0s"
+flush_interval              = "10s"
+flush_jitter                = "0s"
+precision                   = ""
+hostname                    = ""
+omit_hostname               = false
+
+
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+# Configuration for sending metrics to InfluxDB
+[[outputs.influxdb]]
+##########
+# RaspiBlitz Note:
+#   it is necessary to keep the exact spacing for the sed-part in custom-installs.sh
+#
+urls = ["URL of influxDB with port"]
+database = "influxDB database name"
+username = "user with write access to above database"
+password = "password of the above influx user"
+##########
+database_tag               = ""
+exclude_database_tag       = false
+skip_database_creation     = false
+retention_policy           = ""
+write_consistency          = "any"
+timeout                    = "5s"
+user_agent                 = "telegraf"
+udp_payload                = "512B"
+

--- a/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
+++ b/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
@@ -195,6 +195,9 @@
 [[inputs.procstat]]
   systemd_unit                = "background.service"
 
+[[inputs.procstat]]
+  systemd_unit                = "mempool.service"
+
 
 
 #####################################

--- a/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
+++ b/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
@@ -22,7 +22,7 @@
 
 ####  Read metrics about network interface usage
 [[inputs.net]]
-  interfaces                  = ["eth0"]
+  ##interfaces                  = ["eth0"]
   ignore_protocol_stats       = false
 
 

--- a/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
+++ b/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
@@ -1,0 +1,265 @@
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+####  Collect statistics about itself
+[[inputs.internal]]
+  collect_memstats            = true
+
+
+####  Read metrics about cpu usage
+[[inputs.cpu]]
+  percpu                      = false
+  totalcpu                    = true
+  collect_cpu_time            = false
+  report_active               = false
+
+
+####  Read metrics about disk usage by mount point
+[[inputs.disk]]
+  ignore_fs                   = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+
+
+####  Read metrics about network interface usage
+[[inputs.net]]
+  interfaces                  = ["eth0"]
+  ignore_protocol_stats       = false
+
+
+####  Read metrics about disk IO by device
+[[inputs.diskio]]
+
+
+####  Get kernel statistics from /proc/stat
+[[inputs.kernel]]
+
+
+####  Read metrics about memory usage
+[[inputs.mem]]
+
+
+####  Get the number of processes and group them by status
+[[inputs.processes]]
+
+
+####  Read metrics about swap memory usage
+[[inputs.swap]]
+
+
+####  Read metrics about system load & uptime
+[[inputs.system]]
+
+
+#####################################
+####  Bitcoin and Lightning Network related metrics
+####
+####  Note: [[inputs.exec]] => data_format = "json" only evaluate numeric values.
+####        All NON-NUMERIC values will be dropped
+####
+#####################################
+
+
+####  Bitcoin related metric
+####  basic information about the blockchain
+####  --> https://developer.bitcoin.org/reference/rpc/getblockchaininfo.html
+##
+##    Most usefull fields...
+##      *   blocks
+##      *   headers
+##      *   verificationprogress
+##
+[[inputs.exec]]
+  interval                    = "60s"
+  commands                    = ["/usr/local/bin/bitcoin-cli  -conf=/mnt/hdd/bitcoin/bitcoin.conf  getblockchaininfo" ]
+  name_override               = "bitcoin_blockchaininfo"
+  data_format                 = "json"
+
+
+####  Bitcoin related metric
+####  information about network traffic, including bytes in, bytes out, and current time window
+####  --> https://developer.bitcoin.org/reference/rpc/getnettotals.html
+##
+##    Most usefull fields...
+##      *   totalbytesrecv
+##      *   totalbytessent
+##
+[[inputs.exec]]
+  interval                    = "60s"
+  commands                    = ["/usr/local/bin/bitcoin-cli  -conf=/mnt/hdd/bitcoin/bitcoin.conf  getnettotals" ]
+  name_override               = "bitcoin_nettotals"
+  data_format                 = "json"
+
+
+# ####  Bitcoin related metric
+# ####  total uptime of the bitcoind service in seconds
+# ####  --> https://developer.bitcoin.org/reference/rpc/uptime.html
+# ##
+# ##    Replaced by "/etc/telegraf/getserviceuptime.sh"
+# ##
+# [[inputs.exec]]
+#   interval                    = "60s"
+#   commands                    = ["/usr/local/bin/bitcoin-cli  -conf=/mnt/hdd/bitcoin/bitcoin.conf  uptime" ]
+#   name_override               = "bitcoin_uptime"
+#   data_format                 = "value"
+#   data_type                   = "integer"
+
+
+####  Bitcoin related metric
+####  number of connections to other nodes
+####  --> https://developer.bitcoin.org/reference/rpc/getconnectioncount.html
+##
+[[inputs.exec]]
+  interval                    = "60s"
+  commands                    = ["/usr/local/bin/bitcoin-cli  -conf=/mnt/hdd/bitcoin/bitcoin.conf  getconnectioncount" ]
+  name_override               = "bitcoin_connectioncount"
+  data_format                 = "value"
+  data_type                   = "integer"
+
+
+####  Lightning Network related metric
+####  basic information about the LN node
+####  --> https://api.lightning.community/#getinfo
+##
+##    Most usefull fields...
+##      *   block_height
+##      *   num_peers
+##      *   num_active_channels
+##      *   num_inactive_channels
+##      *   num_pending_channels
+##
+[[inputs.exec]]
+  interval                    = "60s"
+  commands                    = ["/usr/local/bin/lncli --lnddir=/mnt/hdd/app-data/lnd getinfo" ]
+  name_override               = "ln_info"
+  data_format                 = "json"
+
+
+
+#####################################
+####  Various IP addresses
+####
+#####################################
+
+#### gets the creation timestamp and uptime of several raspiblitz IP addresses
+##
+##      *   publicIP from /mnt/hdd/raspiblitz.conf
+##      *   bitcoind node ip address via:   bitcoin-cli getnetworkinfo  =>  "localaddresses"
+##      *   lnd ip addess via:              lncli getinfo               =>  "uris"
+##      *   IPv6 global from eth0/wlan0
+##      *   IPv4 local network address from eth0/wlan0
+##
+[[inputs.exec]]
+  interval                    = "60s"
+  commands                    = ["/etc/telegraf/getraspiblitzipinfo.sh" ]
+  data_format                 = "influx"
+
+
+
+#####################################
+####  Processes and Services
+####
+#####################################
+
+#### gets the uptime of various important raspiblitz services via
+[[inputs.exec]]
+  # this should match the standard metrics-gathering-interval as defined in the [agent] section
+  commands                    = ["/etc/telegraf/getserviceuptime.sh" ]
+  data_format                 = "influx"
+
+
+## check for the systemd services not the plain exe-file names
+[[inputs.procstat]]
+  systemd_unit                = "bootstrap.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "telegraf.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "ssh.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "bitcoind.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "lnd.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "RTL.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "electrs.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "btc-rpc-explorer.service"
+
+[[inputs.procstat]]
+  systemd_unit                = "background.service"
+
+
+
+#####################################
+####  Hardware data: cpu/gpu temperature, voltage, cpu clock
+####
+#####################################
+[[inputs.file]]
+  files                       = ["/sys/class/thermal/thermal_zone0/temp"]
+  name_override               = "cpu_temperature"
+  data_format                 = "value"
+  data_type                   = "integer"
+
+
+[[inputs.exec]]
+  commands                    = ["/opt/vc/bin/vcgencmd measure_temp"]
+  name_override               = "gpu_temperature"
+  data_format                 = "grok"
+  grok_patterns               = ["%{NUMBER:value:float}"]
+
+
+[[inputs.exec]]
+  commands                    = ["/opt/vc/bin/vcgencmd measure_volts core"]
+  name_override               = "cpu_volts"
+  data_format                 = "grok"
+  grok_patterns               = ["%{NUMBER:value:float}"]
+
+
+[[inputs.exec]]
+  commands                    = ["/opt/vc/bin/vcgencmd measure_clock arm"]
+  name_override               = "cpu_frequency"
+  data_format                 = "grok"
+  grok_patterns               = ["=%{NUMBER:value:int}"]
+
+
+
+#####################################
+####  web services
+####
+#### JSON web interface for statistical data from "blockchain.com"
+####
+#### documentation:         https://www.blockchain.com/api/charts_api
+#### example:               https://www.blockchain.com/stats
+#### JSON api URL:          https://api.blockchain.info/stats
+####
+#####################################
+[[inputs.http]]
+  interval                    = "60s"
+  urls                        = ["https://api.blockchain.info/stats"]
+  timeout                     = "5s"
+  name_override               = "web_bitcoin_info"
+  data_format                 = "json"
+
+###############################################################################
+#                            SERVICE INPUT PLUGINS                            #
+###############################################################################
+
+
+####  Read metrics from one or many prometheus clients
+#
+# electrs stats
+[[inputs.prometheus]]
+  interval                    = "60s"
+  urls                        = ["http://localhost:4224/metrics"]
+  metric_version              = 2
+  name_override               = "electrs_info"
+
+
+### -eof-

--- a/home.admin/assets/telegraf/raspiblitz-grafana-dashboard.json
+++ b/home.admin/assets/telegraf/raspiblitz-grafana-dashboard.json
@@ -45,7 +45,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 12,
-  "iteration": 1601744789875,
+  "iteration": 1601814213178,
   "links": [],
   "panels": [
     {
@@ -109,9 +109,9 @@
       },
       "hideTimeOverride": true,
       "id": 70,
-      "interval": "10s",
+      "interval": "",
       "links": [],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -131,11 +131,11 @@
         {
           "alias": "",
           "groupBy": [],
-          "limit": "1",
+          "limit": "",
           "measurement": "system",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "query": "SELECT last(\"uptime\") FROM \"system\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -163,7 +163,7 @@
           "tz": ""
         }
       ],
-      "timeFrom": null,
+      "timeFrom": "2m",
       "timeShift": null,
       "title": "system",
       "transparent": true,
@@ -216,9 +216,9 @@
       },
       "hideTimeOverride": true,
       "id": 92,
-      "interval": "10s",
+      "interval": "",
       "links": [],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -245,11 +245,11 @@
               "type": "tag"
             }
           ],
-          "limit": "1",
-          "measurement": "service-uptime",
+          "limit": "",
+          "measurement": "service_uptime",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "query": "SELECT last(\"uptime\") FROM \"service_uptime\" WHERE (\"host\" =~ /^$host$/ AND \"service\" = 'bitcoind') AND $timeFilter GROUP BY \"service\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -283,7 +283,7 @@
           "tz": ""
         }
       ],
-      "timeFrom": null,
+      "timeFrom": "2m",
       "timeShift": null,
       "title": "bitcoind - service",
       "transparent": true,
@@ -336,9 +336,9 @@
       },
       "hideTimeOverride": true,
       "id": 71,
-      "interval": "10s",
+      "interval": "",
       "links": [],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -365,11 +365,11 @@
               "type": "tag"
             }
           ],
-          "limit": "1",
-          "measurement": "service-uptime",
+          "limit": "",
+          "measurement": "service_uptime",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "query": "SELECT last(\"uptime\") FROM \"service_uptime\" WHERE (\"host\" =~ /^$host$/ AND \"service\" = 'lnd') AND $timeFilter GROUP BY \"service\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -403,7 +403,7 @@
           "tz": ""
         }
       ],
-      "timeFrom": null,
+      "timeFrom": "2m",
       "timeShift": null,
       "title": "lnd - service",
       "transparent": true,
@@ -456,9 +456,9 @@
       },
       "hideTimeOverride": true,
       "id": 72,
-      "interval": "10s",
+      "interval": "",
       "links": [],
-      "maxDataPoints": 100,
+      "maxDataPoints": 1,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -485,11 +485,11 @@
               "type": "tag"
             }
           ],
-          "limit": "1",
-          "measurement": "service-uptime",
+          "limit": "",
+          "measurement": "service_uptime",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "query": "SELECT last(\"uptime\") FROM \"service_uptime\" WHERE (\"host\" =~ /^$host$/ AND \"service\" = 'electrs') AND $timeFilter GROUP BY \"service\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -523,7 +523,7 @@
           "tz": ""
         }
       ],
-      "timeFrom": null,
+      "timeFrom": "2m",
       "timeShift": null,
       "title": "electrs - service",
       "transparent": true,
@@ -612,7 +612,7 @@
           "measurement": "bitcoin_nettotals",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"num_peers\") FROM \"ln-info\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "query": "SELECT last(\"totalbytesrecv\") AS \"Recv\" FROM \"bitcoin_nettotals\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -734,7 +734,7 @@
           "measurement": "bitcoin_nettotals",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"num_peers\") FROM \"ln-info\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "query": "SELECT last(\"totalbytessent\") AS \"Sent\" FROM \"bitcoin_nettotals\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -848,7 +848,7 @@
           "measurement": "bitcoin_blockchaininfo",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"num_peers\") FROM \"ln-info\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "query": "SELECT last(\"size_on_disk\") FROM \"bitcoin_blockchaininfo\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1240,7 +1240,7 @@
       ],
       "timeFrom": "2m",
       "timeShift": null,
-      "title": "eth0 - IPv6 (global)",
+      "title": "IPv6 (global)",
       "transparent": true,
       "type": "stat"
     },
@@ -1572,7 +1572,7 @@
           "measurement": "raspiblitz_ip_info",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "query": "SELECT last(\"uptime\") FROM \"raspiblitz_ip_info\" WHERE (\"host\" =~ /^$host$/ AND \"origin\" = 'publicIP') AND $timeFilter GROUP BY \"ipaddr\"",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -3312,7 +3312,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 35
           },
           "id": 22,
           "interval": "10s",
@@ -3415,7 +3415,7 @@
                 }
               ],
               "limit": "1",
-              "measurement": "service-uptime",
+              "measurement": "service_uptime",
               "orderByTime": "ASC",
               "policy": "default",
               "query": "SELECT last(\"uptime\") FROM \"autogen\".\"service-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY \"service\" LIMIT 1",
@@ -3494,7 +3494,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 35
           },
           "hideTimeOverride": true,
           "id": 6,
@@ -3653,7 +3653,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 45
           },
           "hiddenSeries": false,
           "id": 104,
@@ -3669,7 +3669,7 @@
             "rightSide": true,
             "show": true,
             "sort": "current",
-            "sortDesc": false,
+            "sortDesc": true,
             "total": false,
             "values": true
           },
@@ -3842,7 +3842,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 45
           },
           "id": 94,
           "interval": "1m",
@@ -3938,7 +3938,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 53
           },
           "hiddenSeries": false,
           "id": 102,
@@ -4077,7 +4077,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 45
+            "y": 61
           },
           "hiddenSeries": false,
           "id": 31,
@@ -4240,7 +4240,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 55
+            "y": 71
           },
           "hiddenSeries": false,
           "id": 10,
@@ -4448,7 +4448,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 83
           },
           "hiddenSeries": false,
           "hideTimeOverride": false,
@@ -4600,7 +4600,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 14
+            "y": 90
           },
           "hiddenSeries": false,
           "id": 12,
@@ -4929,7 +4929,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 100
           },
           "hiddenSeries": false,
           "id": 41,
@@ -5076,7 +5076,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 109
           },
           "hiddenSeries": false,
           "id": 93,
@@ -6551,5 +6551,5 @@
   "timezone": "",
   "title": "Bitcoin/LN/electrs - Node",
   "uid": "ImRpu1igk",
-  "version": 75
+  "version": 89
 }

--- a/home.admin/assets/telegraf/raspiblitz-grafana-dashboard.json
+++ b/home.admin/assets/telegraf/raspiblitz-grafana-dashboard.json
@@ -1,0 +1,6555 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      },
+      {
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "matchAny": true,
+        "name": "Show reboots",
+        "showIn": 0,
+        "tags": [
+          "reboot"
+        ],
+        "type": "tags"
+      },
+      {
+        "datasource": "-- Grafana --",
+        "enable": false,
+        "hide": true,
+        "iconColor": "#5794F2",
+        "limit": 100,
+        "name": "Global Annotations",
+        "showIn": 0,
+        "tags": [
+          "global"
+        ],
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 12,
+  "iteration": 1601744789875,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 69,
+      "panels": [],
+      "title": "Quick Summary - Node",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "hideTimeOverride": true,
+      "id": 70,
+      "interval": "10s",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "system",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "system",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "hideTimeOverride": true,
+      "id": 92,
+      "interval": "10s",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "/^bitcoind$/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_service",
+          "groupBy": [
+            {
+              "params": [
+                "service"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "service-uptime",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "service",
+              "operator": "=",
+              "value": "bitcoind"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "bitcoind - service",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "hideTimeOverride": true,
+      "id": 71,
+      "interval": "10s",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "/^lnd$/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_service",
+          "groupBy": [
+            {
+              "params": [
+                "service"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "service-uptime",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "service",
+              "operator": "=",
+              "value": "lnd"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "lnd - service",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "hideTimeOverride": true,
+      "id": 72,
+      "interval": "10s",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "/^electrs$/",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_service",
+          "groupBy": [
+            {
+              "params": [
+                "service"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "1",
+          "measurement": "service-uptime",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "service",
+              "operator": "=",
+              "value": "electrs"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "electrs - service",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 3
+              },
+              {
+                "color": "#299c46",
+                "value": 6
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 47,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "bitcoin_nettotals",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"num_peers\") FROM \"ln-info\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "totalbytesrecv"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [
+                  "Recv"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Bitcoin - Recv",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 3
+              },
+              {
+                "color": "#299c46",
+                "value": 6
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 48,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$col",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "bitcoin_nettotals",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"num_peers\") FROM \"ln-info\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "totalbytessent"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [
+                  "Sent"
+                ],
+                "type": "alias"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Bitcoin - Sent",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 51,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "bitcoin_blockchaininfo",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"num_peers\") FROM \"ln-info\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "size_on_disk"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Blockchain Size",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 3
+              },
+              {
+                "color": "#299c46",
+                "value": 6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 5
+      },
+      "id": 81,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "bitcoin_connectioncount",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Bitcoin peers",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 3
+              },
+              {
+                "color": "#299c46",
+                "value": 6
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 5
+      },
+      "id": 82,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "ln_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"num_peers\") FROM \"ln-info\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "num_peers"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "LN peers",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 97,
+      "panels": [],
+      "title": "Quick Summary - IP Addresses",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 10
+      },
+      "hideTimeOverride": true,
+      "id": 95,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "IPv6"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "eth0 - IPv6 (global)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 10
+      },
+      "hideTimeOverride": true,
+      "id": 98,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "bitcoind"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "bitcoind",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 10
+      },
+      "hideTimeOverride": true,
+      "id": 99,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "lnd"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "lnd",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 12,
+        "y": 10
+      },
+      "hideTimeOverride": true,
+      "id": 100,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "publicIP"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "public IPv6",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 74,
+      "panels": [],
+      "title": "Quick Summary - Blocks",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 16
+      },
+      "hideTimeOverride": true,
+      "id": 75,
+      "interval": "1m",
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "web_bitcoin_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"blocks\") FROM \"bitcoin-blockchaininfo\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "n_blocks_total"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "10m",
+      "timeShift": null,
+      "title": "Bitcoin Blocks (Web)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 16
+      },
+      "hideTimeOverride": true,
+      "id": 76,
+      "interval": "1m",
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "bitcoin_blockchaininfo",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"blocks\") FROM \"bitcoin-blockchaininfo\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "blocks"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "10m",
+      "timeShift": null,
+      "title": "Bitcoin Blocks",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 16
+      },
+      "hideTimeOverride": true,
+      "id": 77,
+      "interval": "",
+      "links": [],
+      "maxDataPoints": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "ln_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"blocks\") FROM \"bitcoin-blockchaininfo\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "block_height"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "10m",
+      "timeShift": null,
+      "title": "LN BlockHeight",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 16
+      },
+      "hideTimeOverride": true,
+      "id": 78,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "electrs_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"blocks\") FROM \"bitcoin-blockchaininfo\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "electrs_index_height"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "10m",
+      "timeShift": null,
+      "title": "electrs IndexHeight",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 130
+              },
+              {
+                "color": "semi-dark-purple",
+                "value": 140
+              },
+              {
+                "color": "blue",
+                "value": 150
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 20
+      },
+      "hideTimeOverride": true,
+      "id": 86,
+      "interval": "1m",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "Block Beat",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "web_bitcoin_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "n_blocks_total"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "24h",
+      "timeShift": null,
+      "title": "Block Beat / 24h (Web)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 130
+              },
+              {
+                "color": "semi-dark-purple",
+                "value": 140
+              },
+              {
+                "color": "blue",
+                "value": 150
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 20
+      },
+      "hideTimeOverride": true,
+      "id": 87,
+      "interval": "1m",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "Block Beat",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "bitcoin_blockchaininfo",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "blocks"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "24h",
+      "timeShift": null,
+      "title": "Block Beat / 24h",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 90,
+      "panels": [],
+      "title": "Quick Summary - MemPool",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 10000
+              },
+              {
+                "color": "#d44a3a",
+                "value": 20000
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 25
+      },
+      "id": 34,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "limit": "",
+          "measurement": "electrs_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "electrs_mempool_count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pending Tx",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 25
+      },
+      "id": 66,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_fee_rate",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "fee_rate"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "limit": "",
+          "measurement": "electrs_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "electrs_mempool_vsize"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "fee_rate",
+              "operator": "=",
+              "value": "≤         1"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "1 sat/vbyte",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 25
+      },
+      "id": 67,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_fee_rate",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "fee_rate"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "limit": "",
+          "measurement": "electrs_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "electrs_mempool_vsize"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "fee_rate",
+              "operator": "=",
+              "value": "≤         2"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "2 sat/vbyte",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 25
+      },
+      "hiddenSeries": false,
+      "id": 32,
+      "interval": "1m",
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 0.5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$tag_fee_rate",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "fee_rate"
+              ],
+              "type": "tag"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "electrs_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"electrs_mempool_vsize\"  / __series.field FROM \"autogen\".\"prometheus\" WHERE $timeFilter GROUP BY \"fee_rate\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "electrs_mempool_vsize"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": "6h",
+      "timeRegions": [
+        {
+          "colorMode": "gray",
+          "fill": true,
+          "fillColor": "rgba(234, 112, 112, 0.12)",
+          "fromDayOfWeek": 6,
+          "line": false,
+          "lineColor": "rgba(237, 46, 24, 0.60)",
+          "op": "time",
+          "toDayOfWeek": 7
+        }
+      ],
+      "timeShift": null,
+      "title": "fees",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": false,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 57,
+      "panels": [],
+      "title": "api.blockchain.info",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 30
+      },
+      "hideTimeOverride": true,
+      "id": 58,
+      "interval": "1m",
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [],
+          "limit": "1",
+          "measurement": "web_bitcoin_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"blocks\") FROM \"bitcoin-blockchaininfo\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "n_blocks_total"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "10m",
+      "timeShift": null,
+      "title": "Bitcoin Blocks (Web)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 130
+              },
+              {
+                "color": "semi-dark-purple",
+                "value": 140
+              },
+              {
+                "color": "blue",
+                "value": 150
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 30
+      },
+      "hideTimeOverride": true,
+      "id": 65,
+      "interval": "1m",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "Block Beat",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "web_bitcoin_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "n_blocks_total"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              },
+              {
+                "params": [],
+                "type": "difference"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": "24h",
+      "timeShift": null,
+      "title": "Block Beat / 24h (Web)",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 30
+      },
+      "id": 61,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "Blocks mined",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "limit": "",
+          "measurement": "web_bitcoin_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "n_blocks_mined"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Blocks Mined / 24h",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 3,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyBTC"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 30
+      },
+      "id": 60,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "Fees per 24h",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "limit": "",
+          "measurement": "web_bitcoin_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "total_fees_btc"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 100000000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Fees / 24h",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#299c46",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 30
+      },
+      "id": 91,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "Marketprice USD",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "limit": "",
+          "measurement": "web_bitcoin_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "market_price_usd"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Marketprice USD",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 25,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "columns": [],
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fontSize": "100%",
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "id": 22,
+          "interval": "10s",
+          "links": [],
+          "pageSize": null,
+          "pluginVersion": "6.3.6",
+          "scroll": true,
+          "showHeader": true,
+          "sort": {
+            "col": null,
+            "desc": false
+          },
+          "styles": [
+            {
+              "alias": "Last seen",
+              "align": "auto",
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "pattern": "Time",
+              "type": "date"
+            },
+            {
+              "alias": "Uptime",
+              "align": "auto",
+              "colorMode": "row",
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "decimals": 2,
+              "pattern": "Value",
+              "thresholds": [
+                "36000",
+                "360000"
+              ],
+              "type": "number",
+              "unit": "dtdurations"
+            },
+            {
+              "alias": "service",
+              "align": "auto",
+              "colorMode": null,
+              "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+              ],
+              "dateFormat": "YYYY-MM-DD HH:mm:ss",
+              "decimals": 2,
+              "mappingType": 1,
+              "pattern": "Metric",
+              "thresholds": [],
+              "type": "string",
+              "unit": "short"
+            }
+          ],
+          "targets": [
+            {
+              "alias": "system",
+              "groupBy": [],
+              "hide": false,
+              "limit": "1",
+              "measurement": "system",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"uptime\") FROM \"autogen\".\"system\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "uptime"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "$tag_service",
+              "groupBy": [
+                {
+                  "params": [
+                    "service"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "limit": "1",
+              "measurement": "service-uptime",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"uptime\") FROM \"autogen\".\"service-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY \"service\" LIMIT 1",
+              "rawQuery": false,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "uptime"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Uptime system / services",
+          "transform": "timeseries_to_rows",
+          "transparent": true,
+          "type": "table-old"
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "left",
+                "displayMode": "auto"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "noValue": "No Data",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Time"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Last seen"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "hideTimeOverride": true,
+          "id": 6,
+          "interval": "1m",
+          "links": [],
+          "options": {
+            "frameIndex": 1,
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": false,
+                "displayName": "Value"
+              }
+            ]
+          },
+          "pluginVersion": "7.1.5",
+          "targets": [
+            {
+              "alias": "$col",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                }
+              ],
+              "limit": "1",
+              "measurement": "bitcoin_nettotals",
+              "orderByTime": "DESC",
+              "policy": "autogen",
+              "query": "SELECT last(\"totalbytesrecv\") AS \"Bytes recv\" FROM \"autogen\".\"bitcoin-nettotals\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY \"host\" LIMIT 1",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "totalbytesrecv"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "Bytes recv"
+                    ],
+                    "type": "alias"
+                  }
+                ],
+                [
+                  {
+                    "params": [
+                      "totalbytessent"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "Bytes sent"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "slimit": "",
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "$col",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                }
+              ],
+              "limit": "1",
+              "measurement": "bitcoin_blockchaininfo",
+              "orderByTime": "DESC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "size_on_disk"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "Size on disk"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "timeFrom": "10m",
+          "timeShift": null,
+          "title": "Bitcoin - totals",
+          "transformations": [
+            {
+              "id": "seriesToRows",
+              "options": {}
+            }
+          ],
+          "transparent": true,
+          "type": "table"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "dateTimeAsIso"
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 104,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": false,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/ = ::1/",
+              "legend": false
+            },
+            {
+              "alias": "/^eth0_.+/",
+              "legend": false
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_origin = $tag_ipaddr",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "origin"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "ipaddr"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "measurement": "raspiblitz_ip_info",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "created"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "*1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "IP Address History",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "dateTimeAsIso",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "center",
+                "displayMode": "color-background"
+              },
+              "decimals": 1,
+              "mappings": [],
+              "noValue": "No Value transmitted",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 3600
+                  },
+                  {
+                    "color": "green",
+                    "value": 72000
+                  }
+                ]
+              },
+              "unit": "dtdurations"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Time"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Last seen"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 94,
+          "interval": "1m",
+          "links": [],
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": false,
+                "displayName": "uptime"
+              }
+            ]
+          },
+          "pluginVersion": "7.1.5",
+          "targets": [
+            {
+              "alias": "$tag_origin = $tag_ipaddr",
+              "groupBy": [
+                {
+                  "params": [
+                    "ipaddr"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "origin"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "hide": false,
+              "limit": "",
+              "measurement": "raspiblitz_ip_info",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "SELECT last(\"uptime\") FROM \"autogen\".\"system\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "table",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "uptime"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "uptime"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "slimit": "",
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ],
+              "tz": ""
+            }
+          ],
+          "timeFrom": "10m",
+          "timeShift": null,
+          "title": "IP addresses from services and network devices",
+          "transparent": true,
+          "type": "table"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "hiddenSeries": false,
+          "id": 102,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": true,
+          "targets": [
+            {
+              "alias": "$tag_origin",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "origin"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "raspiblitz_ip_info",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "changed"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "IP Address changes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": "5",
+              "min": "-1",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "hiddenSeries": false,
+          "id": 31,
+          "interval": "10s",
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "bootstrap.service",
+              "bars": true,
+              "lines": false
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_systemd_unit",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "systemd_unit"
+                  ],
+                  "type": "tag"
+                }
+              ],
+              "limit": "",
+              "measurement": "procstat",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"created_at\")  / 1000000 FROM \"procstat\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time($__interval), \"systemd_unit\"",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "created_at"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      " / 1000000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "slimit": "",
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "Services Start History",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "dateTimeFromNow",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "decimals": 0,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 55
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "alias": "Bitcoin peers",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "bitcoin_connectioncount",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "LN peers",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "ln_info",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "num_peers"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "Peers / Connection Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Uptime & Connections",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 27,
+      "panels": [
+        {
+          "aliasColors": {
+            "Block Beat": "purple",
+            "Block Beat (24h)": "dark-purple",
+            "Heartbeat": "dark-purple"
+          },
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "decimals": 0,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "hideTimeOverride": false,
+          "id": 62,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Block Beat",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "limit": "",
+              "measurement": "bitcoin_blockchaininfo",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "blocks"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [],
+                    "type": "difference"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [
+            {
+              "colorMode": "custom",
+              "fill": false,
+              "fillColor": "rgba(51, 162, 229, 0.2)",
+              "line": true,
+              "lineColor": "rgba(31, 96, 196, 0.6)",
+              "op": "gt",
+              "value": 6,
+              "yaxis": "left"
+            }
+          ],
+          "timeFrom": "24h",
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Block Beat",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": false,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "decimals": 0,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 14
+          },
+          "hiddenSeries": false,
+          "id": 12,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Bitcoin - Verification Progress",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Bitcoin - Blocks",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "bitcoin_blockchaininfo",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "blocks"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "Bitcoin - Headers",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "bitcoin_blockchaininfo",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "headers"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "Bitcoin - Verification Progress",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "bitcoin_blockchaininfo",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "E",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "verificationprogress"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "LN - Bockheight",
+              "groupBy": [
+                {
+                  "params": [
+                    "$interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "ln_info",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "block_height"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "electrs - Indexheight",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "electrs_info",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "electrs_index_height"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "Blockchain Info",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Pending Tx": "orange"
+          },
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 7,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 41,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "alias": "Pending Tx",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "limit": "",
+              "measurement": "electrs_info",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "electrs_mempool_count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "Pending Tx",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "hiddenSeries": false,
+          "id": 93,
+          "interval": "1m",
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 0.5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_fee_rate",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "fee_rate"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "electrs_info",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "SELECT \"electrs_mempool_vsize\"  / __series.field FROM \"autogen\".\"prometheus\" WHERE $timeFilter GROUP BY \"fee_rate\"",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "electrs_mempool_vsize"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "fees via mempool size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Blockchain Info & MemPool",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 29,
+      "panels": [
+        {
+          "aliasColors": {
+            "CPU Frequency": "blue",
+            "CPU Temperature": "red"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "decimals": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 18,
+          "interval": "10s",
+          "legend": {
+            "alignAsTable": false,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "CPU Frequency",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "alias": "CPU Temperature",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "cpu_temperature",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  },
+                  {
+                    "params": [
+                      " / 1000"
+                    ],
+                    "type": "math"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "CPU Frequency",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "cpu_frequency",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      "20"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "CPU Temperature / Frequence",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "celsius",
+              "label": "CPU Temperature",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "hertz",
+              "label": "CPU Frequency",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "CPU system": "light-green",
+            "CPU user": "dark-green"
+          },
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 20,
+          "interval": "10s",
+          "legend": {
+            "alignAsTable": false,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "CPU user",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cpu",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT mean(\"usage_user\") AS \"user\", mean(\"usage_system\")AS \"system\" FROM \"autogen\".\"cpu\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time(1m) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "usage_user"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      "10"
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cpu",
+                  "operator": "=",
+                  "value": "cpu-total"
+                },
+                {
+                  "condition": "AND",
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "CPU system",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "cpu"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "cpu",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "SELECT mean(\"usage_user\") AS \"user\", mean(\"usage_system\")AS \"system\" FROM \"autogen\".\"cpu\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time(1m) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "usage_system"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "cpu",
+                  "operator": "=",
+                  "value": "cpu-total"
+                },
+                {
+                  "condition": "AND",
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "CPU user/system",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "decimals": 1,
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "interval": "10s",
+          "legend": {
+            "alignAsTable": false,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "avail mem",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "alias": "15min",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "system",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT mean(\"load1\") AS \"load 1min\", mean(\"load5\") AS \"load 5min\", mean(\"load15\") AS \"load 15min\" FROM \"system\" WHERE $timeFilter GROUP BY time(1m), \"host\"\n",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "load15"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ],
+              "tz": ""
+            },
+            {
+              "alias": "$col",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "mem",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "available"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      "avail mem"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "SystemLoad / FreeMem",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": true,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Mem avail %": "yellow",
+            "Mem used %": "dark-orange",
+            "Swap used %": "purple"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "hiddenSeries": false,
+          "id": 44,
+          "interval": "10s",
+          "legend": {
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/Mem.+/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Swap used %",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "swap",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "used_percent"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "$col",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "mem",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "used_percent"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  },
+                  {
+                    "params": [
+                      "Mem used %"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            },
+            {
+              "alias": "$col",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "mem",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "available_percent"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  },
+                  {
+                    "params": [
+                      "Mem avail %"
+                    ],
+                    "type": "alias"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "Mem & Swap",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": true,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "mmcblk0p1": "dark-purple",
+            "mmcblk0p2": "light-purple",
+            "sda1": "super-light-purple"
+          },
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 40
+          },
+          "hiddenSeries": false,
+          "id": 23,
+          "interval": "10s",
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_device",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "device"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "disk",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "SELECT mean(\"usage_user\") AS \"user\", mean(\"usage_system\")AS \"system\" FROM \"autogen\".\"cpu\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time(1m) fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "used_percent"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "Disk used %",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percent",
+              "label": "",
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "decimals": 0,
+              "format": "bytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "mmcblk0p1": "dark-purple",
+            "mmcblk0p2": "light-purple",
+            "sda1": "super-light-purple"
+          },
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 48
+          },
+          "hiddenSeries": false,
+          "id": 42,
+          "interval": "10s",
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pluginVersion": "7.1.5",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_device",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "device"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "disk",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "SELECT mean(\"usage_user\") AS \"user\", mean(\"usage_system\")AS \"system\" FROM \"autogen\".\"cpu\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter GROUP BY time(1m) fill(null)",
+              "rawQuery": false,
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "free"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      10
+                    ],
+                    "type": "moving_average"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "host",
+                  "operator": "=~",
+                  "value": "/^$host$/"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [
+            {
+              "colorMode": "gray",
+              "fill": true,
+              "fillColor": "rgba(234, 112, 112, 0.12)",
+              "fromDayOfWeek": 6,
+              "line": false,
+              "lineColor": "rgba(237, 46, 24, 0.60)",
+              "op": "time",
+              "toDayOfWeek": 7
+            }
+          ],
+          "timeShift": null,
+          "title": "Disk free space",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "transparent": true,
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "bytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "decimals": 0,
+              "format": "bytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Computer Metrics",
+      "type": "row"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": null,
+          "value": null
+        },
+        "datasource": "InfluxDB",
+        "definition": "SHOW TAG VALUES FROM \"ln_info\" WITH KEY=host",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Host",
+        "multi": false,
+        "name": "host",
+        "options": [],
+        "query": "SHOW TAG VALUES FROM \"ln_info\" WITH KEY=host",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Bitcoin/LN/electrs - Node",
+  "uid": "ImRpu1igk",
+  "version": 75
+}

--- a/home.admin/assets/telegraf/raspiblitz-grafana-dashboard.json
+++ b/home.admin/assets/telegraf/raspiblitz-grafana-dashboard.json
@@ -1163,7 +1163,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 3,
         "w": 3,
         "x": 0,
         "y": 10
@@ -1185,7 +1185,7 @@
           "fields": "",
           "values": false
         },
-        "textMode": "value_and_name"
+        "textMode": "value"
       },
       "pluginVersion": "7.1.5",
       "targets": [
@@ -1286,9 +1286,131 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
+        "h": 3,
+        "w": 6,
         "x": 3,
+        "y": 10
+      },
+      "hideTimeOverride": true,
+      "id": 105,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "IPv6"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
         "y": 10
       },
       "hideTimeOverride": true,
@@ -1308,7 +1430,7 @@
           "fields": "",
           "values": false
         },
-        "textMode": "value_and_name"
+        "textMode": "value"
       },
       "pluginVersion": "7.1.5",
       "targets": [
@@ -1409,10 +1531,377 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 6,
+        "h": 3,
+        "w": 6,
+        "x": 15,
         "y": 10
+      },
+      "hideTimeOverride": true,
+      "id": 107,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "bitcoind"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 13
+      },
+      "hideTimeOverride": true,
+      "id": 100,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"uptime\") FROM \"raspiblitz_ip_info\" WHERE (\"host\" =~ /^$host$/ AND \"origin\" = 'publicIP') AND $timeFilter GROUP BY \"ipaddr\"",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "publicIP"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "public IPv6",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 3,
+        "y": 13
+      },
+      "hideTimeOverride": true,
+      "id": 106,
+      "interval": "1m",
+      "links": [],
+      "maxDataPoints": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "alias": "$tag_ipaddr",
+          "groupBy": [
+            {
+              "params": [
+                "ipaddr"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "raspiblitz_ip_info",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "uptime"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "last"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "host",
+              "operator": "=~",
+              "value": "/^$host$/"
+            },
+            {
+              "condition": "AND",
+              "key": "origin",
+              "operator": "=",
+              "value": "publicIP"
+            }
+          ],
+          "tz": ""
+        }
+      ],
+      "timeFrom": "2m",
+      "timeShift": null,
+      "title": "",
+      "type": "stat"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "displayMode": "color-background"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "id": 0,
+              "op": "=",
+              "text": "N/A",
+              "type": 1,
+              "value": "null"
+            }
+          ],
+          "nullValueMode": "connected",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 7200
+              },
+              {
+                "color": "#299c46",
+                "value": 36000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 12,
+        "y": 13
       },
       "hideTimeOverride": true,
       "id": 99,
@@ -1431,7 +1920,7 @@
           "fields": "",
           "values": false
         },
-        "textMode": "value_and_name"
+        "textMode": "value"
       },
       "pluginVersion": "7.1.5",
       "targets": [
@@ -1532,13 +2021,13 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 3,
-        "x": 12,
-        "y": 10
+        "h": 3,
+        "w": 6,
+        "x": 15,
+        "y": 13
       },
       "hideTimeOverride": true,
-      "id": 100,
+      "id": 108,
       "interval": "1m",
       "links": [],
       "maxDataPoints": 1,
@@ -1554,7 +2043,7 @@
           "fields": "",
           "values": false
         },
-        "textMode": "value_and_name"
+        "textMode": "name"
       },
       "pluginVersion": "7.1.5",
       "targets": [
@@ -1572,7 +2061,7 @@
           "measurement": "raspiblitz_ip_info",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"uptime\") FROM \"raspiblitz_ip_info\" WHERE (\"host\" =~ /^$host$/ AND \"origin\" = 'publicIP') AND $timeFilter GROUP BY \"ipaddr\"",
+          "query": "SELECT last(\"value\") FROM \"bitcoin-uptime\" WHERE (\"host\" =~ /^$host$/) AND $timeFilter LIMIT 1",
           "rawQuery": false,
           "refId": "A",
           "resultFormat": "time_series",
@@ -1601,7 +2090,7 @@
               "condition": "AND",
               "key": "origin",
               "operator": "=",
-              "value": "publicIP"
+              "value": "lnd"
             }
           ],
           "tz": ""
@@ -1609,8 +2098,7 @@
       ],
       "timeFrom": "2m",
       "timeShift": null,
-      "title": "public IPv6",
-      "transparent": true,
+      "title": "",
       "type": "stat"
     },
     {
@@ -1620,7 +2108,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "id": 74,
       "panels": [],
@@ -1660,7 +2148,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "hideTimeOverride": true,
       "id": 75,
@@ -1754,7 +2242,7 @@
         "h": 4,
         "w": 3,
         "x": 6,
-        "y": 16
+        "y": 17
       },
       "hideTimeOverride": true,
       "id": 76,
@@ -1848,7 +2336,7 @@
         "h": 4,
         "w": 3,
         "x": 9,
-        "y": 16
+        "y": 17
       },
       "hideTimeOverride": true,
       "id": 77,
@@ -1943,7 +2431,7 @@
         "h": 4,
         "w": 3,
         "x": 12,
-        "y": 16
+        "y": 17
       },
       "hideTimeOverride": true,
       "id": 78,
@@ -2040,7 +2528,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 20
+        "y": 21
       },
       "hideTimeOverride": true,
       "id": 86,
@@ -2150,7 +2638,7 @@
         "h": 4,
         "w": 3,
         "x": 6,
-        "y": 20
+        "y": 21
       },
       "hideTimeOverride": true,
       "id": 87,
@@ -2232,7 +2720,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
       },
       "id": 90,
       "panels": [],
@@ -2280,7 +2768,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 34,
       "interval": "1m",
@@ -2386,7 +2874,7 @@
         "h": 4,
         "w": 3,
         "x": 3,
-        "y": 25
+        "y": 26
       },
       "id": 66,
       "interval": "1m",
@@ -2505,7 +2993,7 @@
         "h": 4,
         "w": 3,
         "x": 6,
-        "y": 25
+        "y": 26
       },
       "id": 67,
       "interval": "1m",
@@ -2608,7 +3096,7 @@
         "h": 4,
         "w": 3,
         "x": 9,
-        "y": 25
+        "y": 26
       },
       "hiddenSeries": false,
       "id": 32,
@@ -2750,7 +3238,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 30
       },
       "id": 57,
       "panels": [],
@@ -2790,7 +3278,7 @@
         "h": 4,
         "w": 3,
         "x": 0,
-        "y": 30
+        "y": 31
       },
       "hideTimeOverride": true,
       "id": 58,
@@ -2886,7 +3374,7 @@
         "h": 4,
         "w": 3,
         "x": 3,
-        "y": 30
+        "y": 31
       },
       "hideTimeOverride": true,
       "id": 65,
@@ -2994,7 +3482,7 @@
         "h": 4,
         "w": 3,
         "x": 6,
-        "y": 30
+        "y": 31
       },
       "id": 61,
       "interval": "1m",
@@ -3101,7 +3589,7 @@
         "h": 4,
         "w": 3,
         "x": 9,
-        "y": 30
+        "y": 31
       },
       "id": 60,
       "interval": "1m",
@@ -3213,7 +3701,7 @@
         "h": 4,
         "w": 3,
         "x": 12,
-        "y": 30
+        "y": 31
       },
       "id": 91,
       "interval": "1m",
@@ -3293,7 +3781,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 35
       },
       "id": 25,
       "panels": [
@@ -4420,7 +4908,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 36
       },
       "id": 27,
       "panels": [
@@ -5222,7 +5710,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 37
       },
       "id": 29,
       "panels": [
@@ -6531,7 +7019,7 @@
     ]
   },
   "time": {
-    "from": "now-2d",
+    "from": "now-4d",
     "to": "now"
   },
   "timepicker": {
@@ -6551,5 +7039,5 @@
   "timezone": "",
   "title": "Bitcoin/LN/electrs - Node",
   "uid": "ImRpu1igk",
-  "version": 89
+  "version": 90
 }

--- a/home.admin/assets/telegraf/raspiblitz.conf-snippet-for-telegraf
+++ b/home.admin/assets/telegraf/raspiblitz.conf-snippet-for-telegraf
@@ -1,0 +1,12 @@
+#########################################################################
+# this has to go to /mnt/hdd/raspiblitz.conf
+# make sure the settings match your local influxDB setup
+#########################################################################
+
+
+# all telegraf switches and configuration variables
+telegrafMonitoring=on
+telegrafInfluxUrl='http://192.168.2.46:8086'
+telegrafInfluxDatabase='telegraf'
+telegrafInfluxUsername='telegraf'
+telegrafInfluxPassword='metricsmetricsmetricsmetrics'

--- a/home.admin/config.scripts/bonus.telegraf.sh
+++ b/home.admin/config.scripts/bonus.telegraf.sh
@@ -73,7 +73,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   echo "*** telegraf installation: apt-get part"
   # get the repository publy key for apt-get
-  curl -sL https://repos.influxdata.com/influxdb.key | apt-key add -
+  curl -sL https://repos.influxdata.com/influxdb.key | sudo apt-key add -
   DISTRIB_ID=$(lsb_release -c -s)
   # 
   # changed according suggestion from @frennkie in #1501

--- a/home.admin/config.scripts/bonus.telegraf.sh
+++ b/home.admin/config.scripts/bonus.telegraf.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+
+###############################################################################
+#   File:   bonus.telegraf.sh
+#   Date:   2020-10-03
+###############################################################################
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+ echo "config script to switch the telegraf metric collection on or off"
+ echo "bonus.telegraf.sh [on|off|status]"
+ exit 1
+fi
+
+# CONFIGFILE - configuration of RaspiBlitz
+configFile="/mnt/hdd/raspiblitz.conf"
+
+# Check if HDD contains configuration
+configExists=$(ls ${configFile} | grep -c '.conf')
+if [ ${configExists} -ne 1 ]; then
+ echo "RaspiBlitz config file '${configFile}' not found"
+ exit 1
+fi
+# at this point the config file exists and can be sourced
+source ${configFile}
+
+# this variables is used repeatedly in this script
+resources_dir=/home/admin/assets/telegraf/etc-telegraf
+
+
+###############################
+# give status
+if [ "$1" = "status" ]; then
+
+  echo "##### STATUS TELEGRAF SERVICE"
+
+  # check if "telegrafMonitoring" is enabled ("1"|"on") in raspiblitz.conf
+  if [ "${telegrafMonitoring}" = "1" ] || [ "${telegrafMonitoring}" = "on" ]; then
+    echo "configured=1"
+  else
+    echo "configured=0"
+  fi
+
+  serviceInstalled=$(sudo systemctl status telegraf --no-page 2>/dev/null | grep -c "telegraf.service - The plugin-driven")
+  echo "serviceInstalled=${serviceInstalled}"
+  if [ ${serviceInstalled} -eq 0 ]; then
+    echo "infoMessage='Telegraf service not installed'"
+  fi
+
+  serviceRunning=$(sudo systemctl status telegraf --no-page 2>/dev/null | grep -c "active (running)")
+  echo "serviceRunning=${serviceRunning}"
+  if [ ${serviceRunning} -eq 1 ]; then
+    echo "infoMessage='Telegraf service is running'"
+  else
+    echo "infoMessage='Not running - check: sudo journalctl -u telegraf'"
+  fi
+
+  exit 0
+fi
+
+
+###############################
+# switch on
+if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+  echo "*** INSTALL TELEGRAF ***"
+  # soure and target dir for copy operation
+  telegraf_source_dir=${resources_dir}
+  telegraf_target_dir=/etc/telegraf
+  #
+  # full path to telegraf config file for sed-replace operation
+  telegraf_conf_file=${telegraf_target_dir}/telegraf.conf
+
+  echo "*** telegraf installation: apt-get part"
+  # get the repository publy key for apt-get
+  curl -sL https://repos.influxdata.com/influxdb.key | apt-key add -
+  DISTRIB_ID=$(lsb_release -c -s)
+  # 
+  # changed according suggestion from @frennkie in #1501
+  echo "deb https://repos.influxdata.com/debian ${DISTRIB_ID} stable" | sudo tee -a /etc/apt/sources.list.d/influxdb.list >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y telegraf
+
+  echo "*** telegraf installation: usermod part"
+  # enable telegraf user to call "/opt/vc/bin/vcgencmd" for frequency and temperatures measurements
+  sudo usermod -aG video telegraf
+  #
+  # enable telegraf as admin for lnd
+  sudo usermod telegraf -a -G lndadmin
+
+  # stop telegraf service
+  sudo systemctl stop telegraf.service
+
+  echo "*** telegraf installation: copying telegraf config templates"
+  # copy custom "telegraf.conf" template to the telegraf target dir
+  # the telegraf inputs part goes into telegraf.d subdir
+  # this split into "telegraf.conf" and "telegraf.d/teöegraf_inputs.conf" is necessary
+  # as the the [[inputs.***]] part contains lines with the keywords
+  # "urls", "database", "username" "password"
+  # so the sed-replacement-part would get confused
+  #
+  # Note: the apt-get install should have already created the path /etc/telegraf and /etc/telegraf/telegraf.d
+  #
+  sudo cp -v ${telegraf_source_dir}/telegraf.conf                     ${telegraf_target_dir}/telegraf.conf
+  sudo cp -v ${telegraf_source_dir}/telegraf.d/telegraf_inputs.conf   ${telegraf_target_dir}/telegraf.d/telegraf_inputs.conf
+  #
+  # copy shell script for service uptime metrics
+  sudo cp -v ${telegraf_source_dir}/getserviceuptime.sh               ${telegraf_target_dir}/getserviceuptime.sh
+  sudo chmod 755 ${telegraf_target_dir}/getserviceuptime.sh
+  #
+  # copy shell script for IP address tracking
+  sudo cp -v ${telegraf_source_dir}/getraspiblitzipinfo.sh            ${telegraf_target_dir}/getraspiblitzipinfo.sh
+  sudo chmod 755 ${telegraf_target_dir}/getraspiblitzipinfo.sh
+
+  echo "*** telegraf installation: replace influxDB url and creds"
+  # here comes the sed-replace-part
+  #
+  # make sure that raspiblitz.conf has the telegraf-variables properly set
+  #   telegrafInfluxUrl
+  #   telegrafInfluxDatabase
+  #   telegrafInfluxUsername
+  #   telegrafInfluxPassword
+  #
+  echo "*** telegraf installation: telegrafInfluxUrl      = '${telegrafInfluxUrl}'"
+  # due to the occurance of '/' in the ${telegrafInfluxUrl} we need to switch to '#' as the sed-separator
+  sudo sed -i "s#^urls = .*#urls = \[\"${telegrafInfluxUrl}\"\]#g" ${telegraf_conf_file}
+  #
+  # the other replacements work with the std separator '/'
+  #
+  # CAUTION: make sure that *none* of the following variables (especially "password") contains a '/'
+  #          this would break the sed-replacement
+  #
+  echo "*** telegraf installation: telegrafInfluxDatabase = '${telegrafInfluxDatabase}'"
+  sudo sed -i "s/^database = .*/database = \"${telegrafInfluxDatabase}\"/g" ${telegraf_conf_file}
+  #
+  echo "*** telegraf installation: telegrafInfluxUsername = '${telegrafInfluxUsername}'"
+  sudo sed -i "s/^username = .*/username = \"${telegrafInfluxUsername}\"/g" ${telegraf_conf_file}
+  #
+  echo "*** telegraf installation: telegrafInfluxPassword = '${telegrafInfluxPassword}'"
+  sudo sed -i "s/^password = .*/password = \"${telegrafInfluxPassword}\"/g" ${telegraf_conf_file}
+
+
+  echo "*** telegraf installation: restart telegraf service with updated config files"
+  # restart telegraf service
+  sudo systemctl start telegraf.service
+  # ...and push some status into the logfile
+  sleep 2
+  sudo systemctl status telegraf.service --no-page 2>/dev/null
+
+  echo "*** telegraf installation: set 'telegrafMonitoring=on' in config file '${configFile}'"
+  sudo sed -i "s/^telegrafMonitoring=.*/telegrafMonitoring=on/g" ${configFile}
+
+
+  echo "*** install telegraf done ***"
+
+  exit 0
+fi
+
+
+###############################
+# switch off
+if [ "$1" = "0" ] || [ "$1" = "off" ]; then
+  echo "*** REMOVE TELEGRAF ***"
+
+  # let apt-get remove the package
+  sudo apt-get remove -y telegraf
+
+  echo "*** telegraf remove: set 'telegrafMonitoring=off' in config file '${configFile}'"
+  sudo sed -i "s/^telegrafMonitoring=.*/telegrafMonitoring=off/g" ${configFile}
+
+  echo "*** remove telegraf done ***"
+
+  exit 0
+fi
+
+echo "FAIL - Unknown Parameter $1"
+exit 1


### PR DESCRIPTION
after integrating the suggestions from PR #1501 I have reworked and extended this PR 
also the git structure had chaged since I open the old PR, so I decided to put all improvements into a new PR which aligns to the updated git structure of raspiblitz,,,
so the related old PR #1501 may be closed and moved over to this



see issue #1369 for reference

[telegraf](https://www.influxdata.com/time-series-platform/telegraf/) is a metric collection tool by influxData.
It is opensource and works fine with [influxDB](https://www.influxdata.com/products/influxdb-overview/) as the timeseries database and [Grafana](https://grafana.com/grafana/) as the graphics front end.

You may take a look [here](https://github.com/gcgarner/IOTstack) for a nice dockerized installation of influxDB and Grafana on a raspberry pi.

Make sure to have a telegraf section in your `/mnt/hdd/raspiblitz.conf` 
you have to manually edit them into `/mnt/hdd/raspiblitz.conf`  before calling 
```
/home/admin/config.scripts/bonus.telegraf.sh on
```

You have to provide a running influxDB / Grafana infrastructure elsewhere (reachable for the RaspiBlitz)

```
# all telegraf switches and configuration variables
telegrafMonitoring=on
telegrafInfluxUrl='http://192.168.2.46:8086'
telegrafInfluxDatabase='telegraf'
telegrafInfluxUsername='telegraf'
telegrafInfluxPassword='metricsmetricsmetricsmetrics'

```
