### PR TITLE
bump joininbox to v0.1.15

### DIFF
--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -130,7 +130,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo -u joinmarket git clone https://github.com/openoms/joininbox.git /home/joinmarket/joininbox
     # check the latest at:
     # https://github.com/openoms/joininbox/releases/
-    sudo -u joinmarket git reset --hard v0.1.14
+    sudo -u joinmarket git reset --hard v0.1.15
     sudo -u joinmarket cp /home/joinmarket/joininbox/scripts/* /home/joinmarket/
     sudo -u joinmarket cp /home/joinmarket/joininbox/scripts/.* /home/joinmarket/ 2>/dev/null
     sudo chmod +x /home/joinmarket/*.sh


### PR DESCRIPTION
Few minor changes in the raspiblitz context, installs the same way.
No problem if does not make it to v1.6.2, the JoininBox scripts can be updated separately within the joinmarket user.

- installs JoinMarket v0.8.0
- advanced update options in menu to help testing
- skip libsecp256k1 tests on update and testPR
- usability improvements

Related: https://github.com/rootzoll/raspiblitz/issues/1813

https://github.com/openoms/joininbox/releases/tag/v0.1.15