### PR TITLE
use "netstat -an" to prevent IP resolution

### DIFF
--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -73,7 +73,7 @@ if [ "$1" = "status" ]; then
       echo "publicIP='${cleanip}'"
     fi
     echo "portTCP='50001'"
-    localPortRunning=$(sudo netstat -a | grep -c '0.0.0.0:50001')
+    localPortRunning=$(sudo netstat -an | grep -c '0.0.0.0:50001')
     echo "localTCPPortActive=${localPortRunning}"
 
     publicPortRunning=$(nc -z -w6 ${publicip} 50001 2>/dev/null; echo $?)
@@ -85,7 +85,7 @@ if [ "$1" = "status" ]; then
       echo "publicTCPPortAnswering=0"
     fi
     echo "portHTTP='50002'"
-    localPortRunning=$(sudo netstat -a | grep -c '0.0.0.0:50002')
+    localPortRunning=$(sudo netstat -an | grep -c '0.0.0.0:50002')
     echo "localHTTPPortActive=${localPortRunning}"
     publicPortRunning=$(nc -z -w6 ${publicip} 50002 2>/dev/null; echo $?)
     if [ "${publicPortRunning}" == "0" ]; then


### PR DESCRIPTION
a call to `netstat -a` in file ` /home/admin/config.scripts/bonus.electrs.sh` creates lots of reverse DNS requests.

Use `netstat -an` instead

seems that issue #1909 is related to this PR