### PR TITLE
bitcoin.conf: add peerbloomfilters for bisq

### DIFF
--- a/home.admin/assets/bitcoin.conf
+++ b/home.admin/assets/bitcoin.conf
@@ -8,6 +8,7 @@ server=1
 daemon=1
 txindex=0
 disablewallet=1
+peerbloomfilters=1
 
 # Connection settings
 rpcuser=raspibolt


### PR DESCRIPTION
I am running my raspiblitz with these settings for a while and my and other people's Bisq is served without any problems.

TG FAQ entry previously:
```
How to connect Bisq to your own node

Edit the bitcoin.conf:  
sudo nano /mnt/hdd/bitcoin/bitcoin.conf

add the line:
peerbloomfilters=1

Restart bitcoind:  
sudo systemctl restart bitcoind

Get the bitcoin Tor address (same as shown on the display):
bitcoin-cli getnetworkinfo | jq .localaddresses

Set Custom Bitcoin Node in Bisq

Download, Install, and run Bisq on your preferred Operating System.
Go to Bisq Settings, Network Info, and choose "Custom Bitcoin Node".
Enter your the raspiblitz bitcoind onion address and then you will be asked to restart Bisq.

Example:  
weburlxxx123.onion:8333

Source:
wiki.ronindojo.io/Bisq
```