### PR TITLE
update Dark Science hidden service v2 -> v3

### DIFF
--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -202,7 +202,7 @@ if [ ! -f "/home/joinmarket/.joinmarket/joinmarket.cfg" ] ; then
   echo "Using the bitcoind wallet: wallet.dat"
   #communicate with IRC servers via Tor
   sed -i "s/^host = irc.darkscience.net/#host = irc.darkscience.net/g" /home/joinmarket/.joinmarket/joinmarket.cfg
-  sed -i "s/^#host = darksci3bfoka7tw.onion/host = darksci3bfoka7tw.onion/g" /home/joinmarket/.joinmarket/joinmarket.cfg
+  sed -i "s/^#host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion/host = darkirc6tqgpnwd3blln3yfv5ckl47eg7llfxkmtovrv7c7iwohhb6ad.onion/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   sed -i "s/^host = irc.hackint.org/#host = irc.hackint.org/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   sed -i "s/^#host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion/host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion/g" /home/joinmarket/.joinmarket/joinmarket.cfg
   sed -i "s/^socks5 = false/#socks5 = false/g" /home/joinmarket/.joinmarket/joinmarket.cfg


### PR DESCRIPTION
From joinmarket release-notes-0.8.3:

Darkscience Tor onion address update
The optional Tor onion address in the default config is updated from the old v2 onion to the new v3 onion address. See here. Users should take note and update this in their config files, since v2 onions are going to be deprecated shortly.

1125120 darkscience tor address v3