### PR TITLE
txindex: only restart bitcoind when running

### DIFF
--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -317,7 +317,7 @@ EOF
   if [ "${blockfilterindex}" = "0" ]; then
     sudo sed -i "s/^blockfilterindex=.*/blockfilterindex=1/g" /mnt/hdd/${network}/${network}.conf
     echo "# switching blockfilterindex=1"
-    isBitcoinRunning=$(sudo systemctl is-active ${network}d | grep -c "^active")
+    isBitcoinRunning=$(systemctl is-active ${network}d | grep -c "^active")
     if [ ${isBitcoinRunning} -eq 1 ]; then
       echo "# ${network}d is running - so restarting"
       sudo systemctl restart ${network}d

--- a/home.admin/config.scripts/network.txindex.sh
+++ b/home.admin/config.scripts/network.txindex.sh
@@ -64,17 +64,22 @@ fi
 # switch on
 ###################
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
-
   # check txindex (parsed and sourced from bitcoin network config above)
   if [ ${txindex} == 0 ]; then
     sudo sed -i "s/^txindex=.*/txindex=1/g" /mnt/hdd/${network}/${network}.conf
-    echo "switching txindex=1 and restarting ${network}d"
-    sudo systemctl restart ${network}d
-    echo "The indexing takes ~7h on an RPi4 with SSD"
-    echo "monitor with: sudo tail -n 20 -f /mnt/hdd/${network}${pathAdd}/debug.log"
+    echo "# switching txindex=1"
+    isBitcoinRunning=$(systemctl is-active ${network}d | grep -c "^active")
+    if [ ${isBitcoinRunning} -eq 1 ]; then
+      echo "# ${network}d is running - so restarting"
+      sudo systemctl restart ${network}d
+    else
+      echo "# ${network}d is not running - so NOT restarting"
+    fi
+    echo "# The indexing takes ~7h on an RPi4 with SSD"
+    echo "# monitor with: sudo tail -n 20 -f /mnt/hdd/${network}${pathAdd}/debug.log"
     exit 0
   else
-    echo "txindex is already active"
+    echo "# txindex is already active"
     exit 0
   fi
 fi


### PR DESCRIPTION
fixes: https://github.com/rootzoll/raspiblitz/issues/1830

An edge case only if the recovery process starts with a new blockchain database without txindex, but BTC-RPC-Explorer enabled.