### PR TITLE
Added timeout to blitz.subscriptions.py -> NEW1 menu option subprocess

### DIFF
--- a/home.admin/config.scripts/blitz.subscriptions.py
+++ b/home.admin/config.scripts/blitz.subscriptions.py
@@ -311,8 +311,12 @@ def main():
 
         # check if Sphinx-Relay is installed
         sphinx_relay = False
-        status_data = subprocess.run(['/home/admin/config.scripts/bonus.sphinxrelay.sh', 'status'],
-                                     stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+        try:
+            status_data = subprocess.run(['/home/admin/config.scripts/bonus.sphinxrelay.sh', 'status'], 
+                stdout=subprocess.PIPE, timeout=10).stdout.decode('utf-8').strip()
+        except Exception as e:
+            print(e)
+            
         if status_data.find("installed=1") > -1:
             sphinx_relay = True
 


### PR DESCRIPTION
If the sphinxrelay service is not available (removed port forwarding ot other cause) selecting  NEW1 from the subscriptions menu hangs the script. This commit adds a 10 second timeout to the  bonus.sphinxrelay.sh subprocess call to prevent this.