### PR TITLE
fix the instructions for the manual SD card build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,7 +1133,7 @@ A ready-to-use SD card image of RaspiBlitz is provided by us for download, to ge
 
 Now you are ready to start the SD card build script (check the code to see if the installation and config are OK for you). Copy the following command into your terminal and execute:
 
-`wget https://raw.githubusercontent.com/rootzoll/raspiblitz/v1.7/build_sdcard.sh && sudo bash build_sdcard.sh`
+`wget https://raw.githubusercontent.com/rootzoll/raspiblitz/v1.7/build_sdcard.sh && sudo bash build_sdcard.sh "" "" "rootzoll" "v1.7"`
 
 As you can see from the URL, you can find the build script in this Git repo under `build_sdcard.sh`. You can check what gets installed and configured in detail. Feel free to post improvements as pull requests.
 


### PR DESCRIPTION
Just  a quick fix to extend instructions foregoing further complaints about the manual build.

Currently without parameters it downloads the scripts from the `dev` branch which is not stable. 