### PR TITLE
telegraf updates for v1.7.0RC2

### DIFF
--- a/home.admin/assets/telegraf/etc-telegraf/getraspiblitzipinfo.sh
+++ b/home.admin/assets/telegraf/etc-telegraf/getraspiblitzipinfo.sh
@@ -3,7 +3,7 @@
 
 ###############################################################################
 #   File:   getraspiblitzipinfo.sh
-#   Date:   2020-10-04
+#   Date:   2021-04-19
 ###############################################################################
 
 # set the "debugLevel"
@@ -18,17 +18,17 @@ logFile=/mnt/hdd/temp/raspiblitzipinfo.log
 
 # get the ISO timestamp for log output
 sts=$(date --iso-8601='seconds')
-if [ -f "${logFile}" ]; then printf "\n---\n%s: %s started\n" "$sts" "$0"  >> ${logFile} ;fi 
+if [ -f "${logFile}" ]; then printf "\n---\n%s: %s started\n" "$sts" "$0"  >> ${logFile} ;fi
 
 # get the seconds since UNIX epoch
 unixTimestamp=$(date +"%s")
-if [ -f "${logFile}" ]; then printf "%s: unixTimeStamp = %s\n" "$sts" "$unixTimestamp"  >> ${logFile} ;fi 
+if [ -f "${logFile}" ]; then printf "%s: unixTimeStamp = %s\n" "$sts" "$unixTimestamp"  >> ${logFile} ;fi
 
 # get active network device (eth0 or wlan0)
 networkDevice=$(ip addr | grep -v "lo:" | grep 'state UP' | tr -d " " | cut -d ":" -f2 | head -n 1)
 #
-if [ -f "${logFile}" ]; then printf "%s: networkDevice = %s\n" "$sts" "$networkDevice"  >> ${logFile} ;fi 
-if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi 
+if [ -f "${logFile}" ]; then printf "%s: networkDevice = %s\n" "$sts" "$networkDevice"  >> ${logFile} ;fi
+if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi
 
 # create the indexed array "origin" an fill it
 # this also creates the "Enumeration"
@@ -41,8 +41,8 @@ if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi
 declare -a origin
 origin=(publicIP bitcoind lnd IPv6 IPv4)
 #
-#if [ -f "${logFile}" ]; then for i in $( seq 0 4 ); do printf "%s: origin[ %d ] = %s\n" "$sts" "$i" "${origin[ $i ]}"  >> ${logFile}       ;done ;fi 
-#if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi 
+#if [ -f "${logFile}" ]; then for i in $( seq 0 4 ); do printf "%s: origin[ %d ] = %s\n" "$sts" "$i" "${origin[ $i ]}"  >> ${logFile}       ;done ;fi
+#if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi
 
 #
 # further we need the arrays
@@ -70,8 +70,8 @@ ip_addr_curr[2]=$(/usr/local/bin/lncli  --lnddir=/mnt/hdd/app-data/lnd  getinfo 
 ip_addr_curr[3]=$(ip -o -6 address show scope global up dev ${networkDevice} 2>/dev/null | cut -d'/' -f1 | awk '/inet6/{print $4}' | head -n 1)
 ip_addr_curr[4]=$(ip -o -4 address show scope global up dev ${networkDevice} 2>/dev/null | cut -d'/' -f1 | awk '/inet/{print $4}' | head -n 1)
 #
-if [ -f "${logFile}" ]; then for i in $( seq 0 4 ); do printf "%s: ip_addr_curr[ %d ] = %s\n" "$sts" "$i" "${ip_addr_curr[ $i ]}"  >> ${logFile}       ;done ;fi 
-if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi 
+if [ -f "${logFile}" ]; then for i in $( seq 0 4 ); do printf "%s: ip_addr_curr[ %d ] = %s\n" "$sts" "$i" "${ip_addr_curr[ $i ]}"  >> ${logFile}       ;done ;fi
+if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi
 #
 if [ ${debugLevel} -gt 10 ]; then for i in $( seq 0 4 ); do printf "  %2d: %-10s  = %s\n" "$i" "${origin[ $i ]}" "${ip_addr_curr[ $i ]}"  ;done ;fi
 
@@ -93,12 +93,12 @@ for i in $( seq 0 4 ); do
     ip_addr_prev[ $i ]=${!s}
 
     # if the variable is still empty, fill it with "N/A"
-    if [ "ip_addr_prev[ $i ]" == "" ]; then ip_addr_prev[ $i ]="N/A" ; fi 
+    if [ "ip_addr_prev[ $i ]" == "" ]; then ip_addr_prev[ $i ]="N/A" ; fi
 
     #if [ -f "${logFile}" ]; then printf "%s: from memoryfile variable %30s = %s\n" "$sts" "$s" "${ip_addr_prev[ $i ]}" >> ${logFile} ; fi
     if [ ${debugLevel} -gt 10 ]; then printf "  %2d: read into          ip_addr_prev[%d] from memoryfile variable %30s = %s\n" "$i" "$i" "$s" "${ip_addr_prev[ $i ]}" ; fi
 done
-#if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi 
+#if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi
 
 
 # initialize the Creation TimeStamps with their old values from the memory file
@@ -121,7 +121,7 @@ for i in $( seq 0 4 ); do
     #if [ -f "${logFile}" ]; then printf "%s: from memoryfile variable %30s = %s\n" "$sts" "$s" "${creation_ts_curr[ $i ]}" >> ${logFile} ; fi
     if [ ${debugLevel} -gt 10 ]; then printf "  %2d: read into creation_ts_curr/prev[%d] from memoryfile variable %30s = %s\n" "$i" "$i" "$s" "${creation_ts_curr[ $i ]}" ; fi
 done
-#if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi 
+#if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi
 
 
 # initialize the "has_changed" flag array
@@ -146,7 +146,7 @@ for i in $( seq 0 4 ); do
         if [ ${debugLevel} -gt 10 ]; then printf "  %2d: IP addr --NOT changed-- for %10s: %40s (new) == %40s (old)\n" "$i" "${origin[ $i ]}" "${ip_addr_curr[$i]}" "${ip_addr_prev[$i]}" ; fi
     fi
 done
-if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi 
+if [ -f "${logFile}" ]; then echo " "  >> ${logFile} ;fi
 
 
 # IF at least one value of the memory file needs to be updated, the whole file will be rewritten.
@@ -174,9 +174,9 @@ if [ ${changes} -gt 0 ]; then
             echo " "                                                                >>  ${memoryFile}
         done
 
-        if [ -f "${logFile}" ]; then echo "==========================================================================================="  >> ${logFile} ;fi 
+        if [ -f "${logFile}" ]; then echo "==========================================================================================="  >> ${logFile} ;fi
         if [ -f "${logFile}" ]; then cat ${memoryFile} >> ${logFile} ; fi
-        if [ -f "${logFile}" ]; then echo "==========================================================================================="  >> ${logFile} ;fi 
+        if [ -f "${logFile}" ]; then echo "==========================================================================================="  >> ${logFile} ;fi
     else
         # display info on stdout
         echo ""
@@ -203,7 +203,9 @@ fi
 
 # now create the output for the telegraf "[[inputs.exec]]" section in influx-line-format
 #
-# measurement:  raspiblitz_ip_info
+# 2021-04-19: rename measurement: "raspiblitz_ip_info" -> "ipinfo"
+#
+# measurement:  ipinfo
 #
 # tags
 #   *   host
@@ -228,13 +230,13 @@ for i in $( seq 0 4 ); do
     #
     # create influx-line-format output
     # only if there is a proper creation timestamp
-    if [ ${creation_ts_curr[ $i ]} -gt 1000000000 ]; then 
-        influxLine="raspiblitz_ip_info,origin=${origin[ $i ]},ipaddr=${ip_addr_curr[$i]},ipaddr_prev=${ip_addr_prev[$i]},ipaddr_changed=${has_changed[ $i ]} created=${creation_ts_curr[ $i ]}i,uptime=${ipaddr_online}i,changed=${has_changed[ $i ]}i"
+    if [ ${creation_ts_curr[ $i ]} -gt 1000000000 ]; then
+        influxLine="ipinfo,origin=${origin[ $i ]},ipaddr=${ip_addr_curr[$i]},ipaddr_prev=${ip_addr_prev[$i]},ipaddr_changed=${has_changed[ $i ]} created=${creation_ts_curr[ $i ]}i,uptime=${ipaddr_online}i,changed=${has_changed[ $i ]}i"
         if [ -f "${logFile}" ]; then printf "%s: === %s\n" "$sts" "$influxLine" >> ${logFile} ; fi
         echo "${influxLine}"
-    else 
+    else
         if [ -f "${logFile}" ]; then printf "%s: creation time ERROR for origin %s \n" "$sts" "${origin[ $i ]}" >> ${logFile} ; fi
-    fi 
+    fi
 done
 
 # -eof-

--- a/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
+++ b/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
@@ -76,6 +76,22 @@
 
 
 ####  Bitcoin related metric
+####  basic information about the mempool
+####  --> https://developer.bitcoin.org/reference/rpc/getmempoolinfo.html
+##
+##    Most usefull fields...
+##      *   loaded            (boolean) True if the mempool is fully loaded
+##      *   size              (numeric) Current tx count
+##      *   usage             (numeric) Total memory usage for the mempool
+##
+[[inputs.exec]]
+  interval                    = "60s"
+  commands                    = ["/usr/local/bin/bitcoin-cli  -conf=/mnt/hdd/bitcoin/bitcoin.conf  getmempoolinfo" ]
+  name_override               = "bitcoin_mempoolinfo"
+  data_format                 = "json"
+
+
+####  Bitcoin related metric
 ####  information about network traffic, including bytes in, bytes out, and current time window
 ####  --> https://developer.bitcoin.org/reference/rpc/getnettotals.html
 ##

--- a/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
+++ b/home.admin/assets/telegraf/etc-telegraf/telegraf.d/telegraf_inputs.conf
@@ -203,6 +203,7 @@
 #####################################
 ####  Hardware data: cpu/gpu temperature, voltage, cpu clock
 ####
+####  2021-04-19  adopt to new path of "vcgencmd" at raspiblitz v1.7.0RC2
 #####################################
 [[inputs.file]]
   files                       = ["/sys/class/thermal/thermal_zone0/temp"]
@@ -212,21 +213,21 @@
 
 
 [[inputs.exec]]
-  commands                    = ["/opt/vc/bin/vcgencmd measure_temp"]
+  commands                    = ["/usr/bin/vcgencmd measure_temp"]
   name_override               = "gpu_temperature"
   data_format                 = "grok"
   grok_patterns               = ["%{NUMBER:value:float}"]
 
 
 [[inputs.exec]]
-  commands                    = ["/opt/vc/bin/vcgencmd measure_volts core"]
+  commands                    = ["/usr/bin/vcgencmd measure_volts core"]
   name_override               = "cpu_volts"
   data_format                 = "grok"
   grok_patterns               = ["%{NUMBER:value:float}"]
 
 
 [[inputs.exec]]
-  commands                    = ["/opt/vc/bin/vcgencmd measure_clock arm"]
+  commands                    = ["/usr/bin/vcgencmd measure_clock arm"]
   name_override               = "cpu_frequency"
   data_format                 = "grok"
   grok_patterns               = ["=%{NUMBER:value:int}"]


### PR DESCRIPTION
some small updates for the telegraf feature

1. due to the OS upgrade for v1.7.0RC2 the path for `vcgencmd` had changed
2. renamed the measurement `raspiblitz_ip_info` to `ipinfo`
3. remove some trailng whitespaces
4. add bitcoin mempool info via bitcoin-cli call