### PR TITLE
Add mempool to update menu

### DIFF
--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -309,6 +309,9 @@ fi
 if [ "${sphinxrelay}" == "on" ]; then
   OPTIONS+=(SPHINX "Update Sphinx Server Relay")
 fi
+if [ "${mempoolExplorer}" == "on" ]; then
+  OPTIONS+=(MEMPOOL "Update Mempool Explorer")
+fi
 
 CHOICE=$(whiptail --clear --title "Update Options" --menu "" 13 55 6 "${OPTIONS[@]}" 2>&1 >/dev/tty)
 
@@ -350,5 +353,8 @@ case $CHOICE in
     ;;
   TOR)
     sudo /home/admin/config.scripts/internet.tor.sh update  
+    ;;
+  MEMPOOL)
+    /home/admin/config.scripts/bonus.mempool.sh update 
     ;;
 esac

--- a/home.admin/config.scripts/bonus.mempool.sh
+++ b/home.admin/config.scripts/bonus.mempool.sh
@@ -337,7 +337,6 @@ if [ "$1" = "update" ]; then
   
   cd /home/mempool/mempool
 
-  #localVersion=$(git tag | sort -V | tail -1) 
   localVersion=$(git describe --tag)
   updateVersion=$(curl -s https://api.github.com/repos/mempool/mempool/releases/latest|grep tag_name|head -1|cut -d '"' -f4)
 

--- a/home.admin/config.scripts/bonus.mempool.sh
+++ b/home.admin/config.scripts/bonus.mempool.sh
@@ -331,5 +331,89 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   exit 0
 fi
 
+# update
+if [ "$1" = "update" ]; then
+  echo "*** Checking Mempool Explorer Version ***"
+  
+  cd /home/mempool/mempool
+
+  #localVersion=$(git tag | sort -V | tail -1) 
+  localVersion=$(git describe --tag)
+  updateVersion=$(curl -s https://api.github.com/repos/mempool/mempool/releases/latest|grep tag_name|head -1|cut -d '"' -f4)
+
+  if [ $localVersion = $updateVersion ]; then
+      echo "***  You are up-to-date on version $localVersion ***" 
+      sudo systemctl restart mempool 2>/dev/null
+      echo "***  Restarting Mempool  ***"
+  else
+
+      sudo -u mempool git checkout $updateVersion
+
+      echo "# npm install for mempool explorer (backend)"
+
+      cd backend/
+      cp mempool-config.json /home/admin
+
+      sudo -u mempool NG_CLI_ANALYTICS=false npm install
+      if ! [ $? -eq 0 ]; then
+          echo "FAIL - npm install did not run correctly, aborting"
+          exit 1
+      fi
+      sudo -u mempool NG_CLI_ANALYTICS=false npm run build
+      if ! [ $? -eq 0 ]; then
+          echo "FAIL - npm run build did not run correctly, aborting"
+          exit 1
+      fi
+
+      echo "# npm install for mempool explorer (frontend)"
+
+      cd ../frontend
+      sudo -u mempool NG_CLI_ANALYTICS=false npm install
+      if ! [ $? -eq 0 ]; then
+          echo "FAIL - npm install did not run correctly, aborting"
+          exit 1
+      fi
+      sudo -u mempool NG_CLI_ANALYTICS=false npm run build
+      if ! [ $? -eq 0 ]; then
+          echo "FAIL - npm run build did not run correctly, aborting"
+          exit 1
+      fi
+
+      sudo mv /home/admin/mempool-config.json /home/mempool/mempool/backend/mempool-config.json
+      sudo chown mempool:mempool /home/mempool/mempool/backend/mempool-config.json
+
+
+      # Restore frontend files 
+      cd /home/mempool/mempool/frontend
+      sudo rsync -I -av --delete dist/mempool/ /var/www/mempool/
+      sudo chown -R www-data:www-data /var/www/mempool
+
+      cd /home/mempool/mempool
+
+      # Reinstall the mempool configuration for nginx
+      cp nginx.conf nginx-mempool.conf /etc/nginx/nginx.conf
+      sudo systemctl restart nginx
+
+      # Remove useless deps
+      echo "Removing unneccesary modules..."
+      npm prune --production
+
+
+      echo "***  Restarting Mempool  ***"
+      sudo systemctl start mempool
+
+  fi
+
+  # check for error
+  isDead=$(sudo systemctl status mempool | grep -c 'inactive (dead)')
+  if [ ${isDead} -eq 1 ]; then
+    echo "error='Mempool service start failed'"
+    exit 1
+  else
+    echo "***  Mempool version ${updateVersion} now running  ***"
+  fi
+  exit 0
+fi
+
 echo "error='unknown parameter'
 exit 1

--- a/home.admin/config.scripts/bonus.mempool.sh
+++ b/home.admin/config.scripts/bonus.mempool.sh
@@ -345,13 +345,14 @@ if [ "$1" = "update" ]; then
       sudo systemctl restart mempool 2>/dev/null
       echo "***  Restarting Mempool  ***"
   else
+      # Preserve Config
+      sudo cp backend/mempool-config.json /home/admin
 
-      sudo -u mempool git checkout $updateVersion
+      sudo -u mempool git fetch --all && sudo -u mempool git reset --hard && sudo -u mempool git pull -p
 
       echo "# npm install for mempool explorer (backend)"
 
-      cd backend/
-      cp mempool-config.json /home/admin
+      cd /home/mempool/mempool/backend/
 
       sudo -u mempool NG_CLI_ANALYTICS=false npm install
       if ! [ $? -eq 0 ]; then

--- a/home.admin/config.scripts/bonus.mempool.sh
+++ b/home.admin/config.scripts/bonus.mempool.sh
@@ -348,7 +348,7 @@ if [ "$1" = "update" ]; then
       # Preserve Config
       sudo cp backend/mempool-config.json /home/admin
 
-      sudo -u mempool git fetch --all && sudo -u mempool git reset --hard && sudo -u mempool git pull -p
+      sudo -u mempool git checkout $updateVersion
 
       echo "# npm install for mempool explorer (backend)"
 


### PR DESCRIPTION
- [x] Tested on RaspiBlitz v1.6.3 
- [x] Mempool update pulls latest changes from git repo and rebuilds mempool service. 
- [x] Mempool service restarts after update

Current implementation pulls update from working repo.  Should we install from official releases, instead?  