### PR TITLE
Add option to install pyblock

### DIFF
--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -99,7 +99,7 @@ if [ "${bos}" == "on" ]; then
   OPTIONS+=(BOS "Balance of Satoshis")
 fi
 if [ "${pyblock}" == "on" ]; then
-  OPTIONS+=(PYBLOCK "PyBLOCk")
+  OPTIONS+=(PYBLOCK "PyBlock")
 fi
 if [ "${thunderhub}" == "on" ]; then
   OPTIONS+=(THUB "ThunderHub")

--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -98,6 +98,9 @@ fi
 if [ "${bos}" == "on" ]; then
   OPTIONS+=(BOS "Balance of Satoshis")
 fi
+if [ "${pyblock}" == "on" ]; then
+  OPTIONS+=(PYBLOCK "PyBLOCk")
+fi
 if [ "${thunderhub}" == "on" ]; then
   OPTIONS+=(THUB "ThunderHub")
 fi
@@ -230,6 +233,9 @@ case $CHOICE in
             ;;
         BOS)
             sudo /home/admin/config.scripts/bonus.bos.sh menu
+            ;;
+		PYBLOCK)
+            sudo /home/admin/config.scripts/bonus.pyblock.sh menu
             ;;
         THUB)
             sudo /home/admin/config.scripts/bonus.thunderhub.sh menu

--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -18,6 +18,7 @@ if [ ${#LNBits} -eq 0 ]; then LNBits="off"; fi
 if [ ${#mempoolExplorer} -eq 0 ]; then mempoolExplorer="off"; fi
 if [ ${#faraday} -eq 0 ]; then faraday="off"; fi
 if [ ${#bos} -eq 0 ]; then bos="off"; fi
+if [ ${#pyblock} -eq 0 ]; then pyblock="off"; fi
 if [ ${#thunderhub} -eq 0 ]; then thunderhub="off"; fi
 
 # show select dialog
@@ -35,6 +36,7 @@ OPTIONS+=(a 'Mempool Explorer' ${mempoolExplorer})
 OPTIONS+=(j 'JoinMarket' ${joinmarket})
 OPTIONS+=(l 'Lightning Loop' ${loop})
 OPTIONS+=(o 'Balance of Satoshis' ${bos})
+OPTIONS+=(y 'PyBLOCK' ${pyblock})
 OPTIONS+=(f 'Faraday' ${faraday})
 OPTIONS+=(m 'lndmanage' ${lndmanage})
 
@@ -288,6 +290,21 @@ if [ "${bos}" != "${choice}" ]; then
   fi
 else
   echo "Balance of Satoshis setting unchanged."
+fi
+
+# PyBLOCK process choice
+choice="off"; check=$(echo "${CHOICES}" | grep -c "o")
+if [ ${check} -eq 1 ]; then choice="on"; fi
+if [ "${pyblock}" != "${choice}" ]; then
+  echo "PyBLOCK Setting changed .."
+  anychange=1
+  sudo -u admin /home/admin/config.scripts/bonus.pyblock.sh ${choice}
+  source /mnt/hdd/raspiblitz.conf
+  if [ "${pyblock}" =  "on" ]; then
+    sudo -u admin /home/admin/config.scripts/bonus.pyblock.sh menu
+  fi
+else
+  echo "PyBLOCK setting unchanged."
 fi
 
 # thunderhub process choice

--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -293,7 +293,7 @@ else
 fi
 
 # PyBLOCK process choice
-choice="off"; check=$(echo "${CHOICES}" | grep -c "o")
+choice="off"; check=$(echo "${CHOICES}" | grep -c "y")
 if [ ${check} -eq 1 ]; then choice="on"; fi
 if [ "${pyblock}" != "${choice}" ]; then
   echo "PyBLOCK Setting changed .."

--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -129,6 +129,18 @@ function bos() {
   fi
 }
 
+# command: pyblock
+# switch to the pyblock user for PyBLOCK
+function bos() {
+  if [ $(grep -c "pyblock=on" < /mnt/hdd/raspiblitz.conf) -eq 1 ]; then
+    echo "# switching to the pyblock user with the command: 'sudo su - pyblock'"
+    sudo su - pyblock
+  else
+    echo "PyBlock is not installed - to install run:"
+    echo "/home/admin/config.scripts/bonus.pyblock.sh on"
+  fi
+}
+
 # command: jm
 # switch to the joinmarket user for the JoininBox menu
 function jm() {

--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -131,7 +131,7 @@ function bos() {
 
 # command: pyblock
 # switch to the pyblock user for PyBLOCK
-function bos() {
+function pyblock() {
   if [ $(grep -c "pyblock=on" < /mnt/hdd/raspiblitz.conf) -eq 1 ]; then
     echo "# switching to the pyblock user with the command: 'sudo su - pyblock'"
     sudo su - pyblock

--- a/home.admin/config.scripts/bonus.pyblock.sh
+++ b/home.admin/config.scripts/bonus.pyblock.sh
@@ -46,6 +46,8 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   sudo -u pyblock pip3 install -r requirements.txt
   sudo apt-get install hexyl
 
+  # set PATH for the user
+  sudo bash -c "echo 'PATH=\$PATH:/home/pyblock/.local/bin/' >> /home/pyblock/.profile"
   
   # add user to group with admin access to lnd
   sudo /usr/sbin/usermod --append --groups lndadmin pyblock

--- a/home.admin/config.scripts/bonus.pyblock.sh
+++ b/home.admin/config.scripts/bonus.pyblock.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+ echo "config script to install, update or uninstall PyBlock"
+ echo "bonus.pyblock.sh [on|off|menu|update]"
+ exit 1
+fi
+
+source /mnt/hdd/raspiblitz.conf
+
+# add default value to raspi config if needed
+if ! grep -Eq "^pyblock=" /mnt/hdd/raspiblitz.conf; then
+  echo "pyblock=off" >> /mnt/hdd/raspiblitz.conf
+fi
+
+# show info menu
+if [ "$1" = "menu" ]; then
+  dialog --title " Info PyBlock " --msgbox "
+pyblock is a command line tool.
+Type: 'pyblock' in the command line to switch to the dedicated user.
+Then 'pyblock' for starting PyBlock.
+Usage: https://github.com/curly60e/pyblock/blob/master/README.md
+" 10 75
+  exit 0
+fi
+
+# install
+if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+
+  if [ $(sudo ls /home/pyblock/PyBLOCK 2>/dev/null | grep -c "bclock.conf") -gt 0 ]; then
+    echo "# FAIL - pyblock already installed"
+    sleep 3
+    exit 1
+  fi
+  
+  echo "*** INSTALL pyblocks***"
+  
+  # create bos user
+  sudo adduser --disabled-password --gecos "" pyblock
+
+  
+  # download source code
+  sudo -u pyblock git clone https://github.com/curly60e/pyblock.git /home/pyblock/PyBLOCK
+  cd /home/pyblock/PyBLOCK
+  sudo -u pyblock pip3 install -r requirements.txt
+  sudo apt-get install hexyl
+
+  
+  # add user to group with admin access to lnd
+  sudo /usr/sbin/usermod --append --groups lndadmin pyblock
+  
+  sudo rm -rf /home/pyblock/.bitcoin  # not a symlink.. delete it silently
+  sudo -u pyblock mkdir /home/pyblock/.bitcoin
+  sudo cp /mnt/hdd/bitcoin/bitcoin.conf /home/pyblock/.bitcoin/
+  sudo chown pyblock:pyblock /home/pyblock/.bitcoin/bitcoin.conf
+
+  # make sure symlink to central app-data directory exists ***"
+  sudo rm -rf /home/pyblock/.lnd  # not a symlink.. delete it silently
+  # create symlink
+  sudo ln -s "/mnt/hdd/app-data/lnd/" "/home/pyblock/.lnd"
+  
+  ## Create conf
+  # from xxd -p bclock.conf | tr -d '\n'
+  echo 80037d710028580700000069705f706f727471015807000000687474703a2f2f710258070000007270637573657271035800000000710458070000007270637061737371056804580a000000626974636f696e636c697106581a0000002f7573722f6c6f63616c2f62696e2f626974636f696e2d636c697107752e0a | xxd -r -p -  ~/bclock.conf
+  sudo mv ~/bclock.conf /home/pyblock/bclock.conf
+  sudo chown pyblock:pyblock /home/pyblock/bclock.conf
+
+  # from xxd -p blndconnect.conf | tr -d '\n'
+  echo 80037d710028580700000069705f706f72747101580000000071025803000000746c737103680258080000006d616361726f6f6e7104680258020000006c6e710558140000002f7573722f6c6f63616c2f62696e2f6c6e636c697106752e0a | xxd -r -p -  ~/blndconnect.conf
+  sudo mv ~/blndconnect.conf /home/pyblock/blndconnect.conf
+  sudo chown pyblock:pyblock /home/pyblock/blndconnect.conf
+
+  # setting value in raspi blitz config
+  sudo sed -i "s/^pyblock=.*/pyblock=on/g" /mnt/hdd/raspiblitz.conf
+  
+  ## pyblock short command
+  sudo bash -c "echo 'alias pyblock=\"cd ~; python3 ~/PyBLOCK/PyBlock.py\"' >> /home/pyblock/.bashrc"
+  
+  echo "# Usage: https://github.com/alexbosworth/balanceofsatoshis/blob/master/README.md"
+  echo "# To start type: 'sudo su pyblock' in the command line."
+  echo "# Then pyblock"
+  echo "# To exit the user - type 'exit' and press ENTER"
+
+  exit 0
+fi
+
+# switch off
+if [ "$1" = "0" ] || [ "$1" = "off" ]; then
+
+  # setting value in raspi blitz config
+  sudo sed -i "s/^pyblock=.*/pyblock=off/g" /mnt/hdd/raspiblitz.conf
+  
+  echo "*** REMOVING PyBLOCK ***"
+  sudo userdel -rf pyblock
+  echo "# OK, pyblock is removed."
+  exit 0
+
+fi
+
+# update
+if [ "$1" = "update" ]; then
+  echo "*** UPDATING PyBLOCK ***"
+  cd /home/pyblock/PyBLOCK
+  sudo -u pyblock git update
+  echo "*** Updated to the latest in https://github.com/curly60e/pyblock ***"
+  exit 0
+fi
+
+echo "FAIL - Unknown Parameter $1"
+exit 1


### PR DESCRIPTION
Fixes issue #1648

This setup up the basic config for pyblock (bclock.conf and blndconnect.conf).

A pyblock command has been added to switch to the pyblock user and a pyblock alias has been added to bashrc to directly start PyBLOCK