### PR TITLE
#1798 start systemd services after hdd.boot and copy instead of link ssh keys

### DIFF
--- a/home.admin/40addHDD.sh
+++ b/home.admin/40addHDD.sh
@@ -114,13 +114,14 @@ else
 
 fi
 
-# link ssh directory from SD catd to HDD
+# link ssh directory from SD card to HDD
 echo "# --> SSH key settings"
 echo "# moving SSH pub keys to HDD"
 sudo cp -r /etc/ssh /mnt/hdd/ssh
 sudo rm -rf /etc/ssh
 sudo ln -s /mnt/hdd/ssh /etc/ssh
 echo "# OK"
+sudo /home/admin/config.scripts/blitz.systemd.sh update-sshd
 echo ""
 
 # set SetupState

--- a/home.admin/40addHDD.sh
+++ b/home.admin/40addHDD.sh
@@ -116,12 +116,14 @@ fi
 
 # link ssh directory from SD card to HDD
 echo "# --> SSH key settings"
-echo "# moving SSH pub keys to HDD"
+echo "# copying SSH pub keys to HDD"
 sudo cp -r /etc/ssh /mnt/hdd/ssh
-sudo rm -rf /etc/ssh
-sudo ln -s /mnt/hdd/ssh /etc/ssh
+# just copy dont link anymore
+# see: https://github.com/rootzoll/raspiblitz/issues/1798
+#sudo rm -rf /etc/ssh
+#sudo ln -s /mnt/hdd/ssh /etc/ssh
+#sudo /home/admin/config.scripts/blitz.systemd.sh update-sshd
 echo "# OK"
-sudo /home/admin/config.scripts/blitz.systemd.sh update-sshd
 echo ""
 
 # set SetupState

--- a/home.admin/_bootstrap.provision.sh
+++ b/home.admin/_bootstrap.provision.sh
@@ -139,6 +139,7 @@ else
 fi
 sudo rm -rf /etc/ssh >> ${logFile} 2>&1
 sudo ln -s /mnt/hdd/ssh /etc/ssh >> ${logFile} 2>&1
+sudo /home/admin/config.scripts/blitz.systemd.sh update-sshd >> ${logFile} 2>&1
 
 # optimze if RAM >1GB
 kbSizeRAM=$(cat /proc/meminfo | grep "MemTotal" | sed 's/[^0-9]*//g')

--- a/home.admin/_bootstrap.provision.sh
+++ b/home.admin/_bootstrap.provision.sh
@@ -132,14 +132,17 @@ sudo sed -i "s/^alias=.*/alias=${hostname}/g" /home/admin/assets/lnd.${network}.
 # link old SSH PubKeys
 # so that client ssh_known_hosts is not complaining after update
 if [ -d "/mnt/hdd/ssh" ]; then
-  echo "Old SSH PubKey exists on HDD > just linking them" >> ${logFile}
+  echo "Old SSH PubKey exists on HDD > copy them HDD to SD card for next start" >> ${logFile}
+  sudo cp -r /mnt/hdd/ssh/* /etc/ssh/ >> ${logFile} 2>&1
 else
-  echo "No SSH PubKey exists on HDD > copy from SD card and linking them" >> ${logFile}
+  echo "No SSH PubKey exists on HDD > copy from SD card to HDD as backup" >> ${logFile}
   sudo cp -r /etc/ssh /mnt/hdd/ssh >> ${logFile} 2>&1
 fi
-sudo rm -rf /etc/ssh >> ${logFile} 2>&1
-sudo ln -s /mnt/hdd/ssh /etc/ssh >> ${logFile} 2>&1
-sudo /home/admin/config.scripts/blitz.systemd.sh update-sshd >> ${logFile} 2>&1
+# just copy - dont link anymore so that sshd will also start without HDD connected
+# see: https://github.com/rootzoll/raspiblitz/issues/1798
+#sudo rm -rf /etc/ssh >> ${logFile} 2>&1
+#sudo ln -s /mnt/hdd/ssh /etc/ssh >> ${logFile} 2>&1
+#sudo /home/admin/config.scripts/blitz.systemd.sh update-sshd >> ${logFile} 2>&1
 
 # optimze if RAM >1GB
 kbSizeRAM=$(cat /proc/meminfo | grep "MemTotal" | sed 's/[^0-9]*//g')

--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -252,7 +252,7 @@ fi
 # SSH SERVER CERTS RESET
 # if a file called 'ssh.reset' gets
 # placed onto the boot part of
-# the sd card - switch to hdmi
+# the sd card - delete old ssh data
 ################################
 
 sshReset=$(sudo ls /boot/ssh.reset* 2>/dev/null | grep -c reset)

--- a/home.admin/assets/bootstrap.service
+++ b/home.admin/assets/bootstrap.service
@@ -3,7 +3,7 @@
 
 [Unit]
 Description=execute on every startup before everything else
-After=network.target
+After=network.target mnt-hdd.mount
 
 [Service]
 User=root

--- a/home.admin/config.scripts/blitz.systemd.sh
+++ b/home.admin/config.scripts/blitz.systemd.sh
@@ -3,21 +3,9 @@
 # command info
 if [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  echo "additional systemd services"
- echo "blitz.systemd.sh update-sshd"
  echo "blitz.systemd.sh log blockchain STARTED"
  echo "blitz.systemd.sh log lightning STARTED"
  exit 1
-fi
-
-# edit of sshd service file
-if [ "${1}" == "update-sshd" ]; then
-  echo "# DEACTIVATED: blitz.systemd.sh -> update sshd service config"
-  # echo "# blitz.systemd.sh -> update sshd service config"
-  # make sure its updated to wait for HDD mount before start
-  # https://github.com/rootzoll/raspiblitz/issues/1785#issuecomment-730476628
-  # sudo sed -i "s/^After=.*/After=network.target auditd.service mnt-hdd.mount/g" /etc/systemd/system/sshd.service
-  # echo "# OK sshd config edit done and service restarted"
-  exit 0
 fi
 
 # check parameter

--- a/home.admin/config.scripts/blitz.systemd.sh
+++ b/home.admin/config.scripts/blitz.systemd.sh
@@ -11,14 +11,12 @@ fi
 
 # edit of sshd service file
 if [ "${1}" == "update-sshd" ]; then
-  echo "# blitz.systemd.sh -> update sshd service config"
+  echo "# DEACTIVATED: blitz.systemd.sh -> update sshd service config"
+  # echo "# blitz.systemd.sh -> update sshd service config"
   # make sure its updated to wait for HDD mount before start
   # https://github.com/rootzoll/raspiblitz/issues/1785#issuecomment-730476628
-  sudo sed -i "s/^After=.*/After=network.target auditd.service mnt-hdd.mount/g" /etc/systemd/system/sshd.service
-  # make sure sto restart service
-  sudo systemctl daemon-reload
-  sudo systemctl restart sshd
-  echo "# OK sshd config edit done and service restarted"
+  # sudo sed -i "s/^After=.*/After=network.target auditd.service mnt-hdd.mount/g" /etc/systemd/system/sshd.service
+  # echo "# OK sshd config edit done and service restarted"
   exit 0
 fi
 

--- a/home.admin/config.scripts/blitz.systemd.sh
+++ b/home.admin/config.scripts/blitz.systemd.sh
@@ -3,9 +3,23 @@
 # command info
 if [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  echo "additional systemd services"
+ echo "blitz.systemd.sh update-sshd"
  echo "blitz.systemd.sh log blockchain STARTED"
  echo "blitz.systemd.sh log lightning STARTED"
  exit 1
+fi
+
+# edit of sshd service file
+if [ "${1}" == "update-sshd" ]; then
+  echo "# blitz.systemd.sh -> update sshd service config"
+  # make sure its updated to wait for HDD mount before start
+  # https://github.com/rootzoll/raspiblitz/issues/1785#issuecomment-730476628
+  sudo sed -i "s/^After=.*/After=network.target auditd.service mnt-hdd.mount/g" /etc/systemd/system/sshd.service
+  # make sure sto restart service
+  sudo systemctl daemon-reload
+  sudo systemctl restart sshd
+  echo "# OK sshd config edit done and service restarted"
+  exit 0
 fi
 
 # check parameter

--- a/home.admin/config.scripts/blitz.web.sh
+++ b/home.admin/config.scripts/blitz.web.sh
@@ -124,6 +124,14 @@ elif [ "$1" = "1" ] || [ "$1" = "on" ]; then
   sudo apt-get update
   sudo apt-get install -y nginx apache2-utils
 
+  # additional config
+  sudo mkdir -p /etc/systemd/system/nginx.service.d
+  sudo tee /etc/systemd/system/nginx.service.d/raspiblitz.conf >/dev/null <<EOF
+    # DO NOT EDIT! This file is generate by raspiblitz and will be overwritten
+[Unit]
+After=network.target nss-lookup.target mnt-hdd.mount
+EOF
+
   # make sure that it is enabled and started
   sudo systemctl enable nginx 
   sudo systemctl start nginx

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -358,6 +358,7 @@ EOF
     # DO NOT EDIT! This file is generate by raspiblitz and will be overwritten
 [Service]
 ReadWriteDirectories=-/mnt/hdd/tor
+After=network.target nss-lookup.target mnt-hdd.mount
 EOF
 
   else

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -358,6 +358,7 @@ EOF
     # DO NOT EDIT! This file is generate by raspiblitz and will be overwritten
 [Service]
 ReadWriteDirectories=-/mnt/hdd/tor
+[Unit]
 After=network.target nss-lookup.target mnt-hdd.mount
 EOF
 


### PR DESCRIPTION
As pointed out by emzy in #1798 services that have data stored on hdd should make sure that hdd is mounted by the system to prevent race conditions. That might also be the reason for the "cant login per SSH" problems we saw in the past. So for the sshd it even seems beter to not link to the HDD at all for the keys and just keep a backup copy in the HDD .. so that you can still ssh into the raspiblitz if HDD is disconnected or has problems to mount because of data corruption.