### PR TITLE
remove 00mainMenu.sh loop from submenus

### DIFF
--- a/home.admin/98repairMenu.sh
+++ b/home.admin/98repairMenu.sh
@@ -183,13 +183,11 @@ clear
 case $CHOICE in
   HARDWARE)
     sudo /home/admin/05hardwareTest.sh
-    /home/admin/00mainMenu.sh
     ;;
   SOFTWARE)
     sudo /home/admin/XXdebugLogs.sh
     echo "Press ENTER to return to main menu."
     read key
-    /home/admin/00mainMenu.sh
     ;;
   BACKUP-LND)
     sudo /home/admin/config.scripts/lnd.rescue.sh backup
@@ -202,7 +200,6 @@ case $CHOICE in
     sudo /home/admin/config.scripts/blitz.migration.sh "export-gui"
     echo "Press ENTER to return to main menu."
     read key
-    /home/admin/00mainMenu.sh
     ;;
   RESET-CHAIN)
     /home/admin/XXcleanHDD.sh -blockchain

--- a/home.admin/99connectMenu.sh
+++ b/home.admin/99connectMenu.sh
@@ -291,6 +291,3 @@ HiddenServicePort 8333 127.0.0.1:8333" | sudo tee -a /etc/tor/torrc
     esac
   ;;
 esac
-
-# go into loop - start script from beginning to load config/start fresh
-/home/admin/00mainMenu.sh

--- a/home.admin/99lightningMenu.sh
+++ b/home.admin/99lightningMenu.sh
@@ -114,6 +114,3 @@ case $CHOICE in
             read key
             ;;
 esac
-
-# go into loop - start script from beginning to load config/sate fresh
-/home/admin/00mainMenu.sh

--- a/home.admin/99systemMenu.sh
+++ b/home.admin/99systemMenu.sh
@@ -149,6 +149,3 @@ thunderhub, tor@default, tor@lnd, tor
     echo "use CTRL+C any time to abort"
     sudo journalctl -n 100 -fu $SERVICE;;
 esac
-
-# go into loop - start script from beginning to load config/start fresh
-/home/admin/00mainMenu.sh


### PR DESCRIPTION
after entering and exiting some submenus the `EXIT` button does not work as intended, but loops back to the main menu again.

Easy fix, tested ok.