### PR TITLE
#1723 512MB mempool on 4GB RPis

### DIFF
--- a/home.admin/_bootstrap.provision.sh
+++ b/home.admin/_bootstrap.provision.sh
@@ -147,6 +147,10 @@ if [ ${kbSizeRAM} -gt 1500000 ]; then
   sudo sed -i "s/^dbcache=.*/dbcache=1024/g" /mnt/hdd/${network}/${network}.conf
   sudo sed -i "s/^maxmempool=.*/maxmempool=256/g" /mnt/hdd/${network}/${network}.conf
 fi
+if [ ${kbSizeRAM} -gt 3500000 ]; then
+  echo "Detected RAM >3GB --> optimizing ${network}.conf"
+  sudo sed -i "s/^maxmempool=.*/maxmempool=512/g" /mnt/hdd/${network}/${network}.conf
+fi
 
 # link and copy HDD content into new OS on sd card
 echo "Copy HDD content for user admin" >> ${logFile}


### PR DESCRIPTION
If RaspberryPi has more than 3,5GB RAM mempool will now be extended to 512MB on updates/recovery.