### PR TITLE
Add systemd hardening for bitcoind, lnd, electrs, and btcrpcexplorer

### DIFF
--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -498,7 +498,7 @@ sudo chown bitcoin:bitcoin -R /mnt/hdd/bitcoin 2>/dev/null
 # FIX BLOCKING FILES (just in case)
 # https://github.com/rootzoll/raspiblitz/issues/1901#issue-774279088
 # https://github.com/rootzoll/raspiblitz/issues/1836#issue-755342375
-sudo rm -f /mnt/hdd/bitcoin/bitcoind.pid 2>/dev/null
+sudo rm -f /run/bitcoind/bitcoind.pid 2>/dev/null
 sudo rm -f /mnt/hdd/bitcoin/.lock 2>/dev/null
 
 #################################

--- a/home.admin/assets/bitcoind.service
+++ b/home.admin/assets/bitcoind.service
@@ -11,16 +11,26 @@ After=bootstrap.service
 [Service]
 User=bitcoin
 Group=bitcoin
-Type=forking
-PIDFile=/mnt/hdd/bitcoin/bitcoind.pid
 ExecStartPre=-/home/admin/config.scripts/blitz.systemd.sh log blockchain STARTED
-ExecStart=/usr/local/bin/bitcoind -daemon -conf=/home/bitcoin/.bitcoin/bitcoin.conf -pid=/mnt/hdd/bitcoin/bitcoind.pid
+ExecStart=/usr/local/bin/bitcoind -daemon -conf=/home/bitcoin/.bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid
+RuntimeDirectory=bitcoind
+RuntimeDirectoryMode=0710
+PIDFile=/run/bitcoind/bitcoind.pid
+Type=forking
 KillMode=process
 Restart=always
 TimeoutSec=120
 RestartSec=30
 StandardOutput=null
 StandardError=journal
+
+# Hardening
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=false # TODO: can we move the bitcoind stuff from /home/ elsewhere?
+NoNewPrivileges=true
+PrivateDevices=true
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/home.admin/assets/lnd.service
+++ b/home.admin/assets/lnd.service
@@ -9,12 +9,14 @@ After=bitcoind.service
 #OnFailure=systemd-sendmail@%n
 
 [Service]
+User=bitcoin
+Group=bitcoin
 EnvironmentFile=/mnt/hdd/raspiblitz.conf
 ExecStartPre=-/home/admin/config.scripts/blitz.systemd.sh log lightning STARTED
 ExecStart=/usr/local/bin/lnd --externalip=${publicIP}:${lndPort} ${lndExtraParameter}
-PIDFile=/home/bitcoin/.lnd/lnd.pid
-User=bitcoin
-Group=bitcoin
+RuntimeDirectory=lnd
+RuntimeDirectoryMode=0710
+PIDFile=/run/lnd/lnd.pid
 LimitNOFILE=128000
 Type=simple
 KillMode=process
@@ -23,6 +25,14 @@ Restart=always
 RestartSec=60
 StandardOutput=null
 StandardError=journal
+
+# Hardening
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=false # TODO: can we move the lnd stuff from /home/ elsewhere?
+NoNewPrivileges=true
+PrivateDevices=true
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target

--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -203,9 +203,19 @@ After=${network}d.service
 WorkingDirectory=/home/btcrpcexplorer/btc-rpc-explorer
 ExecStart=/usr/bin/npm start
 User=btcrpcexplorer
-# Restart on failure but no more than default times (DefaultStartLimitBurst=5) every 10 minutes (600 seconds). Otherwise stop
+Group=btcrpcexplorer
+RuntimeDirectory=btcexp
+RuntimeDirectoryMode=0710
 Restart=on-failure
 RestartSec=600
+
+# Hardening
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=false # TODO: can we move the btcexp stuff from /home/ elsewhere?
+NoNewPrivileges=true
+PrivateDevices=true
+#MemoryDenyWriteExecute=false # 'true' unfortunately breaks it
 
 [Install]
 WantedBy=multi-user.target

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -402,11 +402,21 @@ WorkingDirectory=/home/electrs/electrs
 ExecStart=/home/electrs/electrs/target/release/electrs --index-batch-size=10 --electrum-rpc-addr=\"0.0.0.0:50001\"
 User=electrs
 Group=electrs
+RuntimeDirectory=electrs
+RuntimeDirectoryMode=0710
 Type=simple
 KillMode=process
 TimeoutSec=60
 Restart=always
 RestartSec=60
+
+# Hardening
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=false # TODO: can we move the electrs stuff from /home/ elsewhere?
+NoNewPrivileges=true
+PrivateDevices=true
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added some systemd hardening that I've been running in production for months
without any issues.

Please note, I kept `ProtectHome` disabled, as RaspiBlitz seems to use several 
files from /home/ and I didn't want to make big changes.

As a first step, though, I moved the PID files to /run/ where they existed.

- bitcoind.service: add systemd hardening
- lnd.service: add systemd hardening
- bonus.electrs.sh: add systemd hardening
- bonus.btc-rpc-explorer.sh: add systemd hardening
