### PR TITLE
remove passwordB from lnd config

### DIFF
--- a/home.admin/assets/lnd.bitcoin.conf
+++ b/home.admin/assets/lnd.bitcoin.conf
@@ -31,13 +31,6 @@ bitcoin.node=bitcoind
 #bitcoin.testnet=1
 bitcoin.mainnet=1
 
-[Bitcoind]
-bitcoind.rpcuser=raspibolt
-bitcoind.rpcpass=passwordB
-bitcoind.rpchost=127.0.0.1
-bitcoind.zmqpubrawblock=tcp://*:28332
-bitcoind.zmqpubrawtx=tcp://*:28333
-
 [autopilot]
 autopilot.active=0
 autopilot.maxchannels=5

--- a/home.admin/assets/lnd.litecoin.conf
+++ b/home.admin/assets/lnd.litecoin.conf
@@ -29,13 +29,6 @@ litecoin.active=1
 litecoin.mainnet=1
 litecoin.node=litecoind
 
-[Litecoind]
-litecoind.rpchost=127.0.0.1
-litecoind.rpcuser=raspibolt
-litecoind.rpcpass=passwordB
-litecoind.zmqpubrawblock=tcp://*:28332
-litecoind.zmqpubrawtx=tcp://*:28333
-
 [autopilot]
 autopilot.active=0
 autopilot.maxchannels=5


### PR DESCRIPTION
"The auth parameters rpcuser and rpcpass parameters can typically be
determined by lnd for a bitcoind instance running under the same user, including
when using cookie auth. In this case, you can exclude them from the lnd options
entirely."
https://github.com/lightningnetwork/lnd/blob/master/docs/INSTALL.md#using-bitcoind-or-litecoind

As discussed and tested in: https://github.com/rootzoll/raspiblitz/issues/2073