### PR TITLE
Remove all Tor v2 services from the defaults

### DIFF
--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -231,8 +231,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   isTorConfigOK=$(sudo cat /etc/tor/torrc 2>/dev/null | grep -c "BITCOIN")
   if [ ${isTorConfigOK} -eq 0 ]; then
     echo "# - updating Tor config ${torrc}"
-    PASSWORD_B=$(sudo cat /mnt/hdd/${network}/${network}.conf | grep rpcpassword | cut -c 13-)
-    HASHED_PASSWORD=$(sudo -u debian-tor tor --hash-password "$PASSWORD_B")
     cat > ./torrc <<EOF
 ### See 'man tor', or https://www.torproject.org/docs/tor-manual.html
 

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -265,11 +265,6 @@ HiddenServicePort 38332 127.0.0.1:38332
 
 # NOTE: since Bitcoin Core v0.21.0 sets up a v3 Tor service automatically 
 # see /mnt/hdd/bitcoin for the onion private key - delete and restart bitcoind to reset
-
-# Hidden Service for BITCOIN P2P (v2FallBack for Bisq)
-HiddenServiceDir /mnt/hdd/tor/bitcoin8333
-HiddenServiceVersion 2
-HiddenServicePort 8333 127.0.0.1:8333
  
 # Hidden Service for LND (incoming connections)
 HiddenServiceDir /mnt/hdd/tor/lnd9735
@@ -281,19 +276,9 @@ HiddenServiceDir /mnt/hdd/tor/lndrpc10009/
 HiddenServiceVersion 3
 HiddenServicePort 10009 127.0.0.1:10009
 
-# Hidden Service for LND RPC (v2Fallback)
-HiddenServiceDir /mnt/hdd/tor/lndrpc10009fallback/
-HiddenServiceVersion 2
-HiddenServicePort 10009 127.0.0.1:10009
-
 # Hidden Service for LND REST
 HiddenServiceDir /mnt/hdd/tor/lndrest8080/
 HiddenServiceVersion 3
-HiddenServicePort 8080 127.0.0.1:8080
-
-# Hidden Service for LND REST (v2Fallback)
-HiddenServiceDir /mnt/hdd/tor/lndrest8080fallback/
-HiddenServiceVersion 2
 HiddenServicePort 8080 127.0.0.1:8080
 EOF
     sudo rm $torrc


### PR DESCRIPTION
would be probably the safest to not have any v2 Tor services configured by default in case it brakes some Tor versions, like it happened here: https://gitlab.torproject.org/tpo/core/tor/-/issues/40348
and expected network wide from July 2021. 

The entry for Bisq can be added to be set up as part of a BISQ option in the CONNECT menu: https://github.com/rootzoll/raspiblitz/issues/2090

The other fallback services seem to be redundant now.