### PR TITLE
txindex: restart bitcoind only if already active

### DIFF
--- a/home.admin/config.scripts/network.txindex.sh
+++ b/home.admin/config.scripts/network.txindex.sh
@@ -67,11 +67,17 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   # check txindex (parsed and sourced from bitcoin network config above)
   if [ ${txindex} == 0 ]; then
+    echo "switching txindex=1"
     sudo sed -i "s/^txindex=.*/txindex=1/g" /mnt/hdd/${network}/${network}.conf
-    echo "switching txindex=1 and restarting ${network}d"
-    sudo systemctl restart ${network}d
-    echo "The indexing takes ~7h on an RPi4 with SSD"
-    echo "monitor with: sudo tail -n 20 -f /mnt/hdd/${network}${pathAdd}/debug.log"
+    isBitcoinRunning=$(sudo systemctl is-active ${network}d | grep -c "^active")
+    if [ ${isBitcoinRunning} -eq 1 ]; then
+      echo "# ${network}d is running - so restarting"
+      echo "The indexing takes ~7h on an RPi4 with SSD"
+      echo "monitor with: sudo tail -n 20 -f /mnt/hdd/${network}${pathAdd}/debug.log"
+      sudo systemctl restart ${network}d
+    else
+      echo "# ${network}d is not running - so NOT restarting"
+    fi
     exit 0
   else
     echo "txindex is already active"


### PR DESCRIPTION
activated BTCRPCExplorer only in the raspiblitz.conf without switching txindex on and it got stuck on recovery similar to: https://github.com/rootzoll/raspiblitz/pull/1722

This PR only fixing this edge case.

txindex should be already on if BTC-RPC-Explorer was installed previously.

Related: #1906 

If someone would be stuck during recovery after `txindex` is activated run:
`sudo systemctl stop bitcoind`
and the recovery process will continue.