### PR TITLE
Identify newest BlitzPy version during sd building

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -609,7 +609,7 @@ sudo -u admin cp -r /home/admin/raspiblitz/home.admin/config.scripts /home/admin
 sudo -u admin chmod +x /home/admin/config.scripts/*.sh
 
 # install newest version of BlitzPy
-blitzpy_wheel=$(ls -trR /home/admin/raspiblitz/home.admin/BlitzPy/dist | grep -E "*any.whl" | tail -n 1)
+blitzpy_wheel=$(ls -tR /home/admin/raspiblitz/home.admin/BlitzPy/dist | grep -E "*any.whl" | tail -n 1)
 blitzpy_version=$(echo ${blitzpy_wheel} | grep -oE "([0-9]\.[0-9]\.[0-9])")
 echo ""
 echo "*** INSTALLING BlitzPy Version: ${blitzpy_version} ***"


### PR DESCRIPTION
Imho as an absolute newbie to coding the -r (reverse) flag in the ls command leads to an install of the oldest (currently 0.2.0), not the newest version (0.3.0) of BlitzPy.