### PR TITLE
build_sdcard.sh: prepare for the 64bit RaspberryOS

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -971,7 +971,7 @@ if [ "${lcdInstalled}" == "true" ]; then
     cp ./cmdline.txt /boot/
 
     # touch screen calibration
-    apt-get install xserver-xorg-input-evdev
+    apt-get install -y xserver-xorg-input-evdev
     cp -rf /usr/share/X11/xorg.conf.d/10-evdev.conf /usr/share/X11/xorg.conf.d/45-evdev.conf
     # TODO manual touchscreen calibration option
     # https://github.com/tux1c/wavesharelcd-64bit-rpi#adapting-guide-to-other-lcds

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -144,7 +144,7 @@ else
 fi
 
 if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "dietpi" ] || \
-   [ "${baseImage}" = "debian_rpi64" ]; then
+   [ "${baseImage}" = "raspios_arm64" ]||[ "${baseImage}" = "debian_rpi64" ]; then
   # fixing locales for build
   # https://github.com/rootzoll/raspiblitz/issues/138
   # https://daker.me/2014/10/how-to-fix-perl-warning-setting-locale-failed-in-raspbian.html

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -139,7 +139,8 @@ else
   echo "OK running ${baseImage}"
 fi
 
-if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "dietpi" ] ; then
+if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "dietpi" ] || \
+   [ "${baseImage}" = "raspios_arm64" ]; then
   # fixing locales for build
   # https://github.com/rootzoll/raspiblitz/issues/138
   # https://daker.me/2014/10/how-to-fix-perl-warning-setting-locale-failed-in-raspbian.html
@@ -190,10 +191,14 @@ sudo apt upgrade -f -y
 echo ""
 echo "*** PREPARE ${baseImage} ***"
 
-# special prepare when DietPi
-if [ "${baseImage}" = "dietpi" ]; then
-  echo "renaming dietpi user to pi"
+# make sure the pi user is present
+if [ "$(compgen -u | grep -c dietpi)" -gt 0 ];then
+  echo "# Renaming dietpi user to pi"
   sudo usermod -l pi dietpi
+elif [ "$(compgen -u | grep -c pi)" -eq 0 ];then  
+  echo "# Adding the user pi"
+  sudo adduser --disabled-password --gecos "" pi
+  sudo adduser pi sudo
 fi
 
 # special prepare when Raspbian
@@ -248,13 +253,6 @@ if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "raspios_arm64" ]; then
   # https://www.reddit.com/r/linux/comments/lbu0t1/microsoft_repo_installed_on_all_raspberry_pis/
   sudo rm -f /etc/apt/sources.list.d/vscode.list 
   sudo rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
-fi
-
-# special prepare when Ubuntu or Armbian
-if [ "${baseImage}" = "ubuntu" ] || [ "${baseImage}" = "armbian" ]; then
-  # make user pi and add to sudo
-  sudo adduser --disabled-password --gecos "" pi
-  sudo adduser pi sudo
 fi
 
 # special prepare when Nvidia Jetson Nano

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -160,6 +160,11 @@ if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "dietpi" ] || \
 
   # remove unneccesary files
   sudo rm -rf /home/pi/MagPi
+
+  if [ ! -f /etc/apt/sources.list.d/raspi.list ]; then
+    echo "# Add the archive.raspberrypi.org/debian/ to the sources.list"
+    echo "deb http://archive.raspberrypi.org/debian/ buster main" | sudo tee -a /etc/apt/sources.list.d/raspi.list
+  fi
 fi
 
 # remove some (big) packages that are not needed

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -245,7 +245,9 @@ if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "raspios_arm64" ]; then
   else
     echo "$fsOption2 already in $kernelOptionsFile"
   fi
-
+  # https://www.reddit.com/r/linux/comments/lbu0t1/microsoft_repo_installed_on_all_raspberry_pis/
+  sudo rm -f /etc/apt/sources.list.d/vscode.list 
+  sudo rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
 fi
 
 # special prepare when Ubuntu or Armbian


### PR DESCRIPTION
includes the changes from: https://github.com/rootzoll/raspiblitz/pull/1833 but rebased to the dev branch

d4c8d106 build_sdcard: default to the dev branch
54f9399a don't reboot automatically for rpios_arm64 display
e54fc750 fix indentations
14e08818 rename raspbian64 to raspios_arm64 for clarity
a8c42b02 link and sha256sum for raspios_arm64-2020-08-24
529cb578 RPi: disable propriatery audio and V3D drivers
27807010 don't enable I2C, SPI and UART ports by default
a757a5a5 build_sdcard: fix autostart for raspbian64
42e8eced build_sdcard: use full path to LCD driver
70442864 build_sdcard: add LCD driver for raspbian64