### PR TITLE
Avoid hardcoding options list size

### DIFF
--- a/home.admin/00settingsMenuBasics.sh
+++ b/home.admin/00settingsMenuBasics.sh
@@ -75,7 +75,6 @@ echo "run dialog ..."
 # BASIC MENU INFO
 HEIGHT=19 # add 6 to CHOICE_HEIGHT + MENU lines
 WIDTH=45
-CHOICE_HEIGHT=11 # 1 line / OPTIONS
 OPTIONS=()
 
 OPTIONS+=(t 'Run behind TOR' ${runBehindTor})
@@ -97,6 +96,8 @@ if [ ${#runBehindTor} -eq 0 ] || [ "${runBehindTor}" = "off" ]; then
   OPTIONS+=(b 'BTC UPnP (AutoNAT)' ${networkUPnP})  
   OPTIONS+=(l 'LND UPnP (AutoNAT)' ${autoNatDiscovery})
 fi 
+
+CHOICE_HEIGHT=$(("${#OPTIONS[@]}" / 3))
 
 CHOICES=$(dialog \
           --title ' Node Settings & Options ' \


### PR DESCRIPTION
I noticed that settings menu adds unnecessary scrolling if I add one more option to the menu. Looks like it caused by a bunch of magic numbers in this script. `OPTIONS` array is dynamic in size, but its size is statically set in the code. Please note that this patch doesn't solve the issue completely. There is an another variable  (`HEIGHT=19`), which should probably be dynamic too, but I'm not sure which formula to use. The comment states:

```bash
HEIGHT=19 # add 6 to CHOICE_HEIGHT + MENU lines
```

With this patch applied, we can figure out `CHOICE_HEIGHT` dynamically, but I'm not sure where `6` is coming from and how to figure out `MENU lines`