### PR TITLE
Release file handles by restarting rsyslog service

### DIFF
--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -116,6 +116,7 @@ if [ ${logsMegaByte} -gt 1000 ]; then
     echo "/var/log/nginx is present"
   fi
   sudo rm -r /var/log/*
+  sudo service rsyslog restart
   if [ $nginxLog == 1 ]; then
     sudo mkdir /var/log/nginx
     echo "Recreated /var/log/nginx"


### PR DESCRIPTION
Without restating the service the files hold open by rsyslogd will stay on disk. (Standard Unix behavior)
A side effect can be that the /var/log/syslog file is missing from the filesystem. This got me started searching.