### PR TITLE
Always set maxmempool to 300MB in bitcoin.conf

### DIFF
--- a/home.admin/_bootstrap.provision.sh
+++ b/home.admin/_bootstrap.provision.sh
@@ -149,11 +149,11 @@ kbSizeRAM=$(cat /proc/meminfo | grep "MemTotal" | sed 's/[^0-9]*//g')
 if [ ${kbSizeRAM} -gt 1500000 ]; then
   echo "Detected RAM >1GB --> optimizing ${network}.conf"
   sudo sed -i "s/^dbcache=.*/dbcache=1024/g" /mnt/hdd/${network}/${network}.conf
-  sudo sed -i "s/^maxmempool=.*/maxmempool=256/g" /mnt/hdd/${network}/${network}.conf
+  sudo sed -i "s/^maxmempool=.*/maxmempool=300/g" /mnt/hdd/${network}/${network}.conf
 fi
 if [ ${kbSizeRAM} -gt 3500000 ]; then
   echo "Detected RAM >3GB --> optimizing ${network}.conf"
-  sudo sed -i "s/^maxmempool=.*/maxmempool=512/g" /mnt/hdd/${network}/${network}.conf
+  sudo sed -i "s/^maxmempool=.*/maxmempool=300/g" /mnt/hdd/${network}/${network}.conf
 fi
 
 # link and copy HDD content into new OS on sd card


### PR DESCRIPTION
When the mempool fills up to around 500MB, this causes the mempool.space backend to crash on RPI due to OOM. Additionally, raising this above 300MB on a local RPI node arguably isn't a good idea anyway, because:

* On a Raspberry Pi running RaspiBlitz, it takes over 30 minutes for Bitcoin Core to load 478MB of transactions from disk in mempool.dat into RAM, and during this time the RPI's CPU utilization is maxed out
* If you have a 512MB mempool and all your peers have 300MB, you'll broadcast transactions that fit in your mempool but are rejected by all of your peers
* If you connect an SPV wallet to your node, your wallet will think the TX is "in the mempool" despite actually being purged from the entire Bitcoin P2P network, and never attempt to rebroadcast the purged TX
* In any case, the RPI has very limited RAM, so no point in wasting RAM on having such a large sized mempool for bitcoind

Fixes #2008 