### PR TITLE
add client authorization to onion services

### DIFF
--- a/home.admin/config.scripts/internet.hiddenservice.sh
+++ b/home.admin/config.scripts/internet.hiddenservice.sh
@@ -79,7 +79,7 @@ if [ "$1" == "auth" ]; then
       echo
       echo "ClientOnionAuthDir /var/lib/tor/onion_auth/ | sudo tee -a /etc/tor/torrc && sudo chmod 644 /etc/tor/torrc"
       echo "sudo mkdir -p /var/lib/tor/onion_auth && sudo chown -R debian-tor:debian-tor /var/lib/tor"
-      echo "echo 'serviceAddress(without .onion):descriptor:x25519:privKey' | sudo tee /var/lib/tor/onion_auth/blitz-${service}.auth_private"
+      echo "echo '<onion-addr-without-.onion>:descriptor:x25519:<priv-key-in-base32>' | sudo tee /var/lib/tor/onion_auth/blitz-${service}.auth_private"
       echo
       # Finish
       rm -f /tmp/k1.pub.key /tmp/k1.prv.key /tmp/k1.prv.pem

--- a/home.admin/config.scripts/internet.hiddenservice.sh
+++ b/home.admin/config.scripts/internet.hiddenservice.sh
@@ -63,23 +63,25 @@ if [ "$1" == "auth" ]; then
       echo "descriptor:x25519:`cat /tmp/k1.pub.key`" | sudo tee /mnt/hdd/tor/${service}/authorized_clients/me.auth >/dev/null
       # Client side configuration
       echo "Save the information below (encrypted is recommended), it will not be shown to you again (creating new keys overwrites the previous one):"
-      echo "------------------------------------"
+      echo "====================================="
       echo "Client authorization for service --> ${service}:"
+      echo "-------------------------------------"
       echo
-      echo "GUI service [eg.: SPECTER with Tor Browser], use the key below:"
+      echo "Tor Browser with GUI service [i.e.: Blitz WebUI], use the key below:"
       cat /tmp/k1.prv.key
       echo
-      echo "Headless service [eg.: SSH with Tor Daemon], use the key below:"
-      echo "`sudo -u debian-tor cat /mnt/hdd/tor/${service}/hostname | cut -c1-56`:descriptor:x25519:`cat /tmp/k1.prv.key`"
-      echo "------------------------------------"
-      echo
-      echo "If using Tor Daemon:"
-      echo "On your remote desktop, create the file: '<TorDatDir>/<ClientOnionAuthDir>/blitz-${service}.auth_private'."
-      echo "Code example to run on your remote machine (example using default paths):"
+      echo "-------------------------------------"
+      echo "Tor Daemon with Headless service [i.e.: SSH], run the commands with the key below (example using default debian Tor dir paths):"
       echo
       echo "ClientOnionAuthDir /var/lib/tor/onion_auth/ | sudo tee -a /etc/tor/torrc && sudo chmod 644 /etc/tor/torrc"
-      echo "sudo mkdir -p /var/lib/tor/onion_auth && sudo chown -R debian-tor:debian-tor /var/lib/tor"
-      echo "echo '<onion-addr-without-.onion>:descriptor:x25519:<priv-key-in-base32>' | sudo tee /var/lib/tor/onion_auth/blitz-${service}.auth_private"
+      echo
+      echo "sudo mkdir -p /var/lib/tor/onion_auth"
+      echo
+      echo "echo `sudo -u debian-tor cat /mnt/hdd/tor/${service}/hostname | cut -c1-56`:descriptor:x25519:`cat /tmp/k1.prv.key` | sudo tee /var/lib/tor/onion_auth/blitz-${service}.auth_private"
+      echo
+      echo "sudo chown -R debian-tor:debian-tor /var/lib/tor"
+      echo
+      echo "====================================="
       echo
       # Finish
       rm -f /tmp/k1.pub.key /tmp/k1.prv.key /tmp/k1.prv.pem


### PR DESCRIPTION
https://community.torproject.org/onion-services/advanced/client-auth/
https://github.com/rootzoll/raspiblitz/issues/2306#issuecomment-843562208

New keys overwrite previous one if they are created with the script.
auth on $service - generate 1 key. (I see no reason to loop creating keys as Blitz is supposed to be manage by only one person)
auth off $service - deletes all the keys

I did not repeat the key for services with Tor daemon in the code example at the end because it was not fitting the screen.