### PR TITLE
Tor from source

### DIFF
--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -297,6 +297,9 @@ fi
 if [ "${pyblock}" == "on" ]; then
   OPTIONS+=(PYBLOCK "Update PyBLOCK")
 fi
+if [ "${runBehindTor}" == "on" ]; then
+  OPTIONS+=(TOR "Update Tor from the source code")
+fi
 
 CHOICE=$(whiptail --clear --title "Update Options" --menu "" 13 55 6 "${OPTIONS[@]}" 2>&1 >/dev/tty)
 
@@ -326,5 +329,11 @@ case $CHOICE in
     ;;
   PYBLOCK)
     /home/admin/config.scripts/bonus.pyblock.sh update
+    ;;
+  POOL)
+    /home/admin/config.scripts/bonus.pool.sh update  
+    ;;
+  TOR)
+    sudo /home/admin/config.scripts/internet.tor.sh update  
     ;;
 esac

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -478,7 +478,7 @@ if [ "$1" = "update" ]; then
   sudo apt build-dep -y tor deb.torproject.org-keyring
   rm -rf /home/admin/download/debian-packages
   mkdir -p /home/admin/download/debian-packages
-  cd home/admin/download/debian-packages
+  cd /home/admin/download/debian-packages
   echo "# Building Tor from the source code ..."
   apt source tor
   cd tor-*


### PR DESCRIPTION
as suggested in: https://github.com/rootzoll/raspiblitz/issues/1752#issuecomment-726746955

During the build process the node is running normally.
Tor is only restarted to change to the updated .deb package.