### PR TITLE
Update blitz.notify.sh

### DIFF
--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -81,6 +81,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   # install sstmp if not already present
   if ! command -v ssmtp >/dev/null; then
+    [ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ] && sudo apt-get update
     sudo apt-get install -y ssmtp
   fi
 


### PR DESCRIPTION
Make sure to run apt-get update unless it has been already been run recently (within last 7 days).

I got the one-liner from here: https://askubuntu.com/questions/410247/how-to-know-last-time-apt-get-update-was-executed/904259#904259

The problem if `apt-get update` is not run "recently" before apt-get install is that the system could try to use an outdated apt/repo mirror (which happend to me just now).