### PR TITLE
Fix missing torsocks

### DIFF
--- a/home.admin/config.scripts/bonus.kindle-display.sh
+++ b/home.admin/config.scripts/bonus.kindle-display.sh
@@ -29,6 +29,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   isInstalled=$(sudo ls $HOME_DIR 2>/dev/null | grep -c 'kindle-display')
   if [ ${isInstalled} -eq 0 ]; then
     # install dependencies
+	sudo apt update
     sudo apt install -y firefox-esr pngcrush jo jq
 
     # install nodeJS
@@ -68,7 +69,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 DISPLAY_SERVER_PORT=$SERVER_PORT
 
 # Require Tor for outside API calls
-DISPLAY_FORCE_TOR=true
+DISPLAY_FORCE_TOR=false
 
 # Bitcoin RPC credentials for getting the blockcount.
 # Omit these setting to use blockchain.info as a fallback.

--- a/home.admin/config.scripts/bonus.kindle-display.sh
+++ b/home.admin/config.scripts/bonus.kindle-display.sh
@@ -30,7 +30,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   if [ ${isInstalled} -eq 0 ]; then
     # install dependencies
 	sudo apt update
-    sudo apt install -y firefox-esr pngcrush jo jq
+    sudo apt install -y firefox-esr pngcrush jo jq torsocks
 
     # install nodeJS
     /home/admin/config.scripts/bonus.nodejs.sh on
@@ -69,7 +69,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 DISPLAY_SERVER_PORT=$SERVER_PORT
 
 # Require Tor for outside API calls
-DISPLAY_FORCE_TOR=false
+DISPLAY_FORCE_TOR=true
 
 # Bitcoin RPC credentials for getting the blockcount.
 # Omit these setting to use blockchain.info as a fallback.

--- a/home.admin/config.scripts/bonus.kindle-display.sh
+++ b/home.admin/config.scripts/bonus.kindle-display.sh
@@ -29,7 +29,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   isInstalled=$(sudo ls $HOME_DIR 2>/dev/null | grep -c 'kindle-display')
   if [ ${isInstalled} -eq 0 ]; then
     # install dependencies
-	sudo apt update
+    sudo apt update
     sudo apt install -y firefox-esr pngcrush jo jq torsocks
 
     # install nodeJS


### PR DESCRIPTION
In version 1.6.2, torsocks is missing and the server call fails.

I fixed it by installing torsocks 

This should fix the problem in issue #1785 

I added also a
apt-get update, as I had problems installing firefox-esr without doing an update:
```
Err:1 http://raspbian.raspberrypi.org/raspbian buster/main armhf firefox-esr armhf 78.4.1esr-1~deb10u1+rpi1
  404  Not Found [IP: 93.93.128.193 80]
E: Failed to fetch http://raspbian.raspberrypi.org/raspbian/pool/main/f/firefox-esr/firefox-esr_78.4.1esr-1~deb10u1+rpi1_armhf.deb  404  Not Found [IP: 93.93.128.193 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

After doing an apt-get update, I could install firefox-esr. Thus, I added this to the script.