### PR TITLE
Fix for btrfs migration with raid (usb drive) does not work

### DIFF
--- a/home.admin/_bootstrap.provision.sh
+++ b/home.admin/_bootstrap.provision.sh
@@ -596,7 +596,11 @@ source <(sudo /home/admin/config.scripts/blitz.datadrive.sh status)
 # update /etc/fstab
 echo "datadisk --> ${datadisk}" >> ${logFile}
 echo "datapartition --> ${datapartition}" >> ${logFile}
-sudo /home/admin/config.scripts/blitz.datadrive.sh fstab ${datapartition} >> ${logFile}
+if [ ${isBTRFS} -eq 0 ]; then
+  sudo /home/admin/config.scripts/blitz.datadrive.sh fstab ${datapartition} >> ${logFile}
+else
+  sudo /home/admin/config.scripts/blitz.datadrive.sh fstab ${datadisk} >> ${logFile}
+fi
 
 echo "DONE - Give raspi some cool off time after hard building .... 5 secs sleep" >> ${logFile}
 sleep 5

--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -345,7 +345,11 @@ if [ ${isMounted} -eq 0 ]; then
 
   # temp mount the HDD
   echo "Temp mounting data drive ($hddCandidate)" >> $logFile
-  source <(sudo /home/admin/config.scripts/blitz.datadrive.sh tempmount ${hddPartitionCandidate})
+  if [ "${hddFormat}" != "btrfs" ]; then
+    source <(sudo /home/admin/config.scripts/blitz.datadrive.sh tempmount ${hddPartitionCandidate})
+  else
+    source <(sudo /home/admin/config.scripts/blitz.datadrive.sh tempmount ${hddCandidate})
+  fi
   if [ ${#error} -gt 0 ]; then
     echo "Failed to tempmount the HDD .. awaiting user setup." >> $logFile
     sed -i "s/^state=.*/state=waitsetup/g" ${infoFile}

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -115,10 +115,13 @@ if [ "$1" = "status" ]; then
             fi
          fi
       else
-	 # Partion to be created is smaller than disk so this is not correct (but close)
-	 sizeDataPartition=$(sudo fdisk -l /dev/$testdevice | grep GiB | cut -d " " -f 5)
-         hddDataPartition="${testdevice}1"
-         hdd="${testdevice}"
+	     # make sure to use the biggest
+         if [ ${testsize} -gt ${sizeDataPartition} ]; then
+	        # Partion to be created is smaller than disk so this is not correct (but close)
+            sizeDataPartition=$(sudo fdisk -l /dev/$testdevice | grep GiB | cut -d " " -f 5)
+            hddDataPartition="${testdevice}1"
+            hdd="${testdevice}"
+	     fi
       fi
       
     done < .lsblk.tmp

--- a/home.admin/config.scripts/blitz.migration.sh
+++ b/home.admin/config.scripts/blitz.migration.sh
@@ -317,7 +317,11 @@ if [ "$1" = "import-gui" ]; then
   esac
 
   # now temp mount the HDD/SSD
-  source <(sudo /home/admin/config.scripts/blitz.datadrive.sh tempmount ${hddPartitionCandidate})
+  if [ ${isBTRFS} -eq 0 ]; then
+    source <(sudo /home/admin/config.scripts/blitz.datadrive.sh tempmount ${hddPartitionCandidate})
+  else
+    source <(sudo /home/admin/config.scripts/blitz.datadrive.sh tempmount ${hddCandidate})
+  fi
   if [ ${#error} -gt 0 ]; then
     echo "FAIL: Was not able to temp mount the HDD/SSD --> ${error}"
     exit 1


### PR DESCRIPTION
This prevents that the usbdrive is identified as hdd