### PR TITLE
RTL: fix loop HTTPS and macaroon auth

### DIFF
--- a/home.admin/config.scripts/bonus.loop.sh
+++ b/home.admin/config.scripts/bonus.loop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/lightninglabs/loop/releases-
-pinnedVersion="v0.11.1-beta"
+pinnedVersion="v0.11.2-beta"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then


### PR DESCRIPTION
as discussed in:
https://github.com/rootzoll/raspiblitz/issues/1852

added a CLI option to update RTL to the latest master with:
`bonus.rtl.sh update commit` 
for testing.

Ideally should update and test the `pinnedVersion` to the upcoming RTL v0.10.0