### PR TITLE
Refactor parameters on sd crad build script with FATPACK

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -538,7 +538,7 @@ Work notes for the process of producing a new SD card image release:
 * In terminal `ssh pi@[IP-OF-RASPIBLITZ]`
 * Password is `raspberry`
 * Run the following command BUT REPLACE `[BRANCH]` with the branch-string of your latest version
-* `wget https://raw.githubusercontent.com/rootzoll/raspiblitz/[BRANCH]/build_sdcard.sh && sudo bash build_sdcard.sh '[BRANCH]'`
+* `wget https://raw.githubusercontent.com/rootzoll/raspiblitz/[BRANCH]/build_sdcard.sh && sudo bash build_sdcard.sh true rootzoll [BRANCH] true true true`
 * Monitor/Check outputs for warnings/errors - install LCD
 * Login new with `ssh admin@[IP-OF-RASPIBLITZ]` (pw: raspiblitz) and run `./XXprepareRelease.sh`
 * Disconnect WiFi/LAN on build laptop (hardware switch off) and shutdown

--- a/README.md
+++ b/README.md
@@ -1109,20 +1109,20 @@ If done successfully, simply put the SD card into the RaspiBlitz and power on ag
 
 A ready-to-use SD card image of RaspiBlitz is provided by us for download, to get everybody started quickly (see above). But if you want to build that image yourself - here is a quick guide:
 
-* Get a fresh Raspbian RASPBIAN BUSTER WITH DESKTOP card image: [DOWNLOAD](https://www.raspberrypi.org/downloads/raspbian/).
+* Get a fresh RaspiOS 64-bit: [DOWNLOAD](https://downloads.raspberrypi.org/raspios_arm64/images).
 * Write the image to an SD card: [TUTORIAL](https://www.raspberrypi.org/documentation/installation/installing-images/README.md).
-* Add a file called `ssh` to the root of the SD card when mounted to enable SSH login.
-* Start the card in Raspi and login via SSH with `ssh pi@[IP-OF-YOUR-RASPI]`. Password is `raspberry`.
+* Add a file called `ssh` to the root of the SD card when mounted on your laptop to enable SSH login.
+* Start the card on a Raspi and login via SSH with `ssh pi@[IP-OF-YOUR-RASPI]`. Password is `raspberry`.
 
 Now you are ready to start the SD card build script (check the code to see if the installation and config are OK for you). Copy the following command into your terminal and execute:
 
-`wget https://raw.githubusercontent.com/rootzoll/raspiblitz/v1.6/build_sdcard.sh && sudo bash build_sdcard.sh`
+`wget https://raw.githubusercontent.com/rootzoll/raspiblitz/v1.7/build_sdcard.sh && sudo bash build_sdcard.sh`
 
 As you can see from the URL, you can find the build script in this Git repo under `build_sdcard.sh`. You can check what gets installed and configured in detail. Feel free to post improvements as pull requests.
 
-The whole build process takes a while. At the end the LCD drivers get installed and a reboot is needed. A user `admin` is created during the process. Remember the default password is now `raspiblitz`. You can login per SSH again - this time use admin: `ssh admin@[IP-OF-YOUR-RASPI]`. An installer of the SD card image should automatically launch. If you do not want to continue with the installation at this moment and use this sd card as a template for setting up multiple RaspiBlitzes, click `Cancel` and run `/home/admin/XXprepareRelease.sh`. Once you see the LCD going white and the activity LED of the pi starts going dark, you can unplug power and remove the SD card. You have now built your own RaspiBlitz SD card image.
+The whole build process takes a while. At the end the LCD drivers get installed and a reboot is needed. A user `admin` is created during the process. Remember the default password is now `raspiblitz`. You can login per SSH again - this time use admin: `ssh admin@[IP-OF-YOUR-RASPI]`. The install dialog of the RaspiBlitz schould automatically start. If you do not want to continue with the installation at this moment and use this sd card as a template for setting up multiple RaspiBlitzes, click `Cancel` and run `/home/admin/XXprepareRelease.sh`. Once you see the LCD going white and the activity LED of the pi starts going dark, you can unplug power and remove the SD card. You have now built your own RaspiBlitz SD card image.
 
-*Note: If you plan to use your self-built sd card as a MASTER copy to backup image and distribute it. Use a smaller 8GB card for that. This way it's ensured that it will fit on every 16 GB card recommended for RaspiBlitz later on.*
+*Note: If you plan to use your self-build sd card as a MASTER copy and distribute it: Use a smaller 8GB card for that. This way it's ensured that it will fit on every 16 GB card recommended for RaspiBlitz later on.*
 
 * [Can I run RaspiBlitz on other computers than RaspberryPi?](FAQ.md#can-i-run-raspiblitz-on-other-computers-than-raspberrypi)
 * [How can I build an SD card other than the master branch?](FAQ.md#how-can-i-build-an-sd-card-other-then-the-master-branch)

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -29,10 +29,10 @@ if [ ${#fatpack} -eq 0 ]; then
   fatpack="false"
 fi
 if [ "${fatpack}" != "true" ] && [ "${fatpack}" != "false" ]; then
-  echo "ERROR: fatpack parameter needs to be either 'true' or 'false'"
+  echo "ERROR: FATPACK parameter needs to be either 'true' or 'false'"
   exit 1
 else
-  echo "will use fatpack --> '${fatpack}'"
+  echo "1) will use FATPACK --> '${fatpack}'"
 fi
 
 # 2st optional paramater: GITHUB-USERNAME
@@ -45,7 +45,7 @@ githubUser="$2"
 if [ ${#githubUser} -eq 0 ]; then
   githubUser="rootzoll"
 fi
-echo "will use code from user --> '${githubUser}'"
+echo "2) will use GITHUB-USERNAME --> '${githubUser}'"
 
 # 3rd optional paramater: GITHUB-BRANCH
 # -------------------------------------
@@ -54,7 +54,7 @@ githubBranch="$3"
 if [ ${#githubBranch} -eq 0 ]; then
   githubBranch="dev"
 fi
-echo "will use code from branch --> '${githubBranch}'"
+echo "3) will use GITHUB-BRANCH --> '${githubBranch}'"
 
 # 4rd optional paramater: LCD-DRIVER
 # ----------------------------------------
@@ -69,7 +69,7 @@ if [ "${lcdInstalled}" != "false" ] && [ "${lcdInstalled}" != "GPIO" ]; then
   echo "ERROR: LCD-DRIVER parameter needs to be either 'false' or 'GPIO'"
   exit 1
 else
-  echo "will use LCD-DRIVER --> '${lcdInstalled}'"
+  echo "4) will use LCD-DRIVER --> '${lcdInstalled}'"
 fi
 
 # 5rd optional paramater: TWEAK-BOOTDRIVE
@@ -85,7 +85,7 @@ if [ "${tweakBootdrives}" != "true" ] && [ "${tweakBootdrives}" != "false" ]; th
   echo "ERROR: TWEAK-BOOTDRIVE parameter needs to be either 'true' or 'false'"
   exit 1
 else
-  echo "will use TWEAK-BOOTDRIVE --> '${tweakBootdrives}'"
+  echo "5) will use TWEAK-BOOTDRIVE --> '${tweakBootdrives}'"
 fi
 
 # 6rd optional paramater: WIFI
@@ -98,7 +98,7 @@ modeWifi="$6"
 if [ ${#modeWifi} -eq 0 ] || [ "${modeWifi}" == "true" ]; then
   modeWifi="US"
 fi
-echo "will use WIFI --> '${modeWifi}'"
+echo "6) will use WIFI --> '${modeWifi}'"
 
 echo -n "Do you agree with all parameters above? (yes/no) "
 read installRaspiblitzAnswer

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -1042,7 +1042,7 @@ if [ "${lcdInstalled}" != "false" ]; then
 else
   echo "Your SD Card Image for RaspiBlitz is ready."
 fi
-echo "Take the chance & look thru the output above if you can spot any errror."
+echo "Take the chance & look thru the output above if you can spot any error."
 echo ""
 if [ "${lcdInstalled}" != "false" ]; then
   echo "After final reboot - your SD Card Image is ready."

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -10,73 +10,97 @@
 
 echo ""
 echo "*****************************************"
-echo "* RASPIBLITZ SD CARD IMAGE SETUP v1.6   *"
+echo "* RASPIBLITZ SD CARD IMAGE SETUP v1.7   *"
 echo "*****************************************"
+echo "For details on optional parameters - see build script source code:"
 echo ""
 
-# 1st optional parameter is the BRANCH to get code from when
-# provisioning sd card with raspiblitz assets/scripts later on
-echo "*** CHECK INPUT PARAMETERS ***"
-wantedBranch="$1"
-if [ ${#wantedBranch} -eq 0 ]; then
-  wantedBranch="dev"
-else
-  if [ "${wantedBranch}" == "-h" -o "${wantedBranch}" == "--help" ]; then
-    echo "Usage: [branch] [github user] [root partition] [LCD screen installed true|false] [Wifi disabled true|false]"
-    echo "Example (USB boot, no LCD and no wifi): $0 v1.6 rootzoll /dev/sdb2 false true"
-    exit 1
-  fi
-fi
-echo "will use code from branch --> '${wantedBranch}'"
+# 1st optional paramater: FATPACK
+# -------------------------------
+# could be 'true' or 'false' (default)
+# When 'true' it will pre-install needed frameworks for additional apps and features
+# as a convenience to safe on install and update time for additional apps.
+# When 'false' it will just install the bare minimum and additional apps will just
+# install needed frameworks and libraries on demand when activated by user.
+# Use 'false' if you want to run your node without: go, dot-net, nodejs, docker, ...
 
-# 2nd optional parameter is the GITHUB-USERNAME to get code from when
-# provisioning sd card with raspiblitz assets/scripts later on
-# if 2nd parameter is used - 1st is mandatory
+fatpack="$1"
+if [ ${#fatpack} -eq 0 ]; then
+  fatpack="false"
+fi
+if [ "${fatpack}" != "true" ] && [ "${fatpack}" != "false" ]; then
+  echo "ERROR: fatpack parameter needs to be either 'true' or 'false'"
+  exit 1
+else
+  echo "will use fatpack --> '${fatpack}'"
+fi
+
+# 2st optional paramater: GITHUB-USERNAME
+# ---------------------------------------
+# could be any valid github-user that has a fork of the raspiblitz repo - 'rootzoll' is default
+# The 'raspiblitz' repo of this user is used to provisioning sd card 
+# with raspiblitz assets/scripts later on.
+# If this parameter is set also the branch needs to be given (see next parameter).
 githubUser="$2"
 if [ ${#githubUser} -eq 0 ]; then
   githubUser="rootzoll"
 fi
 echo "will use code from user --> '${githubUser}'"
 
-# 3rd optional parameter is the root partition
-rootPartition="$3"
-if [ ${#rootPartition} -eq 0 ]; then
-  rootPartition="/dev/mmcblk0p2"
+# 3rd optional paramater: GITHUB-BRANCH
+# -------------------------------------
+# could be any valid branch of the given GITHUB-USERNAME forked raspiblitz repo - 'dev' is default
+githubBranch="$3"
+if [ ${#githubBranch} -eq 0 ]; then
+  githubBranch="dev"
 fi
-echo "will use root partition --> '${rootPartition}'"
+echo "will use code from branch --> '${githubBranch}'"
 
-# 4th optional parameter is the LCD screen
+# 4rd optional paramater: LCD-DRIVER
+# ----------------------------------------
+# could be 'false' or 'GPIO' (default)
+# Use 'false' if you want to build an image that runs without a specialized LCD (like the GPIO).
+# On 'false' the standard video output is used (HDMI) by default.
 lcdInstalled="$4"
-if [ ${#lcdInstalled} -eq 0 ]; then
-  lcdInstalled="true"
+if [ ${#lcdInstalled} -eq 0 ] || [ "${lcdInstalled}" == "true" ]; then
+  lcdInstalled="GPIO"
+fi
+if [ "${lcdInstalled}" != "false" ] && [ "${lcdInstalled}" != "GPIO" ]; then
+  echo "ERROR: LCD-DRIVER parameter needs to be either 'false' or 'GPIO'"
+  exit 1
 else
-  if [ "${lcdInstalled}" != "false" ]; then
-    lcdInstalled="true"
-  fi
+  echo "will use LCD-DRIVER --> '${lcdInstalled}'"
 fi
-echo "will activate LCD screen --> '${lcdInstalled}'"
 
-# 5th optional parameter is Wifi
-disableWifi="$5"
-if [ ${#disableWifi} -eq 0 ]; then
-  disableWifi="false"
+# 5rd optional paramater: TWEAK-BOOTDRIVE
+# ---------------------------------------
+# could be 'true' (default) or 'false'
+# If 'true' it will try (based on the base OS) to optimize the boot drive.
+# If 'false' this will skipped.
+tweakBootdrives="$5"
+if [ ${#tweakBootdrives} -eq 0 ]; then
+  tweakBootdrives="true"
+fi
+if [ "${tweakBootdrives}" != "true" ] && [ "${tweakBootdrives}" != "false" ]; then
+  echo "ERROR: TWEAK-BOOTDRIVE parameter needs to be either 'true' or 'false'"
+  exit 1
 else
-  if [ "${disableWifi}" != "true" ]; then
-    disableWifi="false"
-  fi
-fi
-echo "will disable wifi --> '${disableWifi}'"
-
-# 6th optional parameter is Wifi country
-wifiCountry="$6"
-if [ ${#wifiCountry} -eq 0 ]; then
-  wifiCountry="US"
-fi
-if [ "${disableWifi}" == "false" ]; then
-  echo "will use Wifi country --> '${wifiCountry}'"
+  echo "will use TWEAK-BOOTDRIVE --> '${tweakBootdrives}'"
 fi
 
-echo -n "Do you wish to install Raspiblitz branch ${wantedBranch}? (yes/no) "
+# 6rd optional paramater: WIFI
+# ---------------------------------------
+# could be 'false' or 'true' (default) or a valid WIFI country code like 'US' (default)
+# If 'false' WIFI will be deactivated by default
+# If 'true' WIFI will be activated by with default country code 'US'
+# If any valid wifi country code Wifi will be activated with that country code by default
+modeWifi="$6"
+if [ ${#modeWifi} -eq 0 ] || [ "${modeWifi}" == "true" ]; then
+  modeWifi="US"
+fi
+echo "will use WIFI --> '${modeWifi}'"
+
+echo -n "Do you agree with all parameters above? (yes/no) "
 read installRaspiblitzAnswer
 if [ "$installRaspiblitzAnswer" == "yes" ] ; then
   echo ""
@@ -85,9 +109,7 @@ else
   exit 1
 fi
 
-
 echo "Installing Raspiblitz..."
-
 sleep 3
 
 echo ""
@@ -223,8 +245,9 @@ if [ "${baseImage}" = "raspbian" ]||[ "${baseImage}" = "raspios_arm64" ]||\
   # set to wait until network is available on boot (0 seems to yes)
   sudo raspi-config nonint do_boot_wait 0
   # set WIFI country so boot does not block
-  if [ "${disableWifi}" == "false" ]; then
-    sudo raspi-config nonint do_wifi_country $wifiCountry
+  if [ "${modeWifi}" != "false" ]; then
+    # this will undo the softblock of rfkill on RaspiOS
+    sudo raspi-config nonint do_wifi_country $modeWifi
   fi
   # see https://github.com/rootzoll/raspiblitz/issues/428#issuecomment-472822840
 
@@ -242,9 +265,15 @@ if [ "${baseImage}" = "raspbian" ]||[ "${baseImage}" = "raspios_arm64" ]||\
 
   # run fsck on sd root partition on every startup to prevent "maintenance login" screen
   # see: https://github.com/rootzoll/raspiblitz/issues/782#issuecomment-564981630
-  # use command to check last fsck check: sudo tune2fs -l ${rootPartition}
-  sudo tune2fs -c 1 ${rootPartition}
   # see https://github.com/rootzoll/raspiblitz/issues/1053#issuecomment-600878695
+  # use command to check last fsck check: sudo tune2fs -l ${rootPartition}
+  if [ "${tweakBootdrives}" == "true" ]; then
+    rootPartition = "/dev/mmcblk0p2"
+    echo "* running tune2fs on ${rootPartition}"
+    sudo tune2fs -c 1 ${rootPartition}
+  else
+    echo "* skipping tweakBootdrives"
+  fi
 
   # edit kernel parameters
   kernelOptionsFile=/boot/cmdline.txt
@@ -281,7 +310,7 @@ echo "*** CONFIG ***"
 echo "root:raspiblitz" | sudo chpasswd
 echo "pi:raspiblitz" | sudo chpasswd
 
-if [ "${lcdInstalled}" == "true" ]; then
+if [ "${lcdInstalled}" != "false" ]; then
    if [ "${baseImage}" = "raspbian" ]||[ "${baseImage}" = "raspios_arm64" ]||\
       [ "${baseImage}" = "debian_rpi64" ]; then
       # set Raspi to boot up automatically with user pi (for the LCD)
@@ -755,7 +784,7 @@ fi
 # move files from gitclone
 cd /home/admin/
 sudo -u admin rm -rf /home/admin/raspiblitz
-sudo -u admin git clone -b ${wantedBranch} https://github.com/${githubUser}/raspiblitz.git
+sudo -u admin git clone -b ${githubBranch} https://github.com/${githubUser}/raspiblitz.git
 sudo -u admin cp -r /home/admin/raspiblitz/home.admin/*.* /home/admin
 sudo -u admin cp -r /home/admin/raspiblitz/home.admin/.tmux.conf /home/admin
 sudo -u admin chmod +x *.sh
@@ -800,7 +829,7 @@ else
   echo "autostart already in $homeFile"
 fi
  
-if [ "${lcdInstalled}" == "true" ]; then
+if [ "${lcdInstalled}" != "false" ]; then
   if [ "${baseImage}" = "raspbian" ]||[ "${baseImage}" = "raspios_arm64" ]||\
      [ "${baseImage}" = "debian_rpi64" ]||[ "${baseImage}" = "armbian" ]||\
      [ "${baseImage}" = "ubuntu" ]; then
@@ -846,7 +875,7 @@ sudo apt install -y --no-install-recommends python3-systemd fail2ban
 
 if [ "${baseImage}" = "raspbian" ]||[ "${baseImage}" = "raspios_arm64"  ]||\
    [ "${baseImage}" = "debian_rpi64" ]; then
-  if [ "${disableWifi}" == "true" ]; then
+  if [ "${modeWifi}" == "false" ]; then
     echo ""
     echo "*** DISABLE WIFI ***"
     sudo systemctl disable wpa_supplicant.service
@@ -888,6 +917,25 @@ if [ "${baseImage}" = "raspbian" ]||[ "${baseImage}" = "raspios_arm64"  ]||\
 
 fi
 
+# *** FATPACK ***
+if [ "${fatpack}" == "true" ]; then
+  echo "*** FATPACK ***"
+  echo "* Adding GO Framework ..."
+  sudo /home/admin/config.scripts/bonus.go.sh on
+  if [ "$?" != "0" ]; then
+    echo "FATPACK FAILED"
+    exit 1
+  fi
+  echo "* Adding nodeJS Framework ..."
+  sudo /home/admin/config.scripts/bonus.nodjs.sh on
+  if [ "$?" != "0" ]; then
+    echo "FATPACK FAILED"
+    exit 1
+  fi
+else
+  echo "* skiping FATPACK"
+fi
+
 # *** CACHE DISK IN RAM ***
 echo "Activating CACHE RAM DISK ... "
 sudo /home/admin/config.scripts/blitz.cache.sh on
@@ -914,7 +962,7 @@ echo ""
 
 # *** RASPIBLITZ LCD DRIVER (do last - because makes a reboot) ***
 # based on https://www.elegoo.com/tutorial/Elegoo%203.5%20inch%20Touch%20Screen%20User%20Manual%20V1.00.2017.10.09.zip
-if [ "${lcdInstalled}" == "true" ]; then
+if [ "${lcdInstalled}" == "GPIO" ]; then
   if [ "${baseImage}" = "raspbian" ] || [ "${baseImage}" = "dietpi" ]; then
     echo "*** 32bit LCD DRIVER ***"
     echo "--> Downloading LCD Driver from Github"
@@ -986,7 +1034,7 @@ echo "SD CARD BUILD DONE"
 echo "**********************************************"
 echo ""
 
-if [ "${lcdInstalled}" == "true" ]; then
+if [ "${lcdInstalled}" != "false" ]; then
   echo "Your SD Card Image for RaspiBlitz is almost ready."
   if [ "${baseImage}" = "raspbian" ]; then
     echo "Last step is to install LCD drivers. This will reboot your Pi when done."
@@ -997,7 +1045,7 @@ else
 fi
 echo "Take the chance & look thru the output above if you can spot any errror."
 echo ""
-if [ "${lcdInstalled}" == "true" ]; then
+if [ "${lcdInstalled}" != "false" ]; then
   echo "After final reboot - your SD Card Image is ready."
   echo ""
 fi
@@ -1006,7 +1054,7 @@ echo "login once after reboot without external HDD/SSD and run 'XXprepareRelease
 echo "REMEMBER for login now use --> user:admin password:raspiblitz"
 echo ""
 
-if [ "${lcdInstalled}" == "true" ]; then
+if [ "${lcdInstalled}" != "false" ]; then
   # activate LCD and trigger reboot
   # dont do this on dietpi to allow for automatic build
   if [ "${baseImage}" = "raspbian" ]; then

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -13,7 +13,6 @@ echo "*****************************************"
 echo "* RASPIBLITZ SD CARD IMAGE SETUP v1.7   *"
 echo "*****************************************"
 echo "For details on optional parameters - see build script source code:"
-echo ""
 
 # 1st optional paramater: FATPACK
 # -------------------------------

--- a/home.admin/config.scripts/bonus.go.sh
+++ b/home.admin/config.scripts/bonus.go.sh
@@ -7,13 +7,6 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  exit 1
 fi
 
-source /mnt/hdd/raspiblitz.conf
-
-# add default value to raspi config if needed
-if ! grep -Eq "^golang=" /mnt/hdd/raspiblitz.conf; then
-  echo "golang=off" >> /mnt/hdd/raspiblitz.conf
-fi
-
 # switch on
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
@@ -89,7 +82,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   fi
 
   # setting value in raspi blitz config
-  sudo sed -i "s/^golang=.*/golang=on/g" /mnt/hdd/raspiblitz.conf
   echo ""
   echo "Installed $(go version)"
   echo ""
@@ -99,7 +91,6 @@ fi
 # switch off
 if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   # setting value in raspiblitz config
-  sudo sed -i "s/^golang=.*/golang=off/g" /mnt/hdd/raspiblitz.conf
   echo "*** REMOVING GO ***"
   sudo rm -rf /usr/local/go
   sudo rm -rf /usr/local/gocode

--- a/home.admin/config.scripts/bonus.nodejs.sh
+++ b/home.admin/config.scripts/bonus.nodejs.sh
@@ -13,13 +13,6 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  exit 1
 fi
 
-source /mnt/hdd/raspiblitz.conf
-
-# add default value to raspi config if needed
-if ! grep -Eq "^nodeJS=" /mnt/hdd/raspiblitz.conf; then
-  echo "nodeJS=off" >> /mnt/hdd/raspiblitz.conf
-fi
-
 # switch on
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # check if nodeJS was installed
@@ -87,8 +80,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
       exit 1
     fi
   fi
-  # setting value in raspi blitz config
-  sudo sed -i "s/^nodeJS=.*/nodeJS=on/g" /mnt/hdd/raspiblitz.conf
   echo "Installed nodeJS $(node -v)"
   exit 0
 fi
@@ -96,7 +87,6 @@ fi
 # switch off
 if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   # setting value in raspiblitz config
-  sudo sed -i "s/^nodeJS=.*/nodeJS=off/g" /mnt/hdd/raspiblitz.conf
   echo "*** REMOVING NODEJS ***"
   sudo rm -rf /usr/local/lib/nodejs
   echo "OK NodeJS removed."


### PR DESCRIPTION
This refectors the options on the sd card build scripts and adds the option to FATPACK which will already add frameworks needed for additional apps to the initial sd card build to save time on install and the update/recovery process. The FATPACK is optional - so you can still build an image of RaspiBlitz with minimal dependencies.