### PR TITLE
Fix btrfs for PR #1615

### DIFF
--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -137,7 +137,7 @@ if [ "$1" = "status" ]; then
         # BTRFS is working with subvolumnes for snapshots / ext4 has no SubVolumes
         subVolumeDir=""
         if [ "${hddFormat}" = "btrfs" ]; then
-          subVolumeDir="/WORKINGDIR"
+          subVolumeDir="/"
         fi
 
         # temp mount data drive

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -137,7 +137,7 @@ if [ "$1" = "status" ]; then
         # BTRFS is working with subvolumnes for snapshots / ext4 has no SubVolumes
         subVolumeDir=""
         if [ "${hddFormat}" = "btrfs" ]; then
-          subVolumeDir="/"
+          subVolumeDir="/WORKINGDIR"
         fi
 
         # temp mount data drive
@@ -211,12 +211,8 @@ if [ "$1" = "status" ]; then
     hddFormat=$(lsblk -o FSTYPE,NAME,TYPE | grep part | grep "${hddDataPartition}" | cut -d " " -f 1)
     if [ "${hddFormat}" = "ext4" ]; then
        hddDataPartitionExt4=$hddDataPartition
-       subVolumeDir=""
     fi
-    if [ "${hddFormat}" = "btrfs" ]; then
-       subVolumeDir="/WORKINGDIR"
-    fi
-    hddRaspiData=$(sudo ls -l /mnt/hdd${subVolumeDir} | grep -c raspiblitz.conf)
+    hddRaspiData=$(sudo ls -l /mnt/hdd | grep -c raspiblitz.conf)
     echo "hddRaspiData=${hddRaspiData}"
 
     isSSD=$(sudo cat /sys/block/${hdd}/queue/rotational 2>/dev/null | grep -c 0)


### PR DESCRIPTION
This fixes :
```
# RASPIBLITZ DATA DRIVE Status

# BASICS
isMounted=1
isBTRFS=1
ls: cannot access '/mnt/hdd/WORKINGDIR': No such file or directory
```
when using `sudo ./config.scripts/blitz.datadrive.sh status` on btrfs