### PR TITLE
introduce "headless" mode for H/W without LCD

### DIFF
--- a/home.admin/00infoLCD.sh
+++ b/home.admin/00infoLCD.sh
@@ -78,6 +78,16 @@ chain=""
 while :
     do
 
+    # save some CPU / log clutter on a "headless" installation (no LCD attached)
+    # by running the LCD stuff each 5 minutes that otherwise will be run every 5 seconds
+    # 
+    # just insert a line "headless=on" into your "/mnt/hdd/raspiblitz.conf" file
+    # 
+    isHeadless=$(cat ${configFile} | grep -Ec "headless=1|headless=on")
+    if [ ${isHeadless} -gt 0 ]; then
+      sleep 600
+    fi
+
     ###########################
     # CHECK BASIC DATA
     ###########################   

--- a/home.admin/00infoLCD.sh
+++ b/home.admin/00infoLCD.sh
@@ -83,8 +83,9 @@ while :
     # 
     # just insert a line "headless=on" into your "/mnt/hdd/raspiblitz.conf" file
     # 
-    isHeadless=$(cat ${configFile} | grep -Ec "headless=1|headless=on")
+    isHeadless=$(cat "${configFile}" 2>/dev/null | grep -Ec "headless=1|headless=on")
     if [ ${isHeadless} -gt 0 ]; then
+      echo "*** headless=on sleeping 600 seconds ***" | systemd-cat
       sleep 600
     fi
 


### PR DESCRIPTION
this will reduce log clutter and CPU utilization
by running the whole LCD specific stuff every 5 minutes instead of 5 seconds