### PR TITLE
run apt update after adding Tor sources

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -221,6 +221,7 @@ else
 fi
 
 echo "*** Install & Enable Tor ***"
+sudo apt update
 sudo apt install tor tor-arm torsocks -y
 echo ""
 


### PR DESCRIPTION
Attempting to solve the the missing packages while building the sdcard:
```
After this operation, 15.6 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian buster/main arm64 python3-stem all 1.7.1-1 [284 kB]
Get:2 http://deb.debian.org/debian buster/main arm64 nyx all 2.1.0-2 [67.6 kB]
Err:3 http://deb.debian.org/debian buster/main arm64 tor arm64 0.3.5.12-1
  404  Not Found [IP: 199.232.18.132 80]
Get:4 http://deb.debian.org/debian buster/main arm64 tor-arm all 2.1.0-2 [3332 B]
Ign:5 http://deb.debian.org/debian buster/main arm64 tor-geoipdb all 0.3.5.12-1
Get:6 http://deb.debian.org/debian buster/main arm64 torsocks arm64 2.3.0-2 [74.9 kB]
Err:5 http://deb.debian.org/debian buster/main arm64 tor-geoipdb all 0.3.5.12-1
  404  Not Found [IP: 199.232.18.132 80]
Fetched 430 kB in 1s (392 kB/s)
E: Failed to fetch http://deb.debian.org/debian/pool/main/t/tor/tor_0.3.5.12-1_arm64.deb  404  Not Found [IP: 199.232.18.132 80]
E: Failed to fetch http://deb.debian.org/debian/pool/main/t/tor/tor-geoipdb_0.3.5.12-1_all.deb  404  Not Found [IP: 199.232.18.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```