### PR TITLE
Fix hdd usage calculation

### DIFF
--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -187,7 +187,7 @@ if [ "$1" = "status" ]; then
     # STATUS INFO WHEN MOUNTED
 
     # output data drive
-    hddDataPartition=$(df | grep "/mnt/hdd" | cut -d " " -f 1 | cut -d "/" -f 3)
+    hddDataPartition=$(df | grep "/mnt/hdd$" | cut -d " " -f 1 | cut -d "/" -f 3)
     hdd=$(echo $hddDataPartition | sed 's/[0-9]*//g')
     hddFormat=$(lsblk -o FSTYPE,NAME,TYPE | grep part | grep "${hddDataPartition}" | cut -d " " -f 1)
     if [ "${hddFormat}" = "ext4" ]; then


### PR DESCRIPTION
## Changes
- Fix hdd usage calculation when having additional mounts nested under `/mnt/hdd` - for example when storing docker volumes somewhere in `/mnt/hdd/app-data`
<img width="498" alt="Screenshot 2020-09-27 at 11 47 39" src="https://user-images.githubusercontent.com/2972266/94361790-41ed0680-00b7-11eb-8fa3-f8b5a4a28a03.png">
