### PR TITLE
Add Homer Homepage as a service

### DIFF
--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -113,6 +113,9 @@ fi
 if [ "${sphinxrelay}" == "on" ]; then
   OPTIONS+=(SPHINX "Sphinx Chat Relay")
 fi
+if [ "${homer}" == "on" ]; then
+  OPTIONS+=(HOMER "Homer")
+fi
 
 # Basic Options
 OPTIONS+=(INFO "RaspiBlitz Status Screen")
@@ -257,6 +260,9 @@ case $CHOICE in
             ;;
         SUBSCRIBE)
             /home/admin/config.scripts/blitz.subscriptions.py
+            ;;
+        HOMER)
+            sudo /home/admin/config.scripts/bonus.homer.sh menu
             ;;
         lnbalance)
             clear

--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -22,6 +22,7 @@ if [ ${#pyblock} -eq 0 ]; then pyblock="off"; fi
 if [ ${#thunderhub} -eq 0 ]; then thunderhub="off"; fi
 if [ ${#pool} -eq 0 ]; then pool="off"; fi
 if [ ${#sphinxrelay} -eq 0 ]; then sphinxrelay="off"; fi
+if [ ${#homer} -eq 0 ]; then homer="off"; fi
 
 # show select dialog
 echo "run dialog ..."
@@ -43,6 +44,7 @@ OPTIONS+=(c 'Lightning Pool' ${pool})
 OPTIONS+=(y 'PyBLOCK' ${pyblock})
 OPTIONS+=(m 'lndmanage' ${lndmanage})
 OPTIONS+=(x 'Sphinx-Relay' ${sphinxrelay})
+OPTIONS+=(x 'Homer' ${homer})
 
 CHOICES=$(dialog --title ' Additional Services ' --checklist ' use spacebar to activate/de-activate ' 20 45 12  "${OPTIONS[@]}" 2>&1 >/dev/tty)
 
@@ -438,6 +440,24 @@ When finished use the new 'MEMPOOL' entry in Main Menu for more info.\n
   fi
 else
   echo "Mempool Explorer Setting unchanged."
+fi
+
+# Homer process choice
+choice="off"; check=$(echo "${CHOICES}" | grep -c "h")
+if [ ${check} -eq 1 ]; then choice="on"; fi
+if [ "${homer}" != "${choice}" ]; then
+  echo "Homer settings changed .."
+  anychange=1
+  /home/admin/config.scripts/bonus.homer.sh ${choice}
+  errorOnInstall=$?
+  if [ "${choice}" =  "on" ]; then
+    whiptail --title " Installed Homer" --msgbox "\
+Homer was installed.\n
+Use the new 'Homer' entry in Main Menu for more info.\n
+" 10 35
+  fi
+else
+  echo "Homer Setting unchanged."
 fi
 
 if [ ${anychange} -eq 0 ]; then

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -309,6 +309,9 @@ fi
 if [ "${sphinxrelay}" == "on" ]; then
   OPTIONS+=(SPHINX "Update Sphinx Server Relay")
 fi
+if [ "${homer}" == "on" ]; then
+  OPTIONS+=(SPHINX "Update Homer")
+fi
 
 CHOICE=$(whiptail --clear --title "Update Options" --menu "" 13 55 6 "${OPTIONS[@]}" 2>&1 >/dev/tty)
 
@@ -350,5 +353,8 @@ case $CHOICE in
     ;;
   TOR)
     sudo /home/admin/config.scripts/internet.tor.sh update  
+    ;;
+  HOMER)
+    /home/admin/config.scripts/bonus.homer.sh update  
     ;;
 esac

--- a/home.admin/assets/nginx/sites-available/homer_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/homer_ssl.conf
@@ -1,0 +1,18 @@
+## homer_ssl.conf
+
+server {
+    listen 4091 ssl;
+    listen [::]:4091 ssl;
+    server_name _;
+
+    include /etc/nginx/snippets/ssl-params.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    access_log /var/log/nginx/access_homer.log;
+    error_log /var/log/nginx/error_homer.log;
+
+    root /var/www/homer;
+    index index.html;
+
+
+}

--- a/home.admin/assets/nginx/sites-available/homer_tor.conf
+++ b/home.admin/assets/nginx/sites-available/homer_tor.conf
@@ -1,0 +1,14 @@
+## homer_tor.conf
+
+server {
+    listen localhost:4092;
+    listen [::1]:4092;
+    server_name _;
+
+    access_log /var/log/nginx/access_homer.log;
+    error_log /var/log/nginx/error_homer.log;
+
+    root /var/www/homer;
+    index index.html;
+
+}

--- a/home.admin/assets/nginx/sites-available/homer_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/homer_tor_ssl.conf
@@ -1,0 +1,17 @@
+## homer_tor_ssl.conf
+
+server {
+    listen localhost:4093;
+    listen [::1]:4093;
+    server_name _;
+
+    include /etc/nginx/snippets/ssl-params.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    access_log /var/log/nginx/access_homer.log;
+    error_log /var/log/nginx/error_homer.log;
+
+    root /var/www/homer;
+    index index.html;
+
+}

--- a/home.admin/config.scripts/bonus.homer.sh
+++ b/home.admin/config.scripts/bonus.homer.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+# https://github.com/bastienwirtz/homer
+
+remoteVersion=$(curl -s https://api.github.com/repos/bastienwirtz/homer/releases/latest|grep tag_name|head -1|cut -d '"' -f4)
+
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+  echo "# small config script to switch Homer on or off"
+  echo "# installs the $remoteVersion by default"
+  echo "# bonus.homer.sh [status|on|off]"
+  exit 1
+fi
+
+source /mnt/hdd/raspiblitz.conf
+
+# show info menu
+if [ "$1" = "menu" ]; then
+
+  # get status
+  echo "# collecting status info ... (please wait)"
+  source <(sudo /home/admin/config.scripts/bonus.homer.sh status)
+
+
+  # get network info
+  localip=$(ip addr | grep 'state UP' -A2 | egrep -v 'docker0' | grep 'eth0\|wlan0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  toraddress=$(sudo cat /mnt/hdd/tor/homer/hostname 2>/dev/null)
+  fingerprint=$(openssl x509 -in /mnt/hdd/app-data/nginx/tls.cert -fingerprint -noout | cut -d"=" -f2)
+
+  if [ "${runBehindTor}" = "on" ] && [ ${#toraddress} -gt 0 ]; then
+
+    # TOR
+    /home/admin/config.scripts/blitz.lcd.sh qr "${toraddress}"
+    whiptail --title " Homer " --msgbox "Open in your local web browser & accept self-signed cert:
+https://${localip}:4091\n
+SHA1 Thumb/Fingerprint:
+${fingerprint}\n
+Hidden Service address for TOR Browser (QR see LCD):
+${toraddress}
+" 16 67
+    /home/admin/config.scripts/blitz.lcd.sh hide
+  else
+
+    # IP + Domain
+    whiptail --title " Homer " --msgbox "Open in your local web browser & accept self-signed cert:
+https://${localip}:4091\n
+SHA1 Thumb/Fingerprint:
+${fingerprint}\n
+Activate TOR to access the web block explorer from outside your local network.
+" 16 54
+  fi
+
+  echo "please wait ..."
+  exit 0
+fi
+
+# add default value to raspi config if needed
+if ! grep -Eq "^homer=" /mnt/hdd/raspiblitz.conf; then
+  echo "homer=off" >> /mnt/hdd/raspiblitz.conf
+fi
+
+# status
+if [ "$1" = "status" ]; then
+
+  if [ "${homer}" = "on" ]; then
+    echo "configured=1"
+  else
+    echo "configured=0"
+  fi
+  exit 0
+fi
+
+
+# switch on
+if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+  echo "# *** INSTALL Homer ***"
+
+  isInstalled=$(sudo ls /var/www/homer/assets/config.yml.dist 2>/dev/null | grep -c 'config.yml.dist')
+  if [ ${isInstalled} -eq 0 ]; then
+
+    # add homer user
+    sudo adduser --disabled-password --gecos "" homer
+
+    # install homer
+    cd /home/homer
+    sudo -u homer git clone https://github.com/bastienwirtz/homer.git
+    cd homer
+    sudo -u homer git reset --hard $remoteVersion
+
+    sudo -u homer NG_CLI_ANALYTICS=false npm install --legacy-peer-deps
+    if ! [ $? -eq 0 ]; then
+        echo "FAIL - npm install did not run correctly, aborting"
+        exit 1
+    fi
+    sudo -u homer NG_CLI_ANALYTICS=false npm run build
+    if ! [ $? -eq 0 ]; then
+        echo "FAIL - npm run build did not run correctly, aborting"
+        exit 1
+    fi    
+
+    sudo -u homer cp /home/homer/homer/dist/assets/config.yml.dist /home/homer/homer/dist/assets/config.yml
+
+    sudo mkdir -p /var/www/homer
+    sudo rsync -av --delete dist/ /var/www/homer/
+    sudo chown -R www-data:www-data /var/www/homer
+
+
+
+    ##################
+    # NGINX
+    ##################
+
+    if ! [ -f /etc/nginx/sites-available/homer_ssl.conf ]; then
+       sudo cp /home/admin/assets/nginx/sites-available/homer_ssl.conf /etc/nginx/sites-available/homer_ssl.conf
+    fi
+    if ! [ -f /etc/nginx/sites-available/homer_tor.conf ]; then
+       sudo cp /home/admin/assets/nginx/sites-available/homer_tor.conf /etc/nginx/sites-available/homer_tor.conf
+    fi
+    if ! [ -f /etc/nginx/sites-available/homer_tor_ssl.conf ]; then
+       sudo cp /home/admin/assets/nginx/sites-available/homer_tor_ssl.conf /etc/nginx/sites-available/homer_tor_ssl.conf
+    fi
+    sudo ln -sf /etc/nginx/sites-available/homer_ssl.conf /etc/nginx/sites-enabled/
+    sudo ln -sf /etc/nginx/sites-available/homer_tor.conf /etc/nginx/sites-enabled/
+    sudo ln -sf /etc/nginx/sites-available/homer_tor_ssl.conf /etc/nginx/sites-enabled/
+
+    sudo nginx -t
+    sudo systemctl restart nginx
+
+    # open the firewall
+    echo "*** Updating Firewall ***"
+    sudo ufw allow from any to any port 4090 comment 'allow homer HTTP'
+    sudo ufw allow from any to any port 4091 comment 'allow homer HTTPS'
+    echo ""
+
+  else 
+    echo "# homer is already installed."
+  fi
+
+  # start the service if ready
+  source /home/admin/raspiblitz.info
+
+  # setting value in raspi blitz config
+  sudo sed -i "s/^homer=.*/homer=on/g" /mnt/hdd/raspiblitz.conf
+  
+
+
+  # Hidden Service for Mempool if Tor is active
+  source /mnt/hdd/raspiblitz.conf
+  if [ "${runBehindTor}" = "on" ]; then
+    # make sure to keep in sync with internet.tor.sh script
+    /home/admin/config.scripts/internet.hiddenservice.sh homer 80 4092 443 4093
+  fi
+  exit 0
+fi
+
+
+# switch off
+if [ "$1" = "0" ] || [ "$1" = "off" ]; then
+
+  # setting value in raspi blitz config
+  sudo sed -i "s/^homer=.*/homer=off/g" /mnt/hdd/raspiblitz.conf
+
+  isInstalled=$(sudo ls /var/www/homer/assets/config.yml.dist 2>/dev/null | grep -c 'config.yml.dist')
+  if [ ${isInstalled} -eq 1 ]; then
+    echo "# *** REMOVING homer ***"
+    # delete user and home directory
+    sudo userdel -rf homer
+    sudo rm -rf /var/www/homer
+
+
+    # remove nginx symlinks
+    sudo rm -f /etc/nginx/sites-enabled/homer_ssl.conf
+    sudo rm -f /etc/nginx/sites-enabled/homer_tor.conf
+    sudo rm -f /etc/nginx/sites-enabled/homer_tor_ssl.conf
+    sudo rm -f /etc/nginx/sites-available/homer_ssl.conf
+    sudo rm -f /etc/nginx/sites-available/homer_tor.conf
+    sudo rm -f /etc/nginx/sites-available/homer_tor_ssl.conf
+    sudo nginx -t
+    sudo systemctl reload nginx
+
+    # Hidden Service if Tor is active
+    if [ "${runBehindTor}" = "on" ]; then
+      # make sure to keep in sync with internet.tor.sh script
+      /home/admin/config.scripts/internet.hiddenservice.sh off homer
+    fi
+
+    echo "# OK Homer removed."
+  
+  else 
+    echo "# Homer is not installed."
+  fi
+
+  exit 0
+fi
+
+
+
+echo "error='unknown parameter'
+exit 1
+

--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -404,6 +404,9 @@ EOF
   if [ "${thunderhub}" = "on" ]; then
     /home/admin/config.scripts/internet.hiddenservice.sh thunderhub 80 3012 443 3013
   fi
+  if [ "${homer}" = "on" ]; then
+    /home/admin/config.scripts/internet.hiddenservice.sh homer 80 4092 443 4093
+  fi
   if [ "${specter}" = "on" ]; then
     # specter makes only sense to be served over https
     /home/admin/config.scripts/internet.hiddenservice.sh cryptoadvance-specter 443 25441


### PR DESCRIPTION
### Feature Request

Members in the raspiblitz community are eager to have a unified interface to bookmark installed applications.  Some users are using homer provided by Bastienwirtz at https://github.com/bastienwirtz/homer.  I've integrated homer as an optional service to bookmark favorite applications. 

- [x] Tested on RaspiBlitz v1.6.3
- [x] Install/Uninstall capable
- [x] Adds user homer
- [x] Updates firewall rules   

### Concern

1. Upstream dependency conflict 
    - Resolution - npm install --legacy-peer-deps
    - Issue opened with project upstream.  



### Future work

1. Automate config generation from list of installed applications

Further testing appreciated as I have yet to setup a proper dev environment just yet.