### PR TITLE
pool: update to v0.3.4, start only if ready

### DIFF
--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -360,6 +360,7 @@ if [ "${pool}" != "${choice}" ]; then
   anychange=1
   sudo -u admin /home/admin/config.scripts/bonus.pool.sh ${choice}
   if [ "${choice}" =  "on" ]; then
+    sudo systemctl start poold
     sudo -u admin /home/admin/config.scripts/bonus.pool.sh menu
   fi
 else

--- a/home.admin/config.scripts/bonus.pool.sh
+++ b/home.admin/config.scripts/bonus.pool.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/lightninglabs/pool/releases/
-pinnedVersion="v0.3.3-alpha"
+pinnedVersion="v0.3.4-alpha"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -125,9 +125,13 @@ WantedBy=multi-user.target
     echo "the poold.service already installed."
   fi
 
-  # start service
-  sudo systemctl start poold.service
-
+  source /home/admin/raspiblitz.info
+  if [ "${state}" == "ready" ]; then
+    echo "# OK - the poold.service is enabled, system is on ready so starting service"
+    sudo systemctl start poold
+  else
+    echo "# OK - the poold.service is enabled, to start manually use: sudo systemctl start poold"
+  fi
   # setting value in raspi blitz config
   sudo sed -i "s/^pool=.*/pool=on/g" /mnt/hdd/raspiblitz.conf
   


### PR DESCRIPTION
Fixing that poold fails during recovery (because needs lnd.service running)

related:
https://github.com/rootzoll/raspiblitz/issues/1906