### PR TITLE
show nginx systemd logs

### DIFF
--- a/home.admin/XXdebugLogs.sh
+++ b/home.admin/XXdebugLogs.sh
@@ -71,6 +71,10 @@ echo "sudo tail -n 30 /mnt/hdd/lnd/logs/${network}/${chain}net/lnd.log"
 sudo tail -n 30 /mnt/hdd/lnd/logs/${network}/${chain}net/lnd.log
 echo ""
 
+echo "*** NGINX SYSTEMD STATUS ***"
+sudo systemctl status nginx -n2 --no-pager
+echo ""
+
 echo "*** LAST NGINX LOGS ***"
 echo "sudo journalctl -u nginx -b --no-pager -n20"
 sudo journalctl -u nginx -b --no-pager -n20


### PR DESCRIPTION
This is important, normally nginx fails and this is not shown.
Specifically status. Journalctl can help debug, but why not add status, as it serves a lot of applications.