### PR TITLE
disable password auth btc-rpc-explorer

### DIFF
--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -151,7 +151,7 @@ BTCEXP_BITCOIND_PASS=$PASSWORD_B
 BTCEXP_BITCOIND_RPC_TIMEOUT=10000
 # Password protection for site via basic auth (enter any username, only the password is checked)
 # Default: none
-BTCEXP_BASIC_AUTH_PASSWORD=$PASSWORD_B
+#BTCEXP_BASIC_AUTH_PASSWORD=$PASSWORD_B
 # Select optional "address API" to display address tx lists and balances
 # Options: electrumx, blockchain.com, blockchair.com, blockcypher.com
 # If electrumx set, the BTCEXP_ELECTRUMX_SERVERS variable must also be


### PR DESCRIPTION
By default password it is not activated, so I think it should be disabled since the script already create a specific user to run this service and rpc commands are disabled by default.