### PR TITLE
Simplify localIP detection and improve compatibility

### DIFF
--- a/home.admin/99connectMenu.sh
+++ b/home.admin/99connectMenu.sh
@@ -166,10 +166,9 @@ HiddenServicePort 8333 127.0.0.1:8333" | sudo tee -a /etc/tor/torrc
     echo "# Running on ${chain}net"
     echo
     localIPrange=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' |\
-    grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' |\
+    grep 'eth0\|wlan0\|enp0\|inet' | tail -n1 | awk '{print $2}' |\
     awk -F. '{print $1"."$2"."$3".0/24"}')
-    localIP=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' |\
-    grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    localIP=$(hostname -I | awk '{print $1}')
     allowIPrange=$(grep -c "rpcallowip=$localIPrange" <  /mnt/hdd/${network}/${network}.conf)
     bindIP=$(grep -c "${chain}.rpcbind=$localIP" <  /mnt/hdd/${network}/${network}.conf)
     rpcTorService=$(grep -c "HiddenServicePort ${BITCOINRPCPORT} 127.0.0.1:${BITCOINRPCPORT}"  < /etc/tor/torrc)

--- a/home.admin/_background.sh
+++ b/home.admin/_background.sh
@@ -94,7 +94,7 @@ do
     echo "*** RECHECK DHCP-SERVER  ***"
 
     # get the local network IP
-    localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    localip=$(hostname -I | awk '{print $1}')
     echo "localip(${localip})"
 
     # detect a missing DHCP config 

--- a/home.admin/config.scripts/blitz.statusscan.sh
+++ b/home.admin/config.scripts/blitz.statusscan.sh
@@ -26,7 +26,7 @@ sudo mkdir /mnt/hdd/temp 2>/dev/null
 sudo chmod 777 -R /mnt/hdd/temp 2>/dev/null
 
 # localIP
-localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep -E -i '(*[eth|ens|enp|eno|wlan|wlp][0-9]$)' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+localip=$(hostname -I | awk '{print $1}')
 echo "localIP='${localip}'"
 
 # temp - no measurement in a VM

--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -27,7 +27,7 @@ if [ "$1" = "status" ]; then
     isInstalled=$(sudo ls /etc/systemd/system/btcpayserver.service 2>/dev/null | grep -c 'btcpayserver.service')
     echo "installed=${isInstalled}"
 
-    localIP=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    localIP=$(hostname -I | awk '{print $1}')
     echo "localIP='${localIP}'"
     echo "httpsPort='23001'"
     echo "publicIP='${publicIP}'"

--- a/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
+++ b/home.admin/config.scripts/bonus.cryptoadvance-specter.sh
@@ -22,7 +22,7 @@ if [ "$1" = "status" ]; then
     echo "configured=1"
 
     # get network info
-    localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    localip=$(hostname -I | awk '{print $1}')
     toraddress=$(sudo cat /mnt/hdd/tor/cryptoadvance-specter/hostname 2>/dev/null)
     fingerprint=$(openssl x509 -in /home/specter/.specter/cert.pem -fingerprint -noout | cut -d"=" -f2)
     echo "localip='${localip}'"

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -29,7 +29,7 @@ fi
 if [ "$1" = "menu" ]; then
 
   # get network info
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0' | grep 'eth0\|wlan0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/lit/hostname 2>/dev/null)
   fingerprint=$(sudo openssl x509 -in /home/lit/.lit/tls.cert -fingerprint -noout | cut -d"=" -f2)
 

--- a/home.admin/config.scripts/bonus.lnbits.sh
+++ b/home.admin/config.scripts/bonus.lnbits.sh
@@ -85,7 +85,7 @@ if [ "$1" = "status" ]; then
   if [ "${LNBits}" = "on" ]; then
     echo "installed=1"
 
-    localIP=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    localIP=$(hostname -I | awk '{print $1}')
     echo "localIP='${localIP}'"
     echo "httpPort='5000'"
     echo "httpsPort='5001'"

--- a/home.admin/config.scripts/bonus.lndconnect.sh
+++ b/home.admin/config.scripts/bonus.lndconnect.sh
@@ -135,7 +135,7 @@ fi
 
 # get the local IP as default host
 if [ ${#host} -eq 0 ]; then
-    host=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    host=$(hostname -I | awk '{print $1}')
 fi
 
 # change host to dynDNS if set

--- a/home.admin/config.scripts/bonus.mempool.sh
+++ b/home.admin/config.scripts/bonus.mempool.sh
@@ -32,7 +32,7 @@ This can take multiple hours.
   fi
 
   # get network info
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0' | grep 'eth0\|wlan0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/mempool/hostname 2>/dev/null)
   fingerprint=$(openssl x509 -in /mnt/hdd/app-data/nginx/tls.cert -fingerprint -noout | cut -d"=" -f2)
 

--- a/home.admin/config.scripts/bonus.rtl.sh
+++ b/home.admin/config.scripts/bonus.rtl.sh
@@ -74,7 +74,7 @@ fi
 if [ "$1" = "menu" ]; then
 
   # get network info
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/RTL/hostname 2>/dev/null)
   fingerprint=$(openssl x509 -in /mnt/hdd/app-data/nginx/tls.cert -fingerprint -noout | cut -d"=" -f2)
 

--- a/home.admin/config.scripts/bonus.sphinxrelay.sh
+++ b/home.admin/config.scripts/bonus.sphinxrelay.sh
@@ -199,7 +199,7 @@ if [ "$1" = "status" ]; then
     echo "installed=0"
   fi
 
-  localIP=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localIP=$(hostname -I | awk '{print $1}')
   echo "localIP='${localIP}'"
   echo "httpsPort='3301'"
   echo "httpPort='3300'"

--- a/home.admin/config.scripts/bonus.thunderhub.sh
+++ b/home.admin/config.scripts/bonus.thunderhub.sh
@@ -23,7 +23,7 @@ fi
 if [ "$1" = "menu" ]; then
 
   # get network info
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/thunderhub/hostname 2>/dev/null)
   fingerprint=$(openssl x509 -in /mnt/hdd/app-data/nginx/tls.cert -fingerprint -noout | cut -d"=" -f2)
 

--- a/home.admin/config.scripts/internet.sh
+++ b/home.admin/config.scripts/internet.sh
@@ -58,11 +58,11 @@ fi
 
 #############################################
 # get local IP (from different sources)
-localip_ALL=$(ip addr 2>/dev/null | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep -E -i '(*[eth|ens|enp|eno|wlan|inet|wlp][0-9]$)' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+localip_ALL=$(hostname -I | awk '{print $1}')
 if [ $(isValidIP ${localip_ALL}) -eq 0 ]; then
   localip_ALL=""
 fi
-localip_LAN=$(ip addr 2>/dev/null | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep -E -i '(*[eth][0-9]$)' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+localip_LAN=$(ip addr 2>/dev/null | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep -E -i '(*[eth][0-9]$)*' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
 if [ $(isValidIP ${localip_LAN}) -eq 0 ]; then
   localip_LAN=""
 fi

--- a/home.admin/config.scripts/lnd.export.sh
+++ b/home.admin/config.scripts/lnd.export.sh
@@ -141,7 +141,7 @@ elif [ "${exportType}" = "scp" ]; then
 ###########################
 elif [ "${exportType}" = "http" ]; then
 
-  local_ip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  local_ip=$(hostname -I | awk '{print $1}')
   randomPortNumber=$(shuf -i 20000-39999 -n 1)
   sudo ufw allow from 192.168.0.0/16 to any port ${randomPortNumber} comment 'temp http server'
   clear

--- a/home.admin/config.scripts/lnd.export.sh
+++ b/home.admin/config.scripts/lnd.export.sh
@@ -123,7 +123,7 @@ elif [ "${exportType}" = "btcpay" ]; then
 ###########################
 elif [ "${exportType}" = "scp" ]; then
 
-  local_ip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  local_ip=$(hostname -I | awk '{print $1}')
   clear
   echo "###### DOWNLOAD BY SCP ######"
   echo "Copy, paste and execute these commands in your client terminal to download the files."


### PR DESCRIPTION
Simplified localIP assignment.  Now works with Odroid HC2 Armbian Buster.  Where "hostname -I" could not be used I added either "inet" or ")*" to the grep commands.  This now also works with Odroid HC2 Armbian Buster.