### PR TITLE
make sure right owner of /mnt/hdd/tor before last Tor restart

### DIFF
--- a/home.admin/config.scripts/internet.tor.sh
+++ b/home.admin/config.scripts/internet.tor.sh
@@ -431,6 +431,10 @@ EOF
 }
 EOF
 
+  # make sure its the correct owner before last Tor restart
+  sudo chmod -R 700 /mnt/hdd/tor
+  sudo chown -R debian-tor:debian-tor /mnt/hdd/tor
+
   sudo systemctl restart tor@default
 
   echo "OK - Tor is now ON"


### PR DESCRIPTION
I had this exact same issue with v1.7.0 https://github.com/rootzoll/raspiblitz/issues/2176
```
Directory /mnt/hdd/tor/web80/ cannot be read: Permission denied
```
Im not sure where is the best place to `chown`, but before the last restart fixes it. The other option I was thinking is [here](https://github.com/rootzoll/raspiblitz/blob/f571dca4857b800740f8c8e5fc980f32a0fcdb92/home.admin/config.scripts/internet.tor.sh#L369), but did that way just to be safe.

It is already [here](https://github.com/rootzoll/raspiblitz/blob/f571dca4857b800740f8c8e5fc980f32a0fcdb92/home.admin/config.scripts/internet.tor.sh#L302), I know, but is not working unfortunately for the blitz webui.

Also, if this is not corrected, the user will need to ssh or use a normal browser with some webui to correct this before using Tor browser.