### PR TITLE
add manual page that can be called with 'man raspiblitz'

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -55,7 +55,7 @@ fi
 # 3rd optional parameter: GITHUB-USERNAME
 # ---------------------------------------
 # could be any valid github-user that has a fork of the raspiblitz repo - 'rootzoll' is default
-# The 'raspiblitz' repo of this user is used to provisioning sd card 
+# The 'raspiblitz' repo of this user is used to provisioning sd card
 # with raspiblitz assets/scripts later on.
 # If this parameter is set also the branch needs to be given (see next parameter).
 githubUser="$3"
@@ -205,7 +205,7 @@ echo "- OK key added"
 
 echo "*** Adding Tor Sources to sources.list ***"
 torSourceListAvailable=$(sudo grep -c 'https://deb.torproject.org/torproject.org' /etc/apt/sources.list)
-echo "torSourceListAvailable=${torSourceListAvailable}"  
+echo "torSourceListAvailable=${torSourceListAvailable}"
 if [ ${torSourceListAvailable} -eq 0 ]; then
   echo "- adding TOR sources ..."
   if [ "${baseimage}" = "raspbian" ] || [ "${baseimage}" = "raspios_arm64" ] || [ "${baseimage}" = "armbian" ] || [ "${baseimage}" = "dietpi" ]; then
@@ -215,7 +215,7 @@ if [ ${torSourceListAvailable} -eq 0 ]; then
   elif [ "${baseimage}" = "ubuntu" ]; then
     echo "- using https://deb.torproject.org/torproject.org focal"
     echo "deb https://deb.torproject.org/torproject.org focal main" | sudo tee -a /etc/apt/sources.list
-    echo "deb-src https://deb.torproject.org/torproject.org focal main" | sudo tee -a /etc/apt/sources.list    
+    echo "deb-src https://deb.torproject.org/torproject.org focal main" | sudo tee -a /etc/apt/sources.list
   else
     echo "!!! FAIL: No Tor sources for os: ${baseimage}"
     exit 1
@@ -253,7 +253,7 @@ if [ "${baseimage}" = "raspbian" ] || [ "${baseimage}" = "dietpi" ] || \
     # remove unnecessary files
     sudo rm -rf /home/pi/MagPi
     # https://www.reddit.com/r/linux/comments/lbu0t1/microsoft_repo_installed_on_all_raspberry_pis/
-    sudo rm -f /etc/apt/sources.list.d/vscode.list 
+    sudo rm -f /etc/apt/sources.list.d/vscode.list
     sudo rm -f /etc/apt/trusted.gpg.d/microsoft.gpg
   fi
   if [ ! -f /etc/apt/sources.list.d/raspi.list ]; then
@@ -308,7 +308,7 @@ echo "*** PREPARE ${baseimage} ***"
 if [ "$(compgen -u | grep -c dietpi)" -gt 0 ];then
   echo "# Renaming dietpi user to pi"
   sudo usermod -l pi dietpi
-elif [ "$(compgen -u | grep -c pi)" -eq 0 ];then  
+elif [ "$(compgen -u | grep -c pi)" -eq 0 ];then
   echo "# Adding the user pi"
   sudo adduser --disabled-password --gecos "" pi
   sudo adduser pi sudo
@@ -320,7 +320,7 @@ if [ "${baseimage}" = "raspbian" ]||[ "${baseimage}" = "raspios_arm64" ]||\
 
   echo ""
   echo "*** PREPARE RASPBIAN ***"
-  sudo apt install -y raspi-config 
+  sudo apt install -y raspi-config
   # do memory split (16MB)
   sudo raspi-config nonint do_memory_split 16
   # set to wait until network is available on boot (0 seems to yes)
@@ -618,12 +618,21 @@ sudo -u admin cp -r /home/admin/raspiblitz/home.admin/config.scripts /home/admin
 sudo -u admin chmod +x /home/admin/config.scripts/*.sh
 sudo -u admin chmod +x /home/admin/setup.scripts/*.sh
 
+## creat man page
+sudo apt install -y gzip pandoc
+sudo mkdir -p /usr/local/man/man1
+pandoc /home/admin/assets/MANUAL.md -s -t man -o /home/admin/assets/raspiblitz.1
+sudo cp /home/admin/assets/raspiblitz.1 /tmp/
+sudo gzip -f /tmp/raspiblitz.1
+sudo mv /tmp/raspiblitz.1.gz /usr/local/man/man1/
+sudo mandb -q -f /usr/local/man/man1/raspiblitz.1.gz
+
 # install newest version of BlitzPy
 blitzpy_wheel=$(ls -tR /home/admin/raspiblitz/home.admin/BlitzPy/dist | grep -E "*any.whl" | tail -n 1)
 blitzpy_version=$(echo ${blitzpy_wheel} | grep -oE "([0-9]\.[0-9]\.[0-9])")
 echo ""
 echo "*** INSTALLING BlitzPy Version: ${blitzpy_version} ***"
-sudo -H /usr/bin/python -m pip install "/home/admin/raspiblitz/home.admin/BlitzPy/dist/${blitzpy_wheel}" >/dev/null 2>&1 
+sudo -H /usr/bin/python -m pip install "/home/admin/raspiblitz/home.admin/BlitzPy/dist/${blitzpy_wheel}" >/dev/null 2>&1
 
 # make sure lndlibs are patched for compatibility for both Python2 and Python3
 if ! grep -Fxq "from __future__ import absolute_import" /home/admin/config.scripts/lndlibs/rpc_pb2_grpc.py; then
@@ -722,7 +731,7 @@ sudo bash -c "echo '# end of pam-auth-update config' >> /etc/pam.d/common-sessio
 # *** fail2ban ***
 # based on https://stadicus.github.io/RaspiBolt/raspibolt_21_security.html
 echo "*** HARDENING ***"
-sudo apt install -y --no-install-recommends python3-systemd fail2ban 
+sudo apt install -y --no-install-recommends python3-systemd fail2ban
 
 # *** CACHE DISK IN RAM ***
 echo "Activating CACHE RAM DISK ... "
@@ -731,7 +740,7 @@ sudo /home/admin/config.scripts/blitz.cache.sh on
 # *** Wifi, Bluetooth & other configs ***
 if [ "${baseimage}" = "raspbian" ]||[ "${baseimage}" = "raspios_arm64"  ]||\
    [ "${baseimage}" = "debian_rpi64" ]; then
-   
+
   if [ "${modeWifi}" == "false" ]; then
     echo ""
     echo "*** DISABLE WIFI ***"
@@ -768,7 +777,7 @@ if [ "${baseimage}" = "raspbian" ]||[ "${baseimage}" = "raspios_arm64"  ]||\
   echo "*** DISABLE AUDIO (snd_bcm2835) ***"
   sudo sed -i "s/^dtparam=audio=on/# dtparam=audio=on/g" /boot/config.txt
   echo
-  
+
   # disable DRM VC4 V3D
   echo "*** DISABLE DRM VC4 V3D driver ***"
   dtoverlay=vc4-fkms-v3d
@@ -777,7 +786,7 @@ if [ "${baseimage}" = "raspbian" ]||[ "${baseimage}" = "raspios_arm64"  ]||\
 
   # I2C fix (make sure dtparam=i2c_arm is not on)
   # see: https://github.com/rootzoll/raspiblitz/issues/1058#issuecomment-739517713
-  sudo sed -i "s/^dtparam=i2c_arm=.*//g" /boot/config.txt 
+  sudo sed -i "s/^dtparam=i2c_arm=.*//g" /boot/config.txt
 fi
 
 # *** FATPACK *** (can be activated by parameter - see details at start of script)
@@ -810,7 +819,7 @@ if [ "${fatpack}" == "true" ]; then
   echo "*** FALLBACK NODE LIST ***"
   sudo -u admin curl -H "Accept: application/json; indent=4" https://bitnodes.io/api/v1/snapshots/latest/ -o /home/admin/fallback.nodes
   byteSizeList=$(sudo -u admin stat -c %s /home/admin/fallback.nodes)
-  if [ ${#byteSizeList} -eq 0 ] || [ ${byteSizeList} -lt 10240 ]; then 
+  if [ ${#byteSizeList} -eq 0 ] || [ ${byteSizeList} -lt 10240 ]; then
     echo "WARN: Failed downloading fresh FALLBACK NODE LIST --> https://bitnodes.io/api/v1/snapshots/latest/"
     sudo rm /home/admin/fallback.nodes 2>/dev/null
     sudo cp /home/admin/assets/fallback.nodes /home/admin/fallback.nodes
@@ -1106,11 +1115,11 @@ if [ ${correctKey} -lt 1 ] || [ ${goodSignature} -lt 1 ]; then
   echo "!!! BUILD FAILED --> PGP verification not OK / signature(${goodSignature}) verify(${correctKey})"
   exit 1
 else
-  echo 
+  echo
   echo "****************************************************************"
   echo "OK --> the PGP signature of the C-lightning SHA256SUMS is correct"
   echo "****************************************************************"
-  echo 
+  echo
 fi
 
 sudo -u admin wget https://github.com/ElementsProject/lightning/releases/download/v${CLVERSION}/clightning-v${CLVERSION}.zip

--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -14,57 +14,10 @@ function blitz() {
   ./00raspiblitz.sh
 }
 
-# command: blitzhelp
-# gives overview of commands
-function blitzhelp() {
-  echo
-  echo "Blitz commands are consolidated here."
-  echo
-  echo "Menu access:"
-  echo "  raspiblitz   menu"
-  echo "  menu         menu"
-  echo "  bash         menu"
-  echo "  repair       menu > repair"
-  echo
-  echo "Checks:"
-  echo "  status       informational Blitz status screen"
-  echo "  sourcemode   copy blockchain source modus"
-  echo "  check        check if Blitz configuration files are correct"
-  echo "  debug        print debug logs"
-  echo "  debug   -l   print debug logs with bin link"
-  echo "  patch        sync scripts with latest set github and branch"
-  echo "  github       jumping directly into the options to change branch/repo/pr"
-  echo
-  echo "Power:"
-  echo "  restart      restart the node"
-  echo "  off          shutdown the node"
-  echo
-  echo "Display:"
-  echo "  hdmi         switch video output to HDMI"
-  echo "  lcd          switch video output to LCD"
-  echo "  headless     switch video output to HEADLESS"
-  echo
-  echo "BTC tx:"
-  echo "  torthistx    broadcast transaction through Tor to Blockstreams API and into the network"
-  echo "  gettx        retrieve transaction from mempool or blockchain and print as JSON"
-  echo "  watchtx      retrieve transaction from mempool or blockchain until certain confirmation target"
-  echo
-  echo "LND:"
-  echo "  balance      your satoshi balance"
-  echo "  channels     your lightning channels"
-  echo "  fwdreport    show forwarding report"
-  echo
-  echo "Users:"
-  echo "  bos          Balance of Satoshis"
-  echo "  chantools    ChanTools"
-  echo "  lit          Lightning Terminal"
-  echo "  jm           JoinMarket"
-  echo "  pyblock      PyBlock"
-  echo
-  echo "Extras:"
-  echo "  whitepaper   download the whitepaper from the blockchain to /home/admin/bitcoin.pdf"
-  echo "  notifyme     wrapper for blitz.notify.sh that will send a notification using the configured method and settings"
-}
+
+# command version
+# prints blitz version
+function version(){ cat /home/admin/_version.info; }
 
 # command: raspiblitz
 # calls the the raspiblitz mainmenu (legacy)
@@ -181,7 +134,7 @@ function status() {
     #echo
     #echo -en "Screen is updating in a loop .... press 'x' now to get back to menu."
     read -n 1 -t 6 keyPressed
-    #echo -en "\rGathering information to update info ... please wait.                \n"  
+    #echo -en "\rGathering information to update info ... please wait.                \n"
     # check if user wants to abort session
     if [ "${keyPressed}" = "x" ]; then
       echo
@@ -294,10 +247,10 @@ if [ -f "/mnt/hdd/raspiblitz.conf" ] && [ $(grep -c "lit=on"  < /mnt/hdd/raspibl
     --tlscertpath=/home/lit/.lit/tls.cert \
     --macaroonpath=/home/lit/.faraday/${chain}net/faraday.macaroon"
   alias lit-loop="sudo -u lit loop --rpcserver=localhost:8443 \\
-    --tlscertpath=/home/lit/.lit/tls.cert \\	
+    --tlscertpath=/home/lit/.lit/tls.cert \\
     --macaroonpath=/home/lit/.loop/${chain}net/loop.macaroon"
   alias lit-pool="sudo -u lit pool --rpcserver=localhost:8443 \
-    --tlscertpath=/home/lit/.lit/tls.cert \	
+    --tlscertpath=/home/lit/.lit/tls.cert \
     --macaroonpath=/home/lit/.pool/${chain}net/pool.macaroon"
 fi
 
@@ -316,7 +269,7 @@ function gettx() {
 
 # command: watchtx
 # try to retrieve transaction from mempool or blockchain until certain confirmation target
-# is reached and then exit cleanly. Default is to wait for 2 confs and to sleep for 60 secs. 
+# is reached and then exit cleanly. Default is to wait for 2 confs and to sleep for 60 secs.
 # $ watchtx "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16" 6 30
 function watchtx() {
     tx_id="${1}"
@@ -348,8 +301,8 @@ function watchtx() {
 }
 
 # command: notifyme
-# A wrapper for blitz.notify.sh that will send a notification using the configured 
-# method and settings. 
+# A wrapper for blitz.notify.sh that will send a notification using the configured
+# method and settings.
 # This makes sense when waiting for commands to finish and then sending a notification.
 # $ notifyme "Hello there..!"
 # $ ./run_job_which_takes_long.sh && notifyme "I'm done."

--- a/home.admin/assets/MANUAL.md
+++ b/home.admin/assets/MANUAL.md
@@ -30,7 +30,7 @@ Raspiblitz - control your bitcoin node
 
 ## CHECK
 
-**-v**, **--version**
+**version**
 : Displays the software version.
 
 **status**

--- a/home.admin/assets/MANUAL.md
+++ b/home.admin/assets/MANUAL.md
@@ -1,0 +1,149 @@
+% RASPIBLITZ(1) raspiblitz 1.7.1
+% The Raspiblitz Developers
+% October 2021
+
+
+# NAME
+
+Raspiblitz - control your bitcoin node
+
+
+# SYNOPSIS
+
+**COMMAND** [*OPTION*]
+
+
+# DESCRIPTION
+
+**raspiblitz** is one of the command that can be used on the fully featured bitcoin and lightning node written in shellscript and python. It is a node manager to faciliate and speed up usage and interaction with the bitcoin blockchain and peering with other lightning nodes. This manual describe commom functions that can be called when using the Raspiblitz software.
+
+
+# OPTIONS
+
+## MENUS
+
+**blitz**, **raspiblitz**, **menu**, **bash**
+: Display the main menu.
+
+**repair**
+: Display the repair menu.
+
+## CHECK
+
+**-v**, **--version**
+: Displays the software version.
+
+**status**
+: Display the info screen.
+
+**sourcemode**
+: Copy blockchain source modus.
+
+**check**
+: Check if Blitz configuration files are correct.
+
+**debug** <*-l*>
+: Print debug logs, optionally create a shareable link with the *-l* option.
+
+**patch**
+: Sync scripts with latest set github and branch.
+
+**github**
+: Jumping directly into the options to change branch/repo/pr.
+
+## POWER
+
+**restart**
+: Restart the node safely.
+
+**off**
+Shutodwn the node safely.
+
+## DISPLAY
+
+**hdmi**
+: Switch video output to HDMI and restart the node.
+
+**lcd**
+: switch video output to LCD and restart the node.
+
+**headless**
+: Switch video output to HEADLESS and restart the node.
+
+## BTC TX
+
+**torthistx** [TXID]
+: Broadcast transaction through Tor to Blockstreams API and into the network.
+
+**gettx** [TXID]
+: Retrieve transaction from mempool or blockchain and print as JSON.
+
+**watchtx** [TXID] <*WAIT_N_CONFS*> <*SLEEP_TIME*>
+: retrieve transaction from mempool or blockchain until certain confirmation target.
+
+## LND
+
+**balance**
+: Your satoshi balance.
+
+**channels**
+: Your lightning channels.
+
+**fwdreport**
+: Show forwarding report.
+
+## USERS
+
+**bos**
+: Switch to the Balance of Satoshis user.
+
+**chantools**
+: Switch to the Chantools user.
+
+**lit**
+: Switch to the Lightning Terminal user.
+
+**jm**
+: Switch to the Joinmarket user.
+
+**pyblock**
+: Switch to the PyBlock user.
+
+## EXTRAS
+
+**release**
+: Prepare for a blitz release
+
+**whitepaper**
+: Download the whitepaper from the blockchain to admin home folder.
+
+**notifyme** <*success|fail*>
+: Wrapper for blitz.notify.sh that will send a notification using the configured method and settings.
+
+**qr** [STRING]
+: QR encodes the string and send to stout.
+
+
+# EXIT VALUE
+**0**
+: Success
+
+**1**
+: Fail
+
+
+# BUGS
+
+Possible.
+
+First take a look at the reported issues on https://github.com/raspiblitz/issues and use keywords on the search bar. If you can't find a solution, open a new issue.
+
+
+# SEE ALSO
+
+bash(1), regex(7), sed(1), awk(1), read(2), find(1)
+
+
+# COPYRIGHT
+
+Copyright (c) 2021 The RaspiBlitz developers


### PR DESCRIPTION
See issue https://github.com/rootzoll/raspiblitz/issues/2601
The manual is written in Markdown format and converted to Man with pandoc.

can call the man as any other man page as it was added to mandb
```
man raspiblitz
```

Mans are for commands, but as blitz is just one of the commands, a single man page is better.

![image](https://user-images.githubusercontent.com/69700936/136629354-6797a303-2352-4532-81d6-cfdf51946337.png)
![image](https://user-images.githubusercontent.com/69700936/136651568-b03f6901-66ef-4949-bd02-5bb7755f9742.png)
