### PR TITLE
README: Improve clarity, spell fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In the end your RaspiBlitz should look like this:
 |Instructions|[Download 1.7.1 image](https://raspiblitz.fulmo.org/images/raspiblitz-v1.7.1-2021-10-12.img.gz) and [Flash the sd card](README.md#write-the-sd-card-image-to-your-sd-card)|[Build your own sd card image](#build-the-sd-card-image)|
 |Verify what?|[Signature file](https://raspiblitz.fulmo.org/images/raspiblitz-v1.7.1-2021-10-12.img.gz.sig) and [verify the Sig](FAQ.md#how-to-verify-the-sd-card-image-after-download) OR SHA-256 (below)|All of the code, don't trust, verify|
 
-If downloading the maintainer sd card image:
+If downloading the maintainer SD card image:
 * GPG 64-bit: 1C73 060C 7C17 6461
 * SHA-256: 4b5481e0f27afe9b5aa8bab5805f7df033f2596db29a1e47c25d2f0109d9c003
 
@@ -164,7 +164,7 @@ Now open up a terminal ([OSX](https://www.youtube.com/watch?v=5XgBd6rjuDQ)/[Win1
 
 *Further down you will find more [detailed documentation of the setup process](#setup-process-detailed-documentation).*
 
-* [I cannot connect per SSH to my RaspiBlitz. What to do?](FAQ.md#i-cannot-connect-per-ssh-to-my-raspiblitz-what-to-do)
+* [I cannot connect by SSH to my RaspiBlitz. What to do?](FAQ.md#i-cannot-connect-per-ssh-to-my-raspiblitz-what-to-do)
 
 ## Support
 
@@ -212,17 +212,18 @@ If you are looking for a tutorial on how to organize a workshop to build the Ras
 
 ### Basic Setup
 
- Everytime you start with a fresh sd card image you will get offerered different options. For example this is also the point where you can import a Migration file from an older RaspiBlitz - read about Migration [further down](README.md#import-a-migration-file). But because you are setting up a brand new RaspiBlitz you will choose here `FRESHSETUP`.
+Every time you start with a fresh SD card image you will be offered different options. For example this is also the point where you can import a Migration file from an older RaspiBlitz - read about Migration [further down](README.md#import-a-migration-file). But because you are setting up a brand new RaspiBlitz you will choose here `FRESHSETUP`.
 
 ![SSH0](pictures/ssh0-welcome2.png)
 
-Then you will be asked what todo with the connected harddrive/ssd.
+Then you will be asked what to do with the connected hard drive/SSD.
 
-If there is already a blockchain on your hardrive/ssd - you will be asked if you want to use this pre-synced/validated data or if its OK to delete it. If there is no blockchain data - this question will be skipped.
+If there is already a blockchain on your hard drive/SSD you will be asked if you want to use this pre-synced/validated data or if its OK to delete it.
+If there is no blockchain data this question will be skipped.
 
 ![SSH0](pictures/ssh0-askchain.png)
 
-Finally you have to agree that all (other) data will get deleted on the harddrive/ssd (except the blockchain if you choosed that before). This might take some seconds.
+Finally you have to agree that all (other) data on the hard drive/SSD will be deleted, except the blockchain if you selected that previously. This might take some seconds.
 
 ![SSH0](pictures/ssh0-formathdd.png)
 
@@ -230,21 +231,23 @@ First thing to setup is giving your RaspiBlitz a name:
 
 ![SSH1](pictures/ssh1-name.png)
 
-This name is given to the RaspiBlitz as a public alias of the lightning node for everybody to see.
+The name you choose for your RaspiBlitz will also be used as your public alias of your lightning node so choose wisely.
 
-Then you can choose which Lightning implementation you want to run on top of your Bitcoin Fullnode. RaspiBlitz started with `LND` from Lightning Labs which is used by most other RaspberryPi lightning nodes and works with most additional apps. But you can now also choose `CL` for c-lightning by Blockstream which is a good choice for already more experienced node operators & lightning developers that want to use the highly customizable plug-in structure that c-lightning offers.
+Then you can choose which Lightning implementation you want to run on top of your Bitcoin Fullnode. RaspiBlitz started with `LND` from Lightning Labs which is used by most other RaspberryPi lightning nodes and works with most additional apps. But you can now also choose `CL` for c-lightning by Blockstream which is a good choice for more experienced node operators & lightning developers that want to use the highly customizable plugin structure that c-lightning offers.
 
-Its also possible to use both in parallel on your RaspiBlitz later on - just pick one to start with or choose `NONE` is your only interested in running a Fullnode without Lightning.
+It's also possible to use both lightning node implementations in parallel on your RaspiBlitz later on - just pick one to start with for now.
+
+Choose `NONE` if you're only interested in running a Bitcoin full node without Lightning.
 
 ![SSH1](pictures/ssh1-layer2.png)
 
 *In the following we show the setup with LND - which is very similar to the steps with c-lightning.*
 
-If you choosed one of the lightning implementations you will now be asked if you want to start a `NEW` wallet/lightning node or if you had an `OLD` lightning wallet/node that you want to re-create.
+If you chose to use one of the lightning implementations you will now be asked if you want to start a `NEW` wallet/lightning node or if you have an `OLD` lightning wallet/node that you want to re-create.
 
 ![SSH1](pictures/ssh1-oldnew.png)
 
-Normally you just chose `NEW` here .. but to recover an old wallet you have the following options if you choose `OLD`:
+Normally you just chose `NEW` here, but to recover an old wallet you have the following options if you choose `OLD`:
 
 ![SSH1](pictures/ssh2-layer2old.png)
 
@@ -256,69 +259,71 @@ Choose this option if you have made a complete backup of the LND or c-lightning 
 
 ##### SEED+SCB Words Seed & channel.backup file (OK)
 
-Next best option is, if you have the channel.backup file and the word list seed. This is the best chance to recover the on-chain funds you had in open channels. But all channels you had open before will be closed during this procedure.
+The next best option is if you have the channel.backup file and the word list seed. This allows you to recover all on-chain funds (i.e. "bitcoin balance") in the lightning wallet, and gives you a good chance of recovering the off-chain funds (i.e. "lightning balance") you had in open channels, as long as the remote peer supports `option_data_loss_protect` which is very common since 2020. All channels you had open before will be closed during this procedure. See [Bitcoin Optech - Static Channel Backups](https://bitcoinops.org/en/topics/static-channel-backups/) for more background information on this process.
 
 ##### ONLY SEED Only Seed Word List (Fallback)
 
-If you just have the word list (RaspiBlitz 1.1 and older) you can at least try to recover your on-chain funds. Recovery of channel funds is not very likely in this scenario.
+If you only have the seed word list (RaspiBlitz 1.1 and older) you can at least try to recover your on-chain funds. Recovery of channel funds is not very likely in this scenario.
 
 But normally you are setting up a new node - so simply choose `NEW` in the menu.
 
 ![SSH2](pictures/ssh2-passwords.png)
 
-Finally you have to set 3 passwords called A, B & C ... please choose here single strings (without spaces and special characters) that are at least 8 chars long.
+Finally you have to set 3 passwords called A, B & C. For each password please choose unique, single strings, without spaces and special characters, that are at least 8 chars long.
 
-You can use this [RaspiBlitz Recovery Sheet (PDF)](https://github.com/rootzoll/raspiblitz/raw/v1.7/home.admin/assets/RaspiBlitzRecoverySheet.pdf) to write those passwords down for save storage and also use it later on for your Seed Words.
+You can use this [RaspiBlitz Recovery Sheet (PDF)](https://github.com/rootzoll/raspiblitz/raw/v1.7/home.admin/assets/RaspiBlitzRecoverySheet.pdf) to write those passwords down for safe storage and also use it later on for your Seed Words.
 
 *The password A,B,C idea is based on the [RaspiBolt Guide Preparations](https://stadicus.github.io/RaspiBolt/raspibolt_10_preparations.html#write-down-your-passwords) - check out for more background.*
 
-First Password A is requested - this is the new password which has to be used for every SSH login for now. It's also set for the existing users: admin, root, bitcoin & pi.
+First, password A is requested - this is the password which will be used for SSH login and it's also set for the existing users: admin, root, bitcoin & pi.
 
 *The bitcoin and lightning services will later run in the background (as daemon) and use the separate user “bitcoin” for security reasons. This user does not have admin rights and cannot change the system configuration.*
 
-Then enter the Password B - this is internally used for the bitcoin RPC interface. But also as login for additional apps like the RTL-WebGUI or the Blockexplorer:
+Then enter password B - this is internally used for the bitcoin RPC interface.
+It is also used as login for additional apps like the RTL-WebGUI or the Blockexplorer.
 
-And finally enter the Password C - this is used to encrypt/lock the lightning wallet on the harddrive/ssd and is used by LND. Everytime a lightning node is started/rebooted LND needs load the wallet into memory to work with and ask you for the Password C to "unlock" the wallet. 
+And finally enter password C - this is used to encrypt/lock the lightning wallet on the hard drive/SSD and is used by LND.
+Every time a lightning node is started/rebooted LND needs load the wallet into memory to work with and ask you for password C to "unlock" the wallet.
 
-*In the early RaspiBlitz versions there was also an additional Pasword D, that is no longer in use.*
+*In the early RaspiBlitz versions there was also an additional password D, that is no longer in use.*
 
-After this the setup process will need some time to set everything up - just wait until it's finished - this can take from 10 to 30 minutes:
+After this the setup process will need some time to set everything up - just wait until it's finished. This can take from 10 to 30 minutes:
 
 ![SSH4](pictures/ssh4-scripts.png)
 
 ### Final Setup
 
-Once the basic setup ran thru you lightning node & wallet was created and you get presented the important backup seed words which you need to write down on paper and store them in a secure location. You will need to confirm that you wrote the seed words down before you can continue.
+Once the basic setup has completed your lightning node will be setup & your lightning wallet will be created for you. As part of this process you will be presented with your lightning node "seed words" which you *MUST* write down on paper (or engrave into steel) and store in a secure location. You will need to confirm that you wrote the seed words down before you can continue.
 
 ![SSH4](pictures/ssh4-seed.png)
 
-WRITE YOUR PERSONAL WORDS DOWN before you continue - you will need them to recover funds in case of failing hardware etc. If you just want to try/experiment with the RaspiBlitz, at least take a photo with your smartphone just in case. If you plan to keep your RaspiBlitz running, store this word list offline or in a password safe.
+WRITE YOUR SEED WORDS DOWN before you continue - you will need them to recover funds in case of failing hardware etc. If you just want to try/experiment with the RaspiBlitz, at least take a photo of the seed words with your smartphone, so you have something just in case. If you plan to keep your RaspiBlitz running store this word list offline or in a password safe.
 
-You can use this [RaspiBlitz Recovery Sheet (PDF)](https://github.com/rootzoll/raspiblitz/raw/v1.7/home.admin/assets/RaspiBlitzRecoverySheet.pdf) to write down those seed words for save storage.
+You can use this [RaspiBlitz Recovery Sheet (PDF)](https://github.com/rootzoll/raspiblitz/raw/v1.7/home.admin/assets/RaspiBlitzRecoverySheet.pdf) to write down your seed words for safe storage.
 
-If you dont had a full copy of the blockchain pre-synced/validated on your harddrive/ssd then you will now be asked how you want to get your copy of the blockchain .. there are two basic options here:
+If you don't have a full copy of the blockchain pre-synced/validated on your hard drive/SSD then you will now be asked how you want to get your copy of the blockchain. There are two basic options :
 
 ![SSH4](pictures/ssh4-blockchain.png)
 
-#### 1. SYNC - Selfvalidate all Blocks
+#### 1. SYNC - Self validate all Blocks
 
-With the new RaspberryPi 4 (with SSD & min 2GB RAM) this is the best way to go. It will take around 3-6 days to sync & validate directly with the bitcoin network. With this option, you have done it the original `don't trust, verify` way.
+For the new RaspberryPi 4 (with SSD & min 2GB RAM) this is the best way to go. It will take around 3-6 days to sync & validate directly with the bitcoin network. With this option, you have done it the original `don't trust, verify` way.
 
 *For the old RaspberryPi 3 this is not recommended. A RaspberryPi 3 has a very low power CPU and syncing+validating the blockchain directly with the peer2peer network can take multiple weeks - that's why for a RP3 you should choose the COPY option .*
 
 #### 2. COPY - Copy from Laptop or another RaspiBlitz over Local Network
 
-If you have a friend that is already running a synced RaspiBlitz or you have a laptop with enough free space on the harddrive that can download & validate the Blockchain much faster you can also choose the `COPY` option. You can then delete existing blockchain your RaspiBlitz already started syncing for you. 
+If you have a friend that is already running a synced RaspiBlitz or you have a laptop with enough free space on the hard drive that can download & validate the Blockchain much faster you can also choose the `COPY` option. You can then delete existing blockchain your RaspiBlitz already started syncing for you. 
 
 ![SSH4](pictures/ssh4-copy.png)
 
 To copy from another RaspiBlitz choose `BLITZ` and follow the instructions. Know that the other Blitz will be offline to the lightning network during the copy that will take multiple hours.
 
-To copy from your laptop/computer (`WINDOWNS`, `MACOS` & `LINUX` options) you first need to download & validate the blockchain on your own computer/laptop. Todo so install latest bitcoin-core (0.18.1 or higher) from [bitcoin.org](https://bitcoin.org/en/download) and keep it running until blockchain is synced (will need around 400 GB). Then under the `COPY` option choose the Operating System. The copy will be done over the local network by SCP (SSH file transfer) - follow the instructions given in the dialogs. It's advised to keep a backup of the bitcoin-core & the blockchain data (e.g. on your laptop) in case you need to re-setup the RaspiBlitz.
+To copy from your laptop/computer (`WINDOWS`, `MACOS` & `LINUX` options) you first need to download & validate the blockchain on your own computer/laptop. To do so, install latest bitcoin-core (0.18.1 or higher) from [bitcoin.org](https://bitcoin.org/en/download) and keep it running until the blockchain is synced (will need around 400 GB). Then under the `COPY` option choose the Operating System. The copy will be done over the local network by SCP (SSH file transfer) - follow the instructions given in the dialogues. It's advised to keep a backup of Bitcoin Core & the blockchain data directory on your laptop/computer in case you need to re-setup the RaspiBlitz.
 
-More details: [I have the full blockchain on another computer. How do I copy it to the RaspiBlitz?](FAQ.md#i-have-the-full-blockchain-on-another-computer-how-do-i-copy-it-to-the-raspiblitz)
+More details: [I have the full blockchain on another computer. How do I copy it to the RaspiBlitz?](FAQ.md#i-have-the-full-blockchain-on-another-storage-how-do-i-copy-it-to-the-raspiblitz)
 
-If you dont have the Bitcoin Blockchain already on another laptop or RaspiBlitz simply choose `SELFSYNC`.
+If you don't have the Bitcoin blockchain already on another laptop or RaspiBlitz simply choose `SELFSYNC`.
 
 And hooray :D Your RaspiBlitz is ready to go! Welcome new node operator.
 
@@ -328,15 +333,15 @@ If you hit OK, the RaspiBlitz will go into a final reboot.
 
 ![SSH5](pictures/ssh5-reboot.png)
 
-Just wait a bit and then the SSH command to login again. Dont forget to use this time your password A ... which is always for password for system login.
+Just wait a bit and then the SSH command to login again. Logging in via SSH requires password A that you setup earlier.
 
 ![SSH5](pictures/ssh5-unlock.png)
 
-If you run LND you will be asked to unlock your wallet - thats always your password C. BTW under `SETTINGS` in the main menu you can activate the Auto-Unlock if you prefer.
+If you run LND you will be asked to unlock your wallet - this requires password C. There is an option to activate auto-unlock of LND if you prefer, this can be found under `SETTINGS` in the main menu.
 
 ![SSH5](pictures/ssh5-blocksync.png)
 
-Remeber that now your RaspiBlitz might need a longer time to sync/validate the blockchain - this can be multiple days. In the beginnig you might see fast progress but its normal that this gets slower later on. Also your RaspberryPi CPU might get quite hot ... thats also OK during this inital sync time - the RaspberryPi has its own protection against overheating and will push thru.
+Your RaspiBlitz might need quite some time to sync and validate the blockchain -- this can be multiple days. In the beginning you might see fast progress but this gets slower later on as historical blocks start to get fuller. Your RaspberryPi CPU will likely get quite hot during initial sync. However this is OK as the RaspberryPi has its own protection against overheating and will ensure the CPU doesn't critically overheat.
 
 ### Main Menu
 
@@ -350,15 +355,16 @@ All options on the main menu will be explained below in the feature documentatio
 
 If you need an idea of what the most basic next steps to experience Lightning would be:
 
-* Fund on-chain Wallet
+* Fund on-chain wallet
 * Open a channel
 * Make a payment
 
-If you would prefer to do this from a web browser with a dashboard UI, instead of an SSH terminal, go to `SERVICES`, activate the `RTL Webinterface`, and after install you will find a new menu option for RTL in the SSH main menu - it will give you all the information so that you can now open the RTL Webinterface in your browser.
+If you would prefer to do this from a web browser with a dashboard UI, instead of an SSH terminal, go to `SERVICES`, activate the `RTL Webinterface`, and after install you will find a new menu option for RTL in the SSH main menu - it will give you all the information so that you can now open the RTL web interface in your browser.
 
 Have fun riding the lightning :D
 
-*BTW always love seeing photos of new RaspBlitzes added to the network on twitter @rootzoll - also there is a [RaspiBlitz Donation Page](https://raspiblitz.org/#donation), why not try to send some satoshis there with your new RaspiBlitz :D *
+*We always love seeing photos of new RaspBlitzes added to the network, tag [@rootzoll](https://twitter.com/rootzoll) in your pictures on twitter.
+There is also a [RaspiBlitz Donation Page](https://raspiblitz.org/#donation), why not try to send some satoshis there with your new RaspiBlitz :D *
 
 * [How can I get further help/support?](#support)
 
@@ -382,11 +388,11 @@ This is the screen that gets displayed on the LCD/display. It's useful to call i
 
 #### LIGHTNING (Basic Node Management)
 
-Under `LND/c-lightning Wallet options` you find some basic steps to manage your Lightning node. Those are very simplified in the RaspiBlitz SSH menu for the reason of learning. For more advanced management of your Lightning node see additional apps under `SERVICES`.
+Under `LND/c-lightning Wallet options` you will find some basic tools for managing your Lightning node. These are very simplified in the RaspiBlitz SSH menu for learning purposes. For more advanced management of your Lightning node see additional apps under `SERVICES`.
 
 ##### FUNDING: Fund your on-chain Wallet
 
-Before you can open channels with other nodes you need to put some coins in your on-chain wallet (managed by your lightning sofware). Use this option to generate an address to send funds to.
+Before you can open channels with other nodes you need to put some coins in your on-chain wallet (managed by your lightning software). Use this option to generate an address to send funds to.
 
 *Reminder: RaspiBlitz is still experimental software. With funding your lightning node you accept the risk of losing funds. So just play with small amounts - something in the area of 20 EUR/USD should be enough to make your first experiences. Also, it's a good privacy practice to [coinjoin your coins](https://bitcoin-only.com/privacy) before sending them to any Lightning Network wallet.*
 
@@ -404,7 +410,8 @@ To open a payment channel with another node, you can use this option.
 
 Find interesting nodes to open channels with through online directories like [1ML.com](https://1ml.com/) or join the RaspiBlitz NodeManager telegram group to meet people to open channels with: https://t.me/raspiblitz
 
-Bear in mind that this option will open a public channel that can be seen by everyone in the network. This is good if you want to route payments. If your intention is to use it privately only, you must go to the command line and open the channel with the -private option.
+Bear in mind that this option will open a public channel that can be seen by everyone in the network and chosen by them as part of their payment route. This is good if you want to route payments.
+If you do not want to route payments for others, you can use a so-called "private" (i.e. unannounced) channel which others cannot use as part of their payment route. To do this you must go to the command line and open the channel with the `-private` option.
 
 *This is just a very basic shell script. For more usability, try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
 
@@ -414,7 +421,7 @@ Pay an invoice through lightning.
 
 *This is just a very basic shell script. For more usability try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
 
-If you are looking for something to test payments with Lightning ... why not [donate some satoshis to RaspiBlitz development](https://raspiblitz.org/#donation)? Thanks :)
+If you are looking for something to test payments with Lightning, why not [donate some satoshis to RaspiBlitz development](https://raspiblitz.org/#donation)? Thanks :)
 
 ##### RECEIVE: Create Invoice/PaymentRequest
 
@@ -428,11 +435,11 @@ Here you can change the alias name of your node as it is shown as part of the Li
 
 ##### CLOSE ALL: Closing all open Channels
 
-*This option is just available if you have channels open.*
+*This option is only available if you have channels open.*
 
-With this feature you can close down all open channels and get the funds locked up in those channels back to your on-chain wallet.
+With this feature you can close down all open channels and get the funds locked up in those channels returned to your on-chain wallet.
 
-You may choose to force-close some channels where the channel partner is no longer reachable. Keep in mind that when you force-close a channel, it can take a much longer time until your funds are available again through your on-chain wallet.
+You may choose to force-close some channels where the channel partner is no longer reachable. Keep in mind that when you force-close a channel it can take a much longer time until your funds are available again through your on-chain wallet.
 
 ##### CASHOUT: Remove Funds from on-chain Wallet
 
@@ -452,27 +459,27 @@ Your RaspiBlitz has an LCD that is touchscreen capable. You can switch on this n
 
 ![RTL](pictures/touchscreen.png)
 
-It will give you 4 buttons on the right side.
+It will enable 4 touch buttons on the left hand side of the screen.
 
 - Info - to be defined later
-- Node - shows the nodeid/uri as QR code (used to open channels from mobile wallets)
+- Node - shows the nodeID/uri as QR code (used to open channels from mobile wallets)
 - Invoice - creates an Invoice-QR code that can be used for payments
 - Off - Shutdown or Restart the RaspiBlitz
 
 ##### LCD Rotate
 
-If you switch this on, you can rotate the LCD of your RaspiBlitz 180 degrees. This might make sense if you have a special case or wall mount.
+If you switch this on you can rotate the LCD of your RaspiBlitz 180 degrees. This might make sense if you have a special case or wall mount.
 
 ##### Run behind Tor
 
-You can run your Bitcoin- & Lightning-Node, as well as additional Apps, as a Tor hidden service - replacing your IP with an .onion-address
+You can run both your Bitcoin & Lightning nodes, as well as additional apps, behind a Tor hidden service. This replaces your clearnet IP address with an `.onion` style hidden service address.
 
 ![tor1](pictures/tor1.png)
 
 Running your node as a hidden service has some benefits:
 
-* You don't publish your IP running a node so it's much harder to resolve your real name and location.
-* You tunnel through the NAT of your router and make Bitcoin and Lightning reachable to all other Tor nodes.
+* You don't publish your IP address so it's much harder to resolve your real name and location.
+* You tunnel through the NAT of your router and make your Bitcoin and Lightning nodes reachable (i.e. allow _incoming_ connections) from all other Tor nodes on the network(s).
 * By using a Tor address it's possible to move the node to a different IPv4 address and keep the existing (i.e. previously opened and funded) channels functional.
 
 But this can also come with the following side effects:
@@ -480,23 +487,23 @@ But this can also come with the following side effects:
 * Some Mobile wallets don't support connecting to RaspiBlitz over Tor yet.
 * Lightning nodes that don't run Tor cannot reach you (like behind NAT).
 
-*Using Tor hides your IP address but will possibly increase the [time](https://twitter.com/SeverinAlexB/status/1442138426740981761) it will take for your node to route a payment. Setting up over clearnet will give you a lower response time when routing but your IP address will be freely availible to the rest of the network like the node [tippin.me](https://1ml.com/node/03c2abfa93eacec04721c019644584424aab2ba4dff3ac9bdab4e9c97007491dda). If you need to be private and/or don't want to doxx your home network then Tor might be the option for you. However if privacy isn't something you need and/or want, or you are trying to set up a service that your node is the back end for then clearnet might be more advantageous choice.*
+*Using Tor hides your IP address but will possibly increase the [time](https://twitter.com/SeverinAlexB/status/1442138426740981761) it will take for your node to route a payment. Setting up over clearnet will give you a lower response time when routing payments but your IP address will be freely available to the rest of the network like the node [tippin.me](https://1ml.com/node/03c2abfa93eacec04721c019644584424aab2ba4dff3ac9bdab4e9c97007491dda). If you need to be private and/or don't want to doxx your home network then Tor might be the option for you. However if privacy isn't something you need and/or want, or you are trying to set up a service that your node is the back end for, then clearnet might be more advantageous choice.*
 
 To try it out, just switch on the service - you can deactivate it later on if it's not working for you.
 
 ##### Parallel Testnet/Signet
 
-It is very convenient to learn and test to play around in a "sandbox" environment. RaspiBlitz allows this through activating "Testnet & Signet" that run in parallel to the "Mainnet".
+It is very convenient to learn and test to play around in a "sandbox" environment. RaspiBlitz allows this through activating "testnet & signet" that run in parallel to the "mainnet".
 
 Once activated you will see an additional option in the SSH Main Menu that will give you more options to operate the Testnet & Signet.
 
-You can get Bitcoin Testnet coins you can use Faucets from different places on the internet, here are a few links:
+To get some bitcoin testnet coins, you can use "faucets" from different places on the internet, here are a few links:
 * https://coinfaucet.eu/en/btc-testnet/
 * https://testnet-faucet.mempool.co/
 * https://kuttler.eu/en/bitcoin/btc/faucet/
 * https://faucet.lightning.community/
 
-You can read more about TESTNET and Bitcoin Faucets here: https://kuttler.eu/code/bitcoin-testnet-blockchain-size-in-2020/
+You can read more about TESTNET and Bitcoin faucets here: https://kuttler.eu/code/bitcoin-testnet-blockchain-size-in-2020/
 
 ##### ZeroTier 
 
@@ -504,15 +511,15 @@ With ZeroTier you can add your RaspiBlitz to a software defined network - see fo
 
 ##### LND LIGHTNING LABS NODE
 
-This needs to switched on to see the sub-settings options for LND. If switched on it means the LND lightning node implementation is installed and running on your RaspiBlitz - it can run in parallel to c-lightning. If activated you will find an additional option in the SSH Main Menu that offers you more options to operate the LND node. Also under `SERVICES` some apps might just be available if LND is activated.
+This needs to be switched on to see the sub-settings options for LND. If switched on it means the LND lightning node implementation is installed and running on your RaspiBlitz - it can run in parallel to c-lightning. If activated you will find an additional option in the SSH Main Menu that offers you more options for operating the LND node. Also under `SERVICES` some apps might only be available if LND is activated.
 
 ##### LND Channel Autopilot
 
-The channels autopilot feature of LND allows to automatically uses around half of your on-chain funds (if available) to open new channels with other lightning nodes. 
-Channels autopilot is very useful to get started transacting swiftly if you're a newbie as the channels are generated for you. 
-It is very likely that after a while, once you will have a hang of the concept of channels and how they work that you will not need channels autopilot anymore.
+The channel autopilot feature of LND allows an "autopilot" to automatically use around half of your on-chain (i.e. bitcoin) funds, if available, to open new channels with other lightning nodes. 
+The autopilot can be very useful to get started transacting swiftly if you're a newbie, as channels are opened for you. 
+It is very likely that after a while, once you will have a hang of the concept of channels and how they work, that you will not need channels autopilot any more.
 
-Beware that presently toggling the Channels Autopilot setting will trigger a reboot of your Raspiblitz. It is not a problem per se, just a bit of waste of time [Improvement request #1953](https://github.com/rootzoll/raspiblitz/issues/1953)
+Beware that currently, toggling the Channels Autopilot setting will trigger a reboot of your RaspiBlitz. It is not a problem per se, just a bit of waste of time [Improvement request #1953](https://github.com/rootzoll/raspiblitz/issues/1953)
 
 ##### LND Accept Keysend
 
@@ -520,7 +527,7 @@ Keysend is a feature of LND that allows your node to accept payments without hav
 
 ##### LND Circuitbreaker (Firewall for LND)
 
-Not everybody is acting friendly in the Lightning network. Circuitbreaker is a background service you can activate that acts similar to a firewall to protect your now better. For details see: https://github.com/lightningequipment/circuitbreaker/blob/master/README.md
+Not all peers in the Lightning network are necessarily friendly. Circuitbreaker is a background service you can activate that acts similarly to a firewall to protect your node. For details see: https://github.com/lightningequipment/circuitbreaker/blob/master/README.md
 
 ##### LND Auto-Unlock
 
@@ -528,35 +535,35 @@ The RaspiBlitz will automatically unlock the LND wallet upon every start.
 
 This feature is based on https://github.com/Stadicus/guides/blob/master/raspibolt/raspibolt_6A_auto-unlock.md
 
-It can be activated under "Services" -> "Auto-unlock LND". We recommend that it be turned on, when DynamicDNS is used. If there is a public IP change on your router, LND restarts automatically, and without Auto-Unlock it will stay inactive/unreachable until you manually unlock it.
+It can be activated under "Services" -> "Auto-unlock LND". We recommend that it be turned on when DynamicDNS is used. If there is a public IP change on your router LND restarts automatically, and without Auto-Unlock it will stay inactive/unreachable until you manually unlock it which could be annoying.
 
 * [When using Auto-Unlock, how much security do I lose?](FAQ.md#when-using-auto-unlock-how-much-security-do-i-lose)
 
 ##### LND StaticChannelBackup on Nextcloud
 
-See [below on this README](README.md#backup-for-on-chain---channel-funds) for your Backup options to secure your funds against loss. Storing the encrypted Static Channel Backup file to your Nextcloud account is an easy and secure way to do this.
+See [below on this README](README.md#backup-for-on-chain---channel-funds) for your Backup options when it comes to securing your funds against accidental loss. Storing the encrypted Static Channel Backup file to your Nextcloud account is an easy and secure way to do this.
 
 Nextcloud is an open-source project to host your own files: https://en.wikipedia.org/wiki/Nextcloud - in its basics its an open DropBox replacement ... but can do much much more. You can run it yourself or use a hosted Nextcloud server. Find free Nextcloud providers here to sign up: https://nextcloud.com/signup/
 
 ##### StaticChannelBackup on USB Drive
 
-You can connect a small extra USB drive to your RaspiBlitz (choose a small one up to 32GB - don't use second HDD or SSD here, that would drain too much power from the RaspiBlitz). On that USB drive your latest StaticChannelBackup will be stored - just in case your HDD gets an error.
+You can connect a small extra USB drive to your RaspiBlitz (choose a small one up to 32GB, don't use second HDD or SSD here as that would drain too much power from the RaspiBlitz). That USB drive will then be used to store your latest StaticChannelBackup, just in case your HDD encounters an error.
 
 ##### StaticChannelBackup per SCP/SSH to other server
 
-An option for more advanced users that you only can set directly in the `raspiblitz.conf` is the automated backup of the Static Channel Backup to another server per SSH/SCP. For this you need to set the value:
+An option for more advanced users -- that you only can set directly in the `raspiblitz.conf` -- is the automated backup of the StaticChannelBackup to another server by SSH/SCP. For this you need to set the value:
 
 `scpBackupTarget='[USER]@[SERVER]:[DIRPATH-WITHOUT-ENDING-/]'`
 
-and you can optionally set custom options for the scp command (for example to set a non-default port) with:
+and you can optionally set custom options for the SCP command (for example to set a non-default port) with:
 
 `scpBackupOptions='[YOUR-CUSTOM-OPTIONS]'`
 
-On target server add the root ssh public key of your RaspiBlitz to the authorized_keys for the user - how to do this see: https://www.linode.com/docs/security/authentication/use-public-key-authentication-with-ssh/
+On the target server add the root ssh public key of your RaspiBlitz to the `authorized_keys` file for the user - how to do this see: https://www.linode.com/docs/security/authentication/use-public-key-authentication-with-ssh/
 
 ##### C-LIGHTNING NODE
 
-This needs to switched on to see the sub-settings options for c-lightning. If switched on it means the c-lighting node implementation is installed and running on your RaspiBlitz - it can run in parallel to LND. If activated you will find an additional option in the SSH Main Menu that offers you more options to operate the c-lightning node. Also under `SERVICES` some apps might just be available if c-lightning is activated.
+This needs to be switched on to see the sub-settings options for c-lightning. If switched on it means the c-lighting node implementation is installed and running on your RaspiBlitz - it can run in parallel to LND. If activated you will find an additional option in the SSH main menu that offers you more options to operate the c-lightning node. Also under `SERVICES` some apps might only be available if c-lightning is activated.
 
 For more details on this lightning node implementation go to the [c-lightning FAQ page](FAQ.cl.md).
 
@@ -568,7 +575,7 @@ Find more info at the [CLBOSS GitHub](https://github.com/ZmnSCPxj/clboss).
 
 ##### CL Wallet Encryption
 
-You can protect your c-lightning wallet by encrypting it with your passwordC. On every restart/reboot you will need to decrypt/unlock with that password before c-lightning can use the wallet. This adds some physical security for example in case your node get stolen.
+You can protect your c-lightning wallet by encrypting it with your password C. On every system restart you will need to decrypt/unlock with that password before c-lightning can use the wallet. This adds some physical security for example in case your node get stolen.
 
 #### SERVICES: Activate/Deactivate Services
 
@@ -580,11 +587,11 @@ Activate/Deactivate service selection with the space bar and then select 'OK' to
 
 ##### Electrum Rust Server
 
-Enables a user to run his own Electrum server on the RaspiBlitz. The server indexes the entire Bitcoin blockchain saved locally on your HDD/SSD, and the resulting index enables fast queries for any given user wallet, allowing the user to keep real-time track of his balances and his transaction history using the [Electrum wallet](https://electrum.org).
+Enables a user to run their own Electrum server on the RaspiBlitz. The server indexes the entire Bitcoin blockchain from the copy saved locally on your HDD/SSD, and the resulting index enables fast queries for any given user wallet. This allows the user to keep real-time track of their balance and transaction history using any wallet which speaks the Electrum Protocol, for example the [Electrum wallet](https://electrum.org).
 
-Since Electrum Rust Server runs on the user's own machine, there is no need for the wallet to communicate with external Electrum servers, thus preserving the privacy of addresses and balances.
+Since Electrum Rust server runs on the user's own machine there is no need for the wallet to communicate with external Electrum servers, thus preserving the privacy of addresses and balances.
 
-By contrast, if you use your Trezor Hardware Wallet with the trezor.io wallet, it will tell their third party server your public keys - connecting it with your IP. Now you can use your Trezor with the Electrum Wallet, just talking to your own Electrum Server, preserving your privacy.
+By contrast, if you use your Trezor Hardware Wallet with the trezor.io web-wallet, it will tell their third party server your public keys - connecting them with your IP. Now you can use your Trezor with the Electrum Wallet by talking to your _own_ Electrum Server, preserving your privacy.
 
 Learn how you can use Electrum with your own Server over Tor:
 
@@ -618,7 +625,7 @@ After install, you will see a new `EXPLORE` option in the SSH main menu - it wil
 
 Bitcoin Core has a very powerful command line interface and a wonderful daemon. Using pre-signed bitcoin transactions (PSBT) and [Hardware Wallet Interface](https://github.com/bitcoin-core/HWI) (HWI), it can also work with hardware wallets. At the moment it is very Linux-focused. The same applies to multi-signature setups.
 
-The goal of Specter Desktop is to make a convenient and user-friendly GUI around Bitcoin Core, focusing on multi-signature setups with airgapped hardware wallets like Trezor, Ledger, COLDCARD or the Specter-DIY.
+The goal of the Specter Desktop wallet is to make a convenient and user-friendly GUI around Bitcoin Core, focusing on multi-signature setups with air-gapped hardware wallets like Trezor, Ledger, COLDCARD or the Specter-DIY.
 
 ![SPECTER](pictures/specter.jpg)
 
@@ -652,11 +659,11 @@ Extract the original Bitcoin Whitepaper as PDF directly from the blockchain of y
 
 ##### RTL Webinterface
 
-The RTL Webinterface is available as an LND & c-lightning Control Dashboard you can run in your browser with a nice GUI - it offers much more control over your Lightning node than the RaspiBlitz SSH menus. It's recommended to give it a try.
+The RTL Webinterface is available as an LND & c-lightning control dashboard you can run in your browser with a nice GUI. It offers much more control over your Lightning node than the RaspiBlitz SSH menus. It's recommended to give it a try.
 
 ![RTL](pictures/RTL-dashboard.png)
 
-Get all the details on how to mannage your channels with RTL in this video:
+Get all the details on how to manage your channels with RTL in this video:
 
 <a href="https://www.youtube.com/watch?v=pESO_Pm0v10" target="_blank"><img src="pictures/video-rtl.png" alt="Video Tutorial" width="400"></a><br>--watch--> https://www.youtube.com/watch?v=pESO_Pm0v10
 
@@ -720,7 +727,7 @@ https://github.com/curly60e/pyblock/blob/master/README.md
 
 ##### Channel Tools (chantools)
 
-This tool provides helper functions that can be used to rescue funds locked in LND channels in case lnd itself cannot run properly anymore. Also some other usefull command line features.
+This tool provides helper functions that can be used to rescue funds locked in LND channels in case LND itself cannot run properly any more. Also some other useful command line features.
 
 https://github.com/guggero/chantools
 
@@ -734,7 +741,7 @@ After install, you will see a new `SPHINX` option in the SSH main menu - it will
 
 ##### C-Lightning RTL Webinterface
 
-The same RTL as above but running with c-lightning node. Can run parrallel to the LND version. See deatils above.
+The same RTL as above but running with c-lightning node. Can run parallel to the LND version. See details above.
 
 ##### C-Lightning Sparko Webwallet
 
@@ -764,7 +771,7 @@ This feature should support connecting your RaspiBlitz to a mobile wallets or ot
 
 ![MOBILE](pictures/mobile.png)
 
-At the moment, the following mobile wallets are supported - some are just available if LND or c-lightning is activated:
+At the moment the following mobile wallets are supported - some are only available if LND or c-lightning is activated:
 
 * [Zeus (iOS/Android)](https://github.com/ZeusLN/zeus) (LND & c-lightning)
 * [Fully Noded (iOS over Tor)](https://apps.apple.com/us/app/fully-noded/id1436425586)
@@ -775,7 +782,7 @@ Mobile wallets work as a remote control app for your RaspiBlitz. First you need 
 
 ##### Electrum Rust Server
 
-Information how to connect to Electrum Rust Server (if installed). 
+Information how to connect to Electrum Rust Server (if installed).
 
 ##### BTCPAY: Get the connection string for the BTCPay Server
 
@@ -802,14 +809,14 @@ Here are the following export options to get the Macaroon and TLS files to be us
 
 ###### SSH Download
 
-SCP is a SSH like command to transfer files. If we're able to SSH into the RaspiBlitz, also the SCP to transfer the files should work. If you choose this option, RaspiBlitz will print prepared SCP commands you can copy+paste to run in a second terminal.
+SCP is a SSH-like command used to transfer files. If we're able to SSH into the RaspiBlitz then using SCP to transfer files should also work. If you choose this option, RaspiBlitz will print prepared SCP commands you can copy+paste to run in a second terminal.
 
 This method is recommended to export to:
 * [Zap Desktop Wallet](https://github.com/LN-Zap/zap-desktop)
 
 ###### Browser download
 
-Opens an ad-hoc webserver so that you can download the files in your local network through the browser.
+Opens an ad-hoc web server so that you can download the files in your local network through the browser.
 
 *This is the least secure way to transfer those files - everybody in your local network has access to those file during download. Remember with the Admin-Macaroon somebody could take over your node and spend all your funds. Just use as last fallback.*
 
@@ -822,7 +829,7 @@ This method is recommended to export to:
 
 #### SUBSCRIBE: Subscription Services
 
-The RaspiBlitz offers now also Subscriptions .. those are free or paid third-party services.
+The RaspiBlitz offers now also Subscriptions. These might be free or paid third-party services.
 
 ![MainMenu-Services](pictures/subscriptions.png)
 
@@ -832,11 +839,11 @@ At the moment, the following subscription services are available:
 
 ##### IP2TOR (paid)
 
-IP2TOR is a tunnel service where you can run your RaspiBlitz anonymously behind TOR but you rent a port on a clearnet IP through which you can make services of your RaspiBlitz easy reachable for everybody on the internet. You don't need to care about your local router or firewall settings. You can pay this service also directly through Lightning from your RaspiBlitz as subscription.
+IP2TOR is a tunnel service where you can run your RaspiBlitz anonymously behind TOR but you rent a port on a clearnet IP through which you can make services of your RaspiBlitz easy reachable for everybody on the internet. You don't need to care about your local router or firewall settings. You can pay for this service directly through Lightning from your RaspiBlitz as subscription.
 
-At first you select what service of your RaspiBlitz you like to tunnel thru a IP2TOR bridge. 
+At first you select what services of your RaspiBlitz you like to tunnel through a IP2TOR bridge. 
 
-You will get a list of available IP2TOR bridge offerings. Select `OK` on an IP2TOR bridge offering and you will see more details on it, such as how many satoshis the subscription will cost you - your node should be funded and have channels open at this point.
+You will get a list of available IP2TOR bridge offerings. Select `OK` on an IP2TOR bridge offering and you will see more details on it, such as how many satoshis the subscription will cost you. Your node should be funded and have channels open already at this point.
 
 Then you get a list of available IP2TOR bridge offerings. By selecting `OK` on a IP2TOR bridge offering you can get more details on it and you will also see how many satoshis the subscription will cost you - your node should be funded and you should have channels open at this point.
 
@@ -846,13 +853,13 @@ To try out the IP2TOR tunnel choose in `MAINMENU` the extra menu point of the Se
 
 ##### HTTPS with LetsEncrypt (free)
 
-If you want a Webservice like BTCPay Server or LNbits available to the outside internet (like with IP2TOR) people expect you to offer HTTPS address so that the communication between the client and your RaspiBlitz is encrypted. You could use the self-signed HTTPS certificate that RaspiBlitzis offering you, but this will give users Security Warnings in their browser and is not very user friendly. That's where you can use a LetsEncrypt Subscription to get a free valid HTTPS certificate that is excepted without warning from almost all common browsers. 
+If you want a web service, like BTCPay Server or LNbits, to be available to the outside internet (like with IP2TOR) people expect you to offer an HTTPS address so that the communication between the client and your RaspiBlitz is encrypted. You could use the self-signed HTTPS certificate that RaspiBlitz is offering you, but this will give users Security Warnings in their browser and is not very user friendly. That's where you can use a LetsEncrypt Subscription to get a free valid HTTPS certificate that is excepted without warning from almost all common browsers. 
 
 Because you also need a domain name for that you will need to open a free account, the following are presently supported, would be good to add more with the help of the community: 
 [DuckDNS.org](https://www.duckdns.org)
 [DYNU.com](https://www.dynu.com) (AT THE MOMENT NOT AVAILABLE)
 
-When you create a new LetsEncrypt subscription, you will be asked for your subdomain on DuckDNS and the Auth-Token of your DuckDNS account. Then RaspiBlitz tries to setup everything for you. If everything worked, you will find the subscription under `MAINMENU` > `SUBSCRIBE` > `LIST My Subscriptions`, where you can cancel it at any time if you wish.
+When you create a new LetsEncrypt subscription, you will be asked for your subdomain on DuckDNS and the auth-token of your DuckDNS account. Then RaspiBlitz tries to setup everything for you. If everything worked, you will find the subscription under `MAINMENU` > `SUBSCRIBE` > `LIST My Subscriptions`, where you can cancel it at any time if you wish.
 
 To try out the IP2TOR tunnel, go into `MAINMENU` and the extra menu point of the Service you want to use the bridge for. It should give you an updated URL to call your service.
 
@@ -897,7 +904,7 @@ Multiple options to repair/backup your c-lightning node:
 
 ##### MIGRATION: Migrate Blitz Data to new Hardware
 
-This stops your RaspiBlitz and creates a Migration ZIP file you can download/export per SCP to your laptop. This contains all important data of your RaspiBlitz including LND, your Blitz configuration and also data from your installed apps. Can be used to migrate your RaspiBlitz to a new hardware - for example if you want to replace the HDD with a SSD. How to import a Migration File [see here](README.md#import-a-migration-file).
+This stops your RaspiBlitz and creates a Migration ZIP file you can download/export per SCP to your laptop. This contains all the important data from your RaspiBlitz including LND, your Blitz configuration and also data from your installed apps. Can be used to migrate your RaspiBlitz to a new hardware - for example if you want to replace the HDD with a SSD. For details on how to import a Migration File [see here](README.md#import-a-migration-file).
 
 *NOTICE: If you start your RaspiBlitz after exporting the migration file again it is outdated and using it can risk losing your channel funds.*
 
@@ -905,7 +912,7 @@ This stops your RaspiBlitz and creates a Migration ZIP file you can download/exp
 
 To expedite the setup process, you can connect another RaspiBlitz and copy over your blockchain data to it. Your RaspiBlitz will be `offline` during that process and it can take between 4 to 6 hours.
 
-Make sure both RaspiBlitzes are connected to the same local network. During setup with the new RaspiBlitz, choose the `COPY` option to get the blockchain data and then select the source computer `RASPIBLITZ`. Now you can activate the `COPY-SOURCE` option, enter the given IP of the new RaspiBlitz and its Password A (not yours) .. then the process should start.
+Make sure both RaspiBlitzes are connected to the same local network. During setup with the new RaspiBlitz, choose the `COPY` option to get the blockchain data and then select the source computer `RASPIBLITZ`. Now you can choose the `COPY-SOURCE` option, enter the IP address of the _new_ RaspiBlitz and its Password A (not yours), after which the process should start automatically.
 
 ##### RESET-CHAIN: Delete Blockchain and Re-Download
 
@@ -941,7 +948,7 @@ The options are explained in detail:
 
 ![UpdateMenu](pictures/update.png)
 
-*Please note that the RaspiBlitz does not support Auto-Update, to ensure that there is no remote control of your node from a central server.*
+*Please note that the RaspiBlitz does not support any form of automatic (over the air) updates. This is to ensure that there can be no remote control of your node from a central server.*
 
 ##### RELEASE: Update RaspiBlitz to a new Version
 
@@ -953,13 +960,13 @@ With Patching you have now an easy way to sync your RaspiBlitz code/scripts with
 
 ##### LND: Interim LND Update
 
-Sometimes there is a new LND release that has some breaking changes that once you updated the LND database cannot be reversed (like the update from 0.9.2 to 0.10.0). Then RaspiBlitz offers you an optional update ... this is where you then can update LND.
+Sometimes there is a new LND release that has some breaking changes that once you updated the LND database cannot be reversed (like the update from 0.9.2 to 0.10.0). In these cases RaspiBlitz will offer you an _optional_ update. This is where you then can update LND.
 
-If you choose this you get the option to do this `VERIFIED` that means it offers you the optional LND update we tested the RaspiBlitz with or `RECKLESS` which will just grab the latest LND release from the GitHub releases page (also Release Candidates) and install it with no further guarantees and verification checks - this is for people that run nodes to test new releases and how they work with existing RaspiBlitz apps.
+If you choose this you get the option to do this `VERIFIED` that means it offers you the optional LND update we tested the RaspiBlitz with or `RECKLESS` which will just grab the latest LND release from the GitHub releases page (also Release Candidates) and install it with no further guarantees and verification checks. The `RECKLESS` option is aimed at people that run nodes to test new releases and how they work with existing RaspiBlitz apps.
 
 ##### BITCOIN: Interim Bitcoin Update
 
-Like with LND you have the possibility to update the bitcoin core version here.
+Like with LND you have the ability to update the Bitcoin core version here.
 
 #### REBOOT: Reboot RaspiBlitz
 
@@ -971,25 +978,25 @@ A safe way to shutdown the RaspiBlitz.
 
 #### EXIT: Console Terminal
 
-The `EXIT` option next to `OK` closes the SSH main menu and exits to the terminal - where the user can make use of the CLI clients `bitcoin-cli` & `lncli` directly.
+The `EXIT` option next to `OK` closes the SSH main menu and exits to the terminal where the user can make use of the CLI clients, `bitcoin-cli` & `lncli`, directly.
 
-With the command `raspiblitz`, it's possible to return to the main menu.
+In the terminal running the command `raspiblitz` will return you to the SSH main menu.
 
 ## Import a Migration File
 
 As mentioned above you can export a Migration File from your RaspiBlitz with `MAINMENU > REPAIR > MIGRATION` and store it on your laptop.
 
-A Migration file contains all the important data from your RaspiBlitz, like your LND data, Bitcoin Wallet, raspiblitz.config, Tor/SSH keys .. and also installed apps. You can use this to migrate your RaspiBlitz to new hardware.
+A Migration file contains all the important data from your RaspiBlitz, like your LND data, Bitcoin Wallet, raspiblitz.config, Tor/SSH keys, and also installed apps. You can use this to migrate your RaspiBlitz to new hardware.
 
-If you want to import it again to a new RaspiBlitz (for example with an updated HDD/SSD), you can choose the `FROMBACKUP` option on the first setup dialog of a fresh sd card image.
+If you want to import it again to a new RaspiBlitz (for example with an updated HDD/SSD), you can choose the `FROMBACKUP` option on the first setup dialogue of a fresh SD card image.
 
 ![SSH0](pictures/ssh0-welcome2.png)
 
-If you start MIGRATION you might get asked to use a existing blockchain on the harddrive/ssd and deleting the rest or even formatting the complete drive. Once thats done you get instructions how to upload the migration file (use the password `raspiblitz` when asked on executing the upload command):
+If you start MIGRATION you be get asked whether you would like to use a existing blockchain on the hard drive/SSD and delete the rest, or whether you'd prefer to format the entire drive. Once that's done you are shown instructions on how to upload the migration file (use the password `raspiblitz` when asked on executing the upload command):
 
 ![MIGRATION1](pictures/migration1.png)
 
-After this you will be asked to set a new PasswordA and your RaspiBlitz will go into recovery/provision process Then RaspiBlitz might give you the option again to self-sync or copy the blockchain from another computer/blitz and after a final reboot.
+After this you will be asked to set a new password A, and your RaspiBlitz will go into recovery/provision process. Then RaspiBlitz might give you the option again to self-sync or copy the blockchain from another computer/blitz, and afterwards a final reboot.
 
 Then the blockchain needs to sync up and you should be back to normal.
 
@@ -997,33 +1004,33 @@ Then the blockchain needs to sync up and you should be back to normal.
 
 Another kind of migration is when you already run a full node with the Umbrel or myNode software and you like to change it to RaspiBlitz without closing channels. You basically have all the hardware needed and just need to change software. You don't need the [LCD from the shopping list](#amazon-shopping-list-buy-parts--build-it-yourself) - RaspiBlitz can also run without an LCD.
 
-*NOTE: This migration is still experimental. You will still use the terminal to setup & manage your RaspiBlitz. If that is too technical for you please wait for the RaspiBlitz v1.8, which will introduce a WebUI for your browser that make the migration to RaspiBlitz familiar like with your old node user experiences.*
+*NOTE: This migration is still experimental. You will still use the terminal to setup & manage your RaspiBlitz. If that is too technical for you please wait for the RaspiBlitz v1.8, which will introduce a WebUI for your browser that will make the migration to RaspiBlitz more familiar to your old node user experience.*
 
 Before you start migration:
 * if you have on-chain funds on your old node - make sure to have the backup seed words
 * if you have lightning channels open on your old node - make sure to have downloaded the latest Static Channel Backup file to your laptop
 
-Also be aware that at the moment RaspiBlitz can only transfer your blockchain and LND wallet data (including channels) over to RaspiBlitz. Any data/pairing of additional apps cannot be transfered and may get lost.
+Also be aware that at the moment RaspiBlitz can only transfer your blockchain and LND wallet data (including channels) over to RaspiBlitz. Any data/pairing of additional apps cannot be transferred and may get lost.
 
 Instructions for Migration:
 * shutdown your old node
-* remove the sd card
+* remove the SD card
 * [download the latest Raspiblitz sd card image & flash it to your sd card](#downloading-the-software)
-* if you like to use a HDMI monitor for status & progress, create a empty file called `hdmi` (without any ending) on the sd card while connected to your laptop 
-* [insert sd card, boot up & login per SSH](#boot-your-raspiblitz)
+* if you want to use a HDMI monitor for status & progress, create a empty file called `hdmi` (without any ending) on the SD card while connected to your laptop 
+* [insert sd card, boot up & login by SSH](#boot-your-raspiblitz)
 
-Now RaspiBlitz should show you that old data from your node was detected and offer you todo the migration.
+Now RaspiBlitz should show you that old data from your node was detected and offer to do the migration for you.
 
-* If you continue it will prepare the data & reboot.
+* If you choose to continue it will prepare the data & reboot.
 * The RaspiBlitz recover/update modus is starting - that will take a while and finally reboot.
-* Login per SSH as before and reset the passwords (`FINAL RECOVERY LOGIN` on LCD). Then a final reboot will happen.
-* Login per SSH with your new password A & unlock LND wallet with password C. Now blockchain needs to catch up and then your RaspiBlitz should be ready and show you (under INFO) your on-chain & channel balance.
+* Login by SSH as before and reset the passwords (`FINAL RECOVERY LOGIN` on LCD). Then a final reboot will happen.
+* Login by SSH with your new password A & unlock LND wallet with password C. Now blockchain needs to catch up and then your RaspiBlitz should be ready and show you (under INFO) your on-chain & channel balance.
 
-If you don't have an LCD or HDMI monitor connected it might be a bit difficult to see what state your RaspiBlitz is in. Just (re-)try to login per SSH again after the reboots (might always take some time until it reacts). 
+If you don't have an LCD or HDMI monitor connected it might be a bit difficult to see what state your RaspiBlitz is in. Just (re-)try to login by SSH again after the reboots. It can take some time after a reboot before the operating system and SSH service is started, so just keep trying at intervals until successful.
 
 ## Interface / APIs
 
-To develop your own scripts/apps and connect other services/apps to your RaspiBlitz, you have multiple interfaces/APIs available:
+To develop your own scripts/apps and connect other services/apps to your RaspiBlitz you have multiple interfaces/APIs available:
 
 ### Bitcoin
 
@@ -1038,21 +1045,21 @@ To develop your own scripts/apps and connect other services/apps to your RaspiBl
 * `gRPC` running on port 10009 (public) [DOC](https://api.lightning.community/)
 * `REST` running on port 8080 (public) [DOC](https://api.lightning.community/rest/index.html)
 
-If you activate Tor, then your LND gRPC & REST APIs will also be reachable publicly as a Hidden Service.
+If you activate Tor then your LND gRPC & REST APIs will also be reachable publicly as a Hidden Service.
 
 ### Backup for On-Chain- & Channel-Funds
 
 Since LND v0.6 (and RaspiBlitz v1.2), a feature called Static-Channel-Backups is available. Within RaspiBlitz this is used when a `channel.backup` file is mentioned.
 
-At this point in time, it is the best way to backup and protect your channel funds on RaspiBlitz - so it's recommended to make use of it.
+At this point in time it is the best way to backup and protect your channel funds on RaspiBlitz, so it's recommended to make use of it.
 
-To recover your funds this way, you will need two things:
+To recover your funds this way you will need two things:
 - the 24-word seed
 - the latest `channel.backup` file
 
-You should have written down the word seed during wallet setup; keep it at a safe (offline) location. The `channel.backup` is stored on the HDD and updated by LND every time a new channel is opened or closed. The latest version of this file is needed to recover all your funds. In case your HDD gets damaged, RaspiBlitz always keeps a copy of the latest version of the `channel.backup` file on the SD card within the sub-directories of: `/home/admin/.lnd/data/chain/`.
+You should have written down the word seed during wallet setup; keep it at a safe (offline) location. The `channel.backup` is stored on the HDD and updated by LND every time a new channel is opened or closed. The latest version of this file is needed to recover all your funds. In case your HDD gets damaged RaspiBlitz always keeps a copy of the latest version of the `channel.backup` file on the SD card within the sub-directories of: `/home/admin/.lnd/data/chain/`.
 
-If you want to get one step further in securing your funds against total fall-out of the RaspiBlitz (gets completely damaged, stolen or lost) then you can additionally set up an off-location or cloud backup of the `channel.backup` file. The file itself is encrypted by your word seed - so it's OK to store the file to untrusted third parties for backup (if you want). 
+If you want to go one step further in securing your funds against total loss of the RaspiBlitz (gets completely damaged, stolen or lost), then you can additionally set up an off-location or cloud backup of the `channel.backup` file. The file itself is encrypted by your word seed so it's acceptable to store the file with untrusted third parties for backup purposes (if you want). 
 
 This video explains in detail how you can set further back Static Channel information:
 
@@ -1062,7 +1069,7 @@ The following options are also explained here shortly:
 
 #### A) DropBox Backup Target
 
-Activate the StaticChannelBackup to DropBox in the `SETTINGS` menu of your RaspiBlitz. It will ask you for the Dropbox-Authtoken. This is how you can get this token:
+Toggle the StaticChannelBackup option to DropBox in the `SETTINGS` menu of your RaspiBlitz. It will ask you for the Dropbox-Authtoken. This is how you can get this token:
 
 Go to your web browser, do the following:
 
@@ -1086,27 +1093,27 @@ Go to your web browser, do the following:
 
     Now go back to the 'Settings' tab and under 'OAuth2', choose 'no expiration' under 'Access token expiration' then click the 'Generate' button. You will now see a long string of letters and numbers appear. This is your **Dropbox-Authtoken**. Make sure to copy the complete token string .. there might be more if you scroll to the right in the token field. 
 
-To test it, try opening or closing a channel, and then check if you can find a copy of `channel.backup` in your Dropbox. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
+To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` in your Dropbox. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
 
 #### B) SCP Backup Target
 
-*You can also backup the SCB to your own server, but this needs manual setup:*
+*You can also backup the StaticChannelBackup file to your own server, but this needs manual setup:*
 
-In the `/mnt/hdd/raspiblitz.conf` the parameter `scpBackupTarget='[USER]@[SERVER]:[DIRPATH-WITHOUT-ENDING-/]'` can be set to activate this feature. On that remote server the public key of the RaspiBlitz root user needs to be part of the authorized keys - so that no password is needed for the background script to make the backup.
+In the `/mnt/hdd/raspiblitz.conf` the parameter `scpBackupTarget='[USER]@[SERVER]:[DIRPATH-WITHOUT-ENDING-/]'` can be set to activate this feature. On the remote server, the public key of the RaspiBlitz root user needs to be added to the `authorized_keys` file so that no password is needed for the background script to make the backup.
 
 The script `/home/admin/config.scripts/internet.sshpubkey.sh` helps on initialization (init); it will show and transfer ssh-pubkey to a remote server.
 
-To test it, try opening or closing a channel, and then check if you can find a copy of `channel.backup` on your remote server. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
+To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` on your remote server. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
 
 #### C) Local Backup Target (USB Thumbdrive)
 
-*You can also backup the SCB to another local drive, e.g. a USB stick:*
+*You can also backup the StaticChannelBackup to another local drive, e.g. a USB stick:*
 
 You can use a small USB thumb drive (everything over 120MB is fine). Please don't use a second HDD/SSD for this because that might drain too much power and could hurt the security of your data more than it helps.
 
 To activate this feature, go to `MAINMENU` > `SETTINGS` > `StaticChannelBackup on USB Drive` and follow the instructions.
 
-To test it, try opening or closing a channel, and then check if you can find a copy of `channel.backup` in the specified location. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
+To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` in the specified location. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
 
 ## Updating RaspiBlitz to new Version
 
@@ -1122,11 +1129,11 @@ If you have a RaspiBlitz v1.0 or v1.1 or higher do the following:
 * Remove power
 * Remove SD card
 
-Now download the new RaspiBlitz SD card image and write it to your SD card. Yes, you simply overwrite the old one, it's OK! The RaspiBlitz stores all your personal data on the HDD. See details about latest SD card image [here](#installing-the-software).
+Now download the new RaspiBlitz SD card image and write it to your SD card. Yes, you simply overwrite the old one -- it's OK! The RaspiBlitz stores all your personal data on the HDD. See details about latest SD card image [here](#installing-the-software).
 
-*If you have done manual changes to the system (installed packages, added scripts, etc), you might need to do some preparations before overwriting your SD card - see [FAQ](FAQ.md#why-do-i-need-to-re-burn-my-sd-card-for-an-update).*
+*If you have done manual changes to the system (installed packages, added scripts, etc.), you might need to take some additional steps before overwriting your SD card - see [FAQ](FAQ.md#why-do-i-need-to-re-burn-my-sd-card-for-an-update).*
 
-If done successfully, simply put the SD card into the RaspiBlitz and power on again. Then follow the instructions on the display ... and don't worry, you don't need to re-download the blockchain again. It is worth noting here that your SSH password will be reset to `raspiblitz`. You will be prompted to change this once the update is finished.
+If done successfully simply put the SD card into the RaspiBlitz and power on again. Then follow the instructions on the display ... and don't worry, you don't need to re-download the blockchain again. It is worth noting here that your SSH password will be reset to `raspiblitz`. You will be prompted to change this once the update is finished.
 
 * [Why do I need to re-burn my SD card for an update?](FAQ.md#why-do-i-need-to-re-burn-my-sd-card-for-an-update)
 
@@ -1145,9 +1152,17 @@ Now you are ready to start the SD card build script (check the code to see if th
 
 As you can see from the URL, you can find the build script in this Git repo under `build_sdcard.sh`. You can check what gets installed and configured in detail. Feel free to post improvements as pull requests.
 
-The whole build process takes a while. At the end the LCD drivers get installed and a reboot is needed. A user `admin` is created during the process. Remember the default password is now `raspiblitz`. You can login per SSH again - this time use admin: `ssh admin@[IP-OF-YOUR-RASPI]`. The install dialog of the RaspiBlitz schould automatically start. If you do not want to continue with the installation at this moment and use this sd card as a template for setting up multiple RaspiBlitzes, click `Cancel` and run `release`. Once you see the LCD going white and the activity LED of the pi starts going dark, you can unplug power and remove the SD card. You have now built your own RaspiBlitz SD card image.
+The whole build process takes a while.
+At the end the LCD drivers get installed and a reboot is needed.
+A user `admin` is created during the process.
+Remember the default password is now `raspiblitz`.
+You can login by SSH again - this time use admin: `ssh admin@[IP-OF-YOUR-RASPI]`.
+The install dialogue of the RaspiBlitz should automatically start.
+If you do not want to continue with the installation at this moment, and use this SD card as a template for setting up multiple RaspiBlitzes, click `Cancel` and run `release`.
+Once you see the LCD going white and the activity LED of the pi starts going dark you can unplug power and remove the SD card.
+You have now built your own RaspiBlitz SD card image.
 
-*Note: If you plan to use your self-build sd card as a MASTER copy and distribute it: Use a smaller 8GB card for that. This way it's ensured that it will fit on every 16 GB card recommended for RaspiBlitz later on.*
+*Note: If you plan to use your self-build SD card as a MASTER copy and distribute it: Use a smaller 8GB card for that. This way it's ensured that it will fit on every 16 GB card recommended for RaspiBlitz later on.*
 
 * [Can I run RaspiBlitz on other computers than RaspberryPi?](FAQ.md#can-i-run-raspiblitz-on-other-computers-than-raspberrypi)
 * [How can I build an SD card other than the master branch?](FAQ.md#how-can-i-build-an-sd-card-other-then-the-master-branch)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 **The RaspiBlitz is a do-it-yourself Lightning Node (LND and/or c-lightning) running together with a Bitcoin-Fullnode on a RaspberryPi (1TB SSD) and a nice display for easy setup & monitoring.**
 
-RaspiBlitz is mainly targeted for learning how to run your own node decentralized from home - because: Not your Node, Not your Rules. Discover & develop the growing ecosystem of the Lightning Network by becoming a full part of it. Build it as part of a [workshop](WORKSHOP.md) or as a weekend project yourself.
+RaspiBlitz is mainly targeted for learning how to run your own node decentralized from home - because: Not your Node, Not your Rules.
+Discover & develop the growing ecosystem of the Lightning Network by becoming a full part of it.
+Build it as part of a [workshop](WORKSHOP.md) or as a weekend project yourself.
 
 ## Feature Overview
 
@@ -52,11 +54,13 @@ Also many more features like Touchscreen, Channels Autopilot, Backup, DynDNS, SS
 
 ## Time Estimate to Set Up a RaspiBlitz
 
-The RaspiBlitz is optimized for being setup during a workshop at a hackday or conference (see [detailed workshop tutorial](WORKSHOP.md)). When it comes fully assembled with an up-to-date synced blockchain, it's possible to have it ready in about 2 to 3 hours.
+The RaspiBlitz is optimized for being setup during a workshop at a hackday or conference (see [detailed workshop tutorial](WORKSHOP.md)).
+When it comes fully assembled with an up-to-date synced blockchain, it's possible to have it ready in about 2 to 3 hours.
 
 If you start at home ordering the parts from Amazon (see shopping list below) then it's a weekend project with a lot of downloading and syncing time where you can do other stuff while checking on the progress from time to time.
 
-If you already run a Umbrel or myNode you have basically all the hardware needed and you can make the [Migration to RaspiBlitz from Umbrel/myNode](#make-a-raspiblitz-out-of-your-umbrel-or-mynode) under one hour. 
+If you already run a Umbrel or myNode you have basically all the hardware needed and you can make the [Migration to RaspiBlitz from Umbrel/myNode](#make-a-raspiblitz-out-of-your-umbrel-or-mynode) under one hour.
+
 
 ## Hardware Needed
 
@@ -70,9 +74,12 @@ Find a list of other shops selling a plug&play RaspiBlitz in your area on [raspi
 
 ### Amazon Shopping List (buy parts & build it yourself)
 
-The cheapest way is to buy and assemble the single parts yourself. There are two packages.
+The cheapest way is to buy and assemble the single parts yourself.
+There are two packages.
 
-*Please try to use the exact hardware models that are recommended in the shopping lists. We have had multiple reports where, for example, other SSD or SSD cases/controllers lead to problems. The idea of the shopping lists is to provide you the best tested hardware components that work together - improvement recommendations are always welcome.*
+*Please try to use the exact hardware models that are recommended in the shopping lists.
+We have had multiple reports where, for example, other SSD or SSD cases/controllers lead to problems.
+The idea of the shopping lists is to provide you the best tested hardware components that work together - improvement recommendations are always welcome.*
 
 * RaspberryPi 4 4GB (or 8GB) [amazon referral link](https://geni.us/raspiblitz-4gb-new)
 * Power Supply - USB-C, 5V, >=3A [amazon referral link](https://geni.us/raspiblitz-ps)
@@ -134,7 +141,8 @@ Useful info:
 
 ## Write the SD-Card image to your SD Card
 
-You need to write the downloaded SD card image (the img.gz-file) to your SD card (16GB minimum) - you can use the very easy tool Balena Etcher for this: https://www.balena.io/etcher/. It's available for Win, Mac & Linux.
+You need to write the downloaded SD card image (the img.gz-file) to your SD card (16GB minimum) - you can use the very easy tool Balena Etcher for this: https://www.balena.io/etcher/.
+It's available for Win, Mac & Linux.
 
 ## Boot your RaspiBlitz
 
@@ -168,7 +176,8 @@ Now open up a terminal ([OSX](https://www.youtube.com/watch?v=5XgBd6rjuDQ)/[Win1
 
 ## Support
 
-If you run into a problem or you have still a question, follow the steps below to get support. Also check the [setup documentation](#setup-process-detailed-documentation) for details.
+If you run into a problem or you have still a question, follow the steps below to get support.
+Also check the [setup documentation](#setup-process-detailed-documentation) for details.
 
 ### Documentation
 
@@ -212,7 +221,9 @@ If you are looking for a tutorial on how to organize a workshop to build the Ras
 
 ### Basic Setup
 
-Every time you start with a fresh SD card image you will be offered different options. For example this is also the point where you can import a Migration file from an older RaspiBlitz - read about Migration [further down](README.md#import-a-migration-file). But because you are setting up a brand new RaspiBlitz you will choose here `FRESHSETUP`.
+Every time you start with a fresh SD card image you will be offered different options.
+For example this is also the point where you can import a Migration file from an older RaspiBlitz - read about Migration [further down](README.md#import-a-migration-file).
+But because you are setting up a brand new RaspiBlitz you will choose here `FRESHSETUP`.
 
 ![SSH0](pictures/ssh0-welcome2.png)
 
@@ -223,7 +234,8 @@ If there is no blockchain data this question will be skipped.
 
 ![SSH0](pictures/ssh0-askchain.png)
 
-Finally you have to agree that all (other) data on the hard drive/SSD will be deleted, except the blockchain if you selected that previously. This might take some seconds.
+Finally you have to agree that all (other) data on the hard drive/SSD will be deleted, except the blockchain if you selected that previously.
+This might take some seconds.
 
 ![SSH0](pictures/ssh0-formathdd.png)
 
@@ -233,7 +245,9 @@ First thing to setup is giving your RaspiBlitz a name:
 
 The name you choose for your RaspiBlitz will also be used as your public alias of your lightning node so choose wisely.
 
-Then you can choose which Lightning implementation you want to run on top of your Bitcoin Fullnode. RaspiBlitz started with `LND` from Lightning Labs which is used by most other RaspberryPi lightning nodes and works with most additional apps. But you can now also choose `CL` for c-lightning by Blockstream which is a good choice for more experienced node operators & lightning developers that want to use the highly customizable plugin structure that c-lightning offers.
+Then you can choose which Lightning implementation you want to run on top of your Bitcoin Fullnode.
+RaspiBlitz started with `LND` from Lightning Labs which is used by most other RaspberryPi lightning nodes and works with most additional apps.
+But you can now also choose `CL` for c-lightning by Blockstream which is a good choice for more experienced node operators & lightning developers that want to use the highly customizable plugin structure that c-lightning offers.
 
 It's also possible to use both lightning node implementations in parallel on your RaspiBlitz later on - just pick one to start with for now.
 
@@ -253,23 +267,31 @@ Normally you just chose `NEW` here, but to recover an old wallet you have the fo
 
 ##### LNDRESCUE LND tar.gz-Backupfile (BEST)
 
-Choose this option if you have made a complete backup of the LND or c-lightning data and have a tar.gz file starting with the word 'lnd-rescue' or 'cl-rescue' available. It will recover all your on-chain funds and open channels you had. But you have to make sure that the rescue backup you have is really the latest version - otherwise you might lose channel funds.
+Choose this option if you have made a complete backup of the LND or c-lightning data and have a tar.gz file starting with the word 'lnd-rescue' or 'cl-rescue' available.
+It will recover all your on-chain funds and open channels you had.
+But you have to make sure that the rescue backup you have is really the latest version - otherwise you might lose channel funds.
 
-*If you have tar.gz file that starts with 'raspiblitz', that's a migration file. That also includes your old LND/c-lightning wallet, but you import that file at the beginning of the setup process with 'FROMBACKUP - Upload Migration Backup' instead choosing FRESHSETUP*
+*If you have tar.gz file that starts with 'raspiblitz', that's a migration file.
+That also includes your old LND/c-lightning wallet, but you import that file at the beginning of the setup process with 'FROMBACKUP - Upload Migration Backup' instead choosing FRESHSETUP*
 
 ##### SEED+SCB Words Seed & channel.backup file (OK)
 
-The next best option is if you have the channel.backup file and the word list seed. This allows you to recover all on-chain funds (i.e. "bitcoin balance") in the lightning wallet, and gives you a good chance of recovering the off-chain funds (i.e. "lightning balance") you had in open channels, as long as the remote peer supports `option_data_loss_protect` which is very common since 2020. All channels you had open before will be closed during this procedure. See [Bitcoin Optech - Static Channel Backups](https://bitcoinops.org/en/topics/static-channel-backups/) for more background information on this process.
+The next best option is if you have the channel.backup file and the word list seed.
+This allows you to recover all on-chain funds (i.e. "bitcoin balance") in the lightning wallet, and gives you a good chance of recovering the off-chain funds (i.e. "lightning balance") you had in open channels, as long as the remote peer supports `option_data_loss_protect` which is very common since 2020.
+All channels you had open before will be closed during this procedure.
+See [Bitcoin Optech - Static Channel Backups](https://bitcoinops.org/en/topics/static-channel-backups/) for more background information on this process.
 
 ##### ONLY SEED Only Seed Word List (Fallback)
 
-If you only have the seed word list (RaspiBlitz 1.1 and older) you can at least try to recover your on-chain funds. Recovery of channel funds is not very likely in this scenario.
+If you only have the seed word list (RaspiBlitz 1.1 and older) you can at least try to recover your on-chain funds.
+Recovery of channel funds is not very likely in this scenario.
 
 But normally you are setting up a new node - so simply choose `NEW` in the menu.
 
 ![SSH2](pictures/ssh2-passwords.png)
 
-Finally you have to set 3 passwords called A, B & C. For each password please choose unique, single strings, without spaces and special characters, that are at least 8 chars long.
+Finally you have to set 3 passwords called A, B & C.
+For each password please choose unique, single strings, without spaces and special characters, that are at least 8 chars long.
 
 You can use this [RaspiBlitz Recovery Sheet (PDF)](https://github.com/rootzoll/raspiblitz/raw/v1.7/home.admin/assets/RaspiBlitzRecoverySheet.pdf) to write those passwords down for safe storage and also use it later on for your Seed Words.
 
@@ -277,7 +299,8 @@ You can use this [RaspiBlitz Recovery Sheet (PDF)](https://github.com/rootzoll/r
 
 First, password A is requested - this is the password which will be used for SSH login and it's also set for the existing users: admin, root, bitcoin & pi.
 
-*The bitcoin and lightning services will later run in the background (as daemon) and use the separate user “bitcoin” for security reasons. This user does not have admin rights and cannot change the system configuration.*
+*The bitcoin and lightning services will later run in the background (as daemon) and use the separate user “bitcoin” for security reasons.
+This user does not have admin rights and cannot change the system configuration.*
 
 Then enter password B - this is internally used for the bitcoin RPC interface.
 It is also used as login for additional apps like the RTL-WebGUI or the Blockexplorer.
@@ -287,39 +310,54 @@ Every time a lightning node is started/rebooted LND needs load the wallet into m
 
 *In the early RaspiBlitz versions there was also an additional password D, that is no longer in use.*
 
-After this the setup process will need some time to set everything up - just wait until it's finished. This can take from 10 to 30 minutes:
+After this the setup process will need some time to set everything up - just wait until it's finished.
+This can take from 10 to 30 minutes:
 
 ![SSH4](pictures/ssh4-scripts.png)
 
 ### Final Setup
 
-Once the basic setup has completed your lightning node will be setup & your lightning wallet will be created for you. As part of this process you will be presented with your lightning node "seed words" which you *MUST* write down on paper (or engrave into steel) and store in a secure location. You will need to confirm that you wrote the seed words down before you can continue.
+Once the basic setup has completed your lightning node will be setup & your lightning wallet will be created for you.
+As part of this process you will be presented with your lightning node "seed words" which you *MUST* write down on paper (or engrave into steel) and store in a secure location.
+You will need to confirm that you wrote the seed words down before you can continue.
 
 ![SSH4](pictures/ssh4-seed.png)
 
-WRITE YOUR SEED WORDS DOWN before you continue - you will need them to recover funds in case of failing hardware etc. If you just want to try/experiment with the RaspiBlitz, at least take a photo of the seed words with your smartphone, so you have something just in case. If you plan to keep your RaspiBlitz running store this word list offline or in a password safe.
+WRITE YOUR SEED WORDS DOWN before you continue - you will need them to recover funds in case of failing hardware etc.
+If you just want to try/experiment with the RaspiBlitz, at least take a photo of the seed words with your smartphone, so you have something just in case.
+If you plan to keep your RaspiBlitz running store this word list offline or in a password safe.
 
 You can use this [RaspiBlitz Recovery Sheet (PDF)](https://github.com/rootzoll/raspiblitz/raw/v1.7/home.admin/assets/RaspiBlitzRecoverySheet.pdf) to write down your seed words for safe storage.
 
-If you don't have a full copy of the blockchain pre-synced/validated on your hard drive/SSD then you will now be asked how you want to get your copy of the blockchain. There are two basic options :
+If you don't have a full copy of the blockchain pre-synced/validated on your hard drive/SSD then you will now be asked how you want to get your copy of the blockchain.
+There are two basic options :
 
 ![SSH4](pictures/ssh4-blockchain.png)
 
 #### 1. SYNC - Self validate all Blocks
 
-For the new RaspberryPi 4 (with SSD & min 2GB RAM) this is the best way to go. It will take around 3-6 days to sync & validate directly with the bitcoin network. With this option, you have done it the original `don't trust, verify` way.
+For the new RaspberryPi 4 (with SSD & min 2GB RAM) this is the best way to go.
+It will take around 3-6 days to sync & validate directly with the bitcoin network.
+With this option, you have done it the original `don't trust, verify` way.
 
-*For the old RaspberryPi 3 this is not recommended. A RaspberryPi 3 has a very low power CPU and syncing+validating the blockchain directly with the peer2peer network can take multiple weeks - that's why for a RP3 you should choose the COPY option .*
+*For the old RaspberryPi 3 this is not recommended.
+A RaspberryPi 3 has a very low power CPU and syncing+validating the blockchain directly with the peer2peer network can take multiple weeks - that's why for a RP3 you should choose the COPY option .*
 
 #### 2. COPY - Copy from Laptop or another RaspiBlitz over Local Network
 
-If you have a friend that is already running a synced RaspiBlitz or you have a laptop with enough free space on the hard drive that can download & validate the Blockchain much faster you can also choose the `COPY` option. You can then delete existing blockchain your RaspiBlitz already started syncing for you. 
+If you have a friend that is already running a synced RaspiBlitz or you have a laptop with enough free space on the hard drive that can download & validate the Blockchain much faster you can also choose the `COPY` option.
+You can then delete existing blockchain your RaspiBlitz already started syncing for you 
 
 ![SSH4](pictures/ssh4-copy.png)
 
-To copy from another RaspiBlitz choose `BLITZ` and follow the instructions. Know that the other Blitz will be offline to the lightning network during the copy that will take multiple hours.
+To copy from another RaspiBlitz choose `BLITZ` and follow the instructions.
+Know that the other Blitz will be offline to the lightning network during the copy that will take multiple hours.
 
-To copy from your laptop/computer (`WINDOWS`, `MACOS` & `LINUX` options) you first need to download & validate the blockchain on your own computer/laptop. To do so, install latest bitcoin-core (0.18.1 or higher) from [bitcoin.org](https://bitcoin.org/en/download) and keep it running until the blockchain is synced (will need around 400 GB). Then under the `COPY` option choose the Operating System. The copy will be done over the local network by SCP (SSH file transfer) - follow the instructions given in the dialogues. It's advised to keep a backup of Bitcoin Core & the blockchain data directory on your laptop/computer in case you need to re-setup the RaspiBlitz.
+To copy from your laptop/computer (`WINDOWS`, `MACOS` & `LINUX` options) you first need to download & validate the blockchain on your own computer/laptop.
+To do so, install latest bitcoin-core (0.18.1 or higher) from [bitcoin.org](https://bitcoin.org/en/download) and keep it running until the blockchain is synced (will need around 400 GB).
+Then under the `COPY` option choose the Operating System.
+The copy will be done over the local network by SCP (SSH file transfer) - follow the instructions given in the dialogues.
+It's advised to keep a backup of Bitcoin Core & the blockchain data directory on your laptop/computer in case you need to re-setup the RaspiBlitz.
 
 More details: [I have the full blockchain on another computer. How do I copy it to the RaspiBlitz?](FAQ.md#i-have-the-full-blockchain-on-another-storage-how-do-i-copy-it-to-the-raspiblitz)
 
@@ -333,15 +371,20 @@ If you hit OK, the RaspiBlitz will go into a final reboot.
 
 ![SSH5](pictures/ssh5-reboot.png)
 
-Just wait a bit and then the SSH command to login again. Logging in via SSH requires password A that you setup earlier.
+Just wait a bit and then the SSH command to login again.
+Logging in via SSH requires password A that you setup earlier.
 
 ![SSH5](pictures/ssh5-unlock.png)
 
-If you run LND you will be asked to unlock your wallet - this requires password C. There is an option to activate auto-unlock of LND if you prefer, this can be found under `SETTINGS` in the main menu.
+If you run LND you will be asked to unlock your wallet - this requires password C.
+There is an option to activate auto-unlock of LND if you prefer, this can be found under `SETTINGS` in the main menu.
 
 ![SSH5](pictures/ssh5-blocksync.png)
 
-Your RaspiBlitz might need quite some time to sync and validate the blockchain -- this can be multiple days. In the beginning you might see fast progress but this gets slower later on as historical blocks start to get fuller. Your RaspberryPi CPU will likely get quite hot during initial sync. However this is OK as the RaspberryPi has its own protection against overheating and will ensure the CPU doesn't critically overheat.
+Your RaspiBlitz might need quite some time to sync and validate the blockchain -- this can be multiple days.
+In the beginning you might see fast progress but this gets slower later on as historical blocks start to get fuller.
+Your RaspberryPi CPU will likely get quite hot during initial sync.
+However this is OK as the RaspberryPi has its own protection against overheating and will ensure the CPU doesn't critically overheat.
 
 ### Main Menu
 
@@ -351,7 +394,8 @@ Once the Blockchain is synced you will enter the SSH Main Menu:
 
 All options on the main menu will be explained below in the feature documentation.
 
-*OK .. so from here on out, your RaspiBlitz is ready to play with.*
+*OK ..
+so from here on out, your RaspiBlitz is ready to play with.*
 
 If you need an idea of what the most basic next steps to experience Lightning would be:
 
@@ -370,17 +414,21 @@ There is also a [RaspiBlitz Donation Page](https://raspiblitz.org/#donation), wh
 
 ### Feature Documentation
 
-These are the features available through the RaspiBlitz SSH menus. They have the goal to offer some basic/fallback functionality & configurations. More complex or user-friendly tasks are best to be done with wallets, apps and scripts you connect to your Lightning Node via [APIs](#interface--apis) - because you have a full Bitcoin- and Lightning-Node on the RaspiBlitz.
+These are the features available through the RaspiBlitz SSH menus.
+They have the goal to offer some basic/fallback functionality & configurations.
+More complex or user-friendly tasks are best to be done with wallets, apps and scripts you connect to your Lightning Node via [APIs](#interface--apis) - because you have a full Bitcoin- and Lightning-Node on the RaspiBlitz.
 
 So let's take a look at the SSH main menu in detail:
 
 #### INFO: Raspiblitz Status Screen
 
-This is the screen that gets displayed on the LCD/display. It's useful to call in a remote situation from SSH if you don't have your RaspiBlitz next to you, or if you want to copy+paste your nodeID or make a screenshot.
+This is the screen that gets displayed on the LCD/display.
+It's useful to call in a remote situation from SSH if you don't have your RaspiBlitz next to you, or if you want to copy+paste your nodeID or make a screenshot.
 
 ![SSH9dz](pictures/ssh9z-ready.png)
 
-*It's not automatically updating. It's just for one-time info.*
+*It's not automatically updating.
+It's just for one-time info.*
 
 * [Why is my bitcoin IP on the display red?](FAQ.md#why-is-my-bitcoin-ip-on-the-display-red)
 * [Why is my node address on the display red?](FAQ.md#why-is-my-node-address-on-the-display-red)
@@ -388,21 +436,30 @@ This is the screen that gets displayed on the LCD/display. It's useful to call i
 
 #### LIGHTNING (Basic Node Management)
 
-Under `LND/c-lightning Wallet options` you will find some basic tools for managing your Lightning node. These are very simplified in the RaspiBlitz SSH menu for learning purposes. For more advanced management of your Lightning node see additional apps under `SERVICES`.
+Under `LND/c-lightning Wallet options` you will find some basic tools for managing your Lightning node.
+These are very simplified in the RaspiBlitz SSH menu for learning purposes.
+For more advanced management of your Lightning node see additional apps under `SERVICES`.
 
 ##### FUNDING: Fund your on-chain Wallet
 
-Before you can open channels with other nodes you need to put some coins in your on-chain wallet (managed by your lightning software). Use this option to generate an address to send funds to.
+Before you can open channels with other nodes you need to put some coins in your on-chain wallet (managed by your lightning software).
+Use this option to generate an address to send funds to.
 
-*Reminder: RaspiBlitz is still experimental software. With funding your lightning node you accept the risk of losing funds. So just play with small amounts - something in the area of 20 EUR/USD should be enough to make your first experiences. Also, it's a good privacy practice to [coinjoin your coins](https://bitcoin-only.com/privacy) before sending them to any Lightning Network wallet.*
+*Reminder: RaspiBlitz is still experimental software.
+With funding your lightning node you accept the risk of losing funds.
+So just play with small amounts - something in the area of 20 EUR/USD should be enough to make your first experiences.
+Also, it's a good privacy practice to [coinjoin your coins](https://bitcoin-only.com/privacy) before sending them to any Lightning Network wallet.*
 
-You can fund it multiple times - starting with small amounts first to test. Your lightning node will always generate a different address, but all funds you send will get into the same LND on-chain wallet.
+You can fund it multiple times - starting with small amounts first to test.
+Your lightning node will always generate a different address, but all funds you send will get into the same LND on-chain wallet.
 
 ##### CONNECT: Connect to a Peer
 
 Before you can open a channel with another node on the network, you need to connect this node as a peer to your node.
 
-Opening a channel with a peer is just optional. Having another node as peer helps your node to receive information about the lightning network through the gossip protocol. It will help your node to find better routes through the network.
+Opening a channel with a peer is just optional.
+Having another node as peer helps your node to receive information about the lightning network through the gossip protocol.
+It will help your node to find better routes through the network.
 
 ##### CHANNEL: Open a Channel with Peer
 
@@ -410,16 +467,20 @@ To open a payment channel with another node, you can use this option.
 
 Find interesting nodes to open channels with through online directories like [1ML.com](https://1ml.com/) or join the RaspiBlitz NodeManager telegram group to meet people to open channels with: https://t.me/raspiblitz
 
-Bear in mind that this option will open a public channel that can be seen by everyone in the network and chosen by them as part of their payment route. This is good if you want to route payments.
-If you do not want to route payments for others, you can use a so-called "private" (i.e. unannounced) channel which others cannot use as part of their payment route. To do this you must go to the command line and open the channel with the `-private` option.
+Bear in mind that this option will open a public channel that can be seen by everyone in the network and chosen by them as part of their payment route.
+This is good if you want to route payments.
+If you do not want to route payments for others, you can use a so-called "private" (i.e. unannounced) channel which others cannot use as part of their payment route.
+To do this you must go to the command line and open the channel with the `-private` option.
 
-*This is just a very basic shell script. For more usability, try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
+*This is just a very basic shell script.
+For more usability, try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
 
 ##### SEND: Pay an Invoice/PaymentRequest
 
 Pay an invoice through lightning.
 
-*This is just a very basic shell script. For more usability try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
+*This is just a very basic shell script.
+For more usability try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
 
 If you are looking for something to test payments with Lightning, why not [donate some satoshis to RaspiBlitz development](https://raspiblitz.org/#donation)? Thanks :)
 
@@ -427,7 +488,8 @@ If you are looking for something to test payments with Lightning, why not [donat
 
 Create an invoice to send to someone for a service to be paid through lightning.
 
-*This is just a very basic shell script. For more usability try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
+*This is just a very basic shell script.
+For more usability try the RTL Webinterface (under Services) or connect a (mobile) wallet with your RaspiBlitz.*
 
 ##### NAME: Change name of your Node
 
@@ -439,7 +501,8 @@ Here you can change the alias name of your node as it is shown as part of the Li
 
 With this feature you can close down all open channels and get the funds locked up in those channels returned to your on-chain wallet.
 
-You may choose to force-close some channels where the channel partner is no longer reachable. Keep in mind that when you force-close a channel it can take a much longer time until your funds are available again through your on-chain wallet.
+You may choose to force-close some channels where the channel partner is no longer reachable.
+Keep in mind that when you force-close a channel it can take a much longer time until your funds are available again through your on-chain wallet.
 
 ##### CASHOUT: Remove Funds from on-chain Wallet
 
@@ -451,11 +514,13 @@ Here you will find basic settings for your RaspiBlitz:
 
 ![MainMenu-Settings](pictures/settings.png)
 
-Activate/Deactivate settings with the space bar and then select 'OK' to activate changes. You can find more details about those options (top to down):
+Activate/Deactivate settings with the space bar and then select 'OK' to activate changes.
+You can find more details about those options (top to down):
 
 ##### Touchscreen (experimental)
 
-Your RaspiBlitz has an LCD that is touchscreen capable. You can switch on this new feature that is still in development.
+Your RaspiBlitz has an LCD that is touchscreen capable.
+You can switch on this new feature that is still in development.
 
 ![RTL](pictures/touchscreen.png)
 
@@ -468,11 +533,13 @@ It will enable 4 touch buttons on the left hand side of the screen.
 
 ##### LCD Rotate
 
-If you switch this on you can rotate the LCD of your RaspiBlitz 180 degrees. This might make sense if you have a special case or wall mount.
+If you switch this on you can rotate the LCD of your RaspiBlitz 180 degrees.
+This might make sense if you have a special case or wall mount.
 
 ##### Run behind Tor
 
-You can run both your Bitcoin & Lightning nodes, as well as additional apps, behind a Tor hidden service. This replaces your clearnet IP address with an `.onion` style hidden service address.
+You can run both your Bitcoin & Lightning nodes, as well as additional apps, behind a Tor hidden service.
+This replaces your clearnet IP address with an `.onion` style hidden service address.
 
 ![tor1](pictures/tor1.png)
 
@@ -487,13 +554,17 @@ But this can also come with the following side effects:
 * Some Mobile wallets don't support connecting to RaspiBlitz over Tor yet.
 * Lightning nodes that don't run Tor cannot reach you (like behind NAT).
 
-*Using Tor hides your IP address but will possibly increase the [time](https://twitter.com/SeverinAlexB/status/1442138426740981761) it will take for your node to route a payment. Setting up over clearnet will give you a lower response time when routing payments but your IP address will be freely available to the rest of the network like the node [tippin.me](https://1ml.com/node/03c2abfa93eacec04721c019644584424aab2ba4dff3ac9bdab4e9c97007491dda). If you need to be private and/or don't want to doxx your home network then Tor might be the option for you. However if privacy isn't something you need and/or want, or you are trying to set up a service that your node is the back end for, then clearnet might be more advantageous choice.*
+*Using Tor hides your IP address but will possibly increase the [time](https://twitter.com/SeverinAlexB/status/1442138426740981761) it will take for your node to route a payment.
+Setting up over clearnet will give you a lower response time when routing payments but your IP address will be freely available to the rest of the network like the node [tippin.me](https://1ml.com/node/03c2abfa93eacec04721c019644584424aab2ba4dff3ac9bdab4e9c97007491dda).
+If you need to be private and/or don't want to doxx your home network then Tor might be the option for you.
+However if privacy isn't something you need and/or want, or you are trying to set up a service that your node is the back end for, then clearnet might be more advantageous choice.*
 
 To try it out, just switch on the service - you can deactivate it later on if it's not working for you.
 
 ##### Parallel Testnet/Signet
 
-It is very convenient to learn and test to play around in a "sandbox" environment. RaspiBlitz allows this through activating "testnet & signet" that run in parallel to the "mainnet".
+It is very convenient to learn and test to play around in a "sandbox" environment.
+RaspiBlitz allows this through activating "testnet & signet" that run in parallel to the "mainnet".
 
 Once activated you will see an additional option in the SSH Main Menu that will give you more options to operate the Testnet & Signet.
 
@@ -511,23 +582,30 @@ With ZeroTier you can add your RaspiBlitz to a software defined network - see fo
 
 ##### LND LIGHTNING LABS NODE
 
-This needs to be switched on to see the sub-settings options for LND. If switched on it means the LND lightning node implementation is installed and running on your RaspiBlitz - it can run in parallel to c-lightning. If activated you will find an additional option in the SSH Main Menu that offers you more options for operating the LND node. Also under `SERVICES` some apps might only be available if LND is activated.
+This needs to be switched on to see the sub-settings options for LND.
+If switched on it means the LND lightning node implementation is installed and running on your RaspiBlitz - it can run in parallel to c-lightning.
+If activated you will find an additional option in the SSH Main Menu that offers you more options for operating the LND node.
+Also under `SERVICES` some apps might only be available if LND is activated.
 
 ##### LND Channel Autopilot
 
-The channel autopilot feature of LND allows an "autopilot" to automatically use around half of your on-chain (i.e. bitcoin) funds, if available, to open new channels with other lightning nodes. 
-The autopilot can be very useful to get started transacting swiftly if you're a newbie, as channels are opened for you. 
+The channel autopilot feature of LND allows an "autopilot" to automatically use around half of your on-chain (i.e. bitcoin) funds, if available, to open new channels with other lightning nodes.
+The autopilot can be very useful to get started transacting swiftly if you're a newbie, as channels are opened for you.
 It is very likely that after a while, once you will have a hang of the concept of channels and how they work, that you will not need channels autopilot any more.
 
-Beware that currently, toggling the Channels Autopilot setting will trigger a reboot of your RaspiBlitz. It is not a problem per se, just a bit of waste of time [Improvement request #1953](https://github.com/rootzoll/raspiblitz/issues/1953)
+Beware that currently, toggling the Channels Autopilot setting will trigger a reboot of your RaspiBlitz.
+It is not a problem per se, just a bit of waste of time [Improvement request #1953](https://github.com/rootzoll/raspiblitz/issues/1953)
 
 ##### LND Accept Keysend
 
-Keysend is a feature of LND that allows your node to accept payments without having created an invoice first. This needs to be activated, for example, if you want to use your nodes for experimental messaging over the Lightning Network (see RaspiBlitz MOBILE apps like SendMany).
+Keysend is a feature of LND that allows your node to accept payments without having created an invoice first.
+This needs to be activated, for example, if you want to use your nodes for experimental messaging over the Lightning Network (see RaspiBlitz MOBILE apps like SendMany).
 
 ##### LND Circuitbreaker (Firewall for LND)
 
-Not all peers in the Lightning network are necessarily friendly. Circuitbreaker is a background service you can activate that acts similarly to a firewall to protect your node. For details see: https://github.com/lightningequipment/circuitbreaker/blob/master/README.md
+Not all peers in the Lightning network are necessarily friendly.
+Circuitbreaker is a background service you can activate that acts similarly to a firewall to protect your node.
+For details see: https://github.com/lightningequipment/circuitbreaker/blob/master/README.md
 
 ##### LND Auto-Unlock
 
@@ -535,23 +613,30 @@ The RaspiBlitz will automatically unlock the LND wallet upon every start.
 
 This feature is based on https://github.com/Stadicus/guides/blob/master/raspibolt/raspibolt_6A_auto-unlock.md
 
-It can be activated under "Services" -> "Auto-unlock LND". We recommend that it be turned on when DynamicDNS is used. If there is a public IP change on your router LND restarts automatically, and without Auto-Unlock it will stay inactive/unreachable until you manually unlock it which could be annoying.
+It can be activated under "Services" -> "Auto-unlock LND".
+We recommend that it be turned on when DynamicDNS is used.
+If there is a public IP change on your router LND restarts automatically, and without Auto-Unlock it will stay inactive/unreachable until you manually unlock it which could be annoying.
 
 * [When using Auto-Unlock, how much security do I lose?](FAQ.md#when-using-auto-unlock-how-much-security-do-i-lose)
 
 ##### LND StaticChannelBackup on Nextcloud
 
-See [below on this README](README.md#backup-for-on-chain---channel-funds) for your Backup options when it comes to securing your funds against accidental loss. Storing the encrypted Static Channel Backup file to your Nextcloud account is an easy and secure way to do this.
+See [below on this README](README.md#backup-for-on-chain---channel-funds) for your Backup options when it comes to securing your funds against accidental loss.
+Storing the encrypted Static Channel Backup file to your Nextcloud account is an easy and secure way to do this.
 
-Nextcloud is an open-source project to host your own files: https://en.wikipedia.org/wiki/Nextcloud - in its basics its an open DropBox replacement ... but can do much much more. You can run it yourself or use a hosted Nextcloud server. Find free Nextcloud providers here to sign up: https://nextcloud.com/signup/
+Nextcloud is an open-source project to host your own files: https://en.wikipedia.org/wiki/Nextcloud - in its basics its an open DropBox replacement ... but can do much much more.
+You can run it yourself or use a hosted Nextcloud server.
+Find free Nextcloud providers here to sign up: https://nextcloud.com/signup/
 
 ##### StaticChannelBackup on USB Drive
 
-You can connect a small extra USB drive to your RaspiBlitz (choose a small one up to 32GB, don't use second HDD or SSD here as that would drain too much power from the RaspiBlitz). That USB drive will then be used to store your latest StaticChannelBackup, just in case your HDD encounters an error.
+You can connect a small extra USB drive to your RaspiBlitz (choose a small one up to 32GB, don't use second HDD or SSD here as that would drain too much power from the RaspiBlitz).
+That USB drive will then be used to store your latest StaticChannelBackup, just in case your HDD encounters an error.
 
 ##### StaticChannelBackup per SCP/SSH to other server
 
-An option for more advanced users -- that you only can set directly in the `raspiblitz.conf` -- is the automated backup of the StaticChannelBackup to another server by SSH/SCP. For this you need to set the value:
+An option for more advanced users -- that you only can set directly in the `raspiblitz.conf` -- is the automated backup of the StaticChannelBackup to another server by SSH/SCP.
+For this you need to set the value:
 
 `scpBackupTarget='[USER]@[SERVER]:[DIRPATH-WITHOUT-ENDING-/]'`
 
@@ -563,19 +648,25 @@ On the target server add the root ssh public key of your RaspiBlitz to the `auth
 
 ##### C-LIGHTNING NODE
 
-This needs to be switched on to see the sub-settings options for c-lightning. If switched on it means the c-lighting node implementation is installed and running on your RaspiBlitz - it can run in parallel to LND. If activated you will find an additional option in the SSH main menu that offers you more options to operate the c-lightning node. Also under `SERVICES` some apps might only be available if c-lightning is activated.
+This needs to be switched on to see the sub-settings options for c-lightning.
+If switched on it means the c-lighting node implementation is installed and running on your RaspiBlitz - it can run in parallel to LND.
+If activated you will find an additional option in the SSH main menu that offers you more options to operate the c-lightning node.
+Also under `SERVICES` some apps might only be available if c-lightning is activated.
 
 For more details on this lightning node implementation go to the [c-lightning FAQ page](FAQ.cl.md).
 
 ##### CL CLBOSS Automatic Node Manager
 
-CLBOSS is an automated manager for C-Lightning routing payments nodes. CLBOSS is effectively a bunch of heuristics modules wired together to a regular clock to continuously monitor your node.
+CLBOSS is an automated manager for C-Lightning routing payments nodes.
+CLBOSS is effectively a bunch of heuristics modules wired together to a regular clock to continuously monitor your node.
 
 Find more info at the [CLBOSS GitHub](https://github.com/ZmnSCPxj/clboss).
 
 ##### CL Wallet Encryption
 
-You can protect your c-lightning wallet by encrypting it with your password C. On every system restart you will need to decrypt/unlock with that password before c-lightning can use the wallet. This adds some physical security for example in case your node get stolen.
+You can protect your c-lightning wallet by encrypting it with your password C.
+On every system restart you will need to decrypt/unlock with that password before c-lightning can use the wallet.
+This adds some physical security for example in case your node get stolen.
 
 #### SERVICES: Activate/Deactivate Services
 
@@ -583,15 +674,19 @@ The RaspiBlitz offers further Services, Apps and configuration (scroll down to s
 
 ![MainMenu-Services](pictures/services.png)
 
-Activate/Deactivate service selection with the space bar and then select 'OK' to trigger Install/Uninstall. You can find more details about those options below (top to bottom):
+Activate/Deactivate service selection with the space bar and then select 'OK' to trigger Install/Uninstall.
+You can find more details about those options below (top to bottom):
 
 ##### Electrum Rust Server
 
-Enables a user to run their own Electrum server on the RaspiBlitz. The server indexes the entire Bitcoin blockchain from the copy saved locally on your HDD/SSD, and the resulting index enables fast queries for any given user wallet. This allows the user to keep real-time track of their balance and transaction history using any wallet which speaks the Electrum Protocol, for example the [Electrum wallet](https://electrum.org).
+Enables a user to run their own Electrum server on the RaspiBlitz.
+The server indexes the entire Bitcoin blockchain from the copy saved locally on your HDD/SSD, and the resulting index enables fast queries for any given user wallet.
+This allows the user to keep real-time track of their balance and transaction history using any wallet which speaks the Electrum Protocol, for example the [Electrum wallet](https://electrum.org).
 
 Since Electrum Rust server runs on the user's own machine there is no need for the wallet to communicate with external Electrum servers, thus preserving the privacy of addresses and balances.
 
-By contrast, if you use your Trezor Hardware Wallet with the trezor.io web-wallet, it will tell their third party server your public keys - connecting them with your IP. Now you can use your Trezor with the Electrum Wallet by talking to your _own_ Electrum Server, preserving your privacy.
+By contrast, if you use your Trezor Hardware Wallet with the trezor.io web-wallet, it will tell their third party server your public keys - connecting them with your IP.
+Now you can use your Trezor with the Electrum Wallet by talking to your _own_ Electrum Server, preserving your privacy.
 
 Learn how you can use Electrum with your own Server over Tor:
 
@@ -603,7 +698,8 @@ After install, you will see a new `ELECTRS` option in the SSH main menu - it wil
 
 ##### BTCPayServer
 
-[BTCPay Server](https://github.com/btcpayserver) is a self-hosted, open-source cryptocurrency payment processor. It's secure, private, censorship-resistant and free.
+[BTCPay Server](https://github.com/btcpayserver) is a self-hosted, open-source cryptocurrency payment processor.
+It's secure, private, censorship-resistant and free.
 
 ![BTCPAY](pictures/btcpay.png)
 
@@ -613,7 +709,8 @@ After install, you will see a new `BTCPAY` option in the SSH main menu - it will
 
 ##### BTC-RPC-Explorer
 
-BTC-RPC-Explorer is a blockchain explorer website you can run on your own RaspiBlitz. See an example running on: https://btc-explorer.com
+BTC-RPC-Explorer is a blockchain explorer website you can run on your own RaspiBlitz.
+See an example running on: https://btc-explorer.com
 
 ![EXPLORER](pictures/blockexplorer.png)
 
@@ -623,7 +720,10 @@ After install, you will see a new `EXPLORE` option in the SSH main menu - it wil
 
 ##### Specter Desktop
 
-Bitcoin Core has a very powerful command line interface and a wonderful daemon. Using pre-signed bitcoin transactions (PSBT) and [Hardware Wallet Interface](https://github.com/bitcoin-core/HWI) (HWI), it can also work with hardware wallets. At the moment it is very Linux-focused. The same applies to multi-signature setups.
+Bitcoin Core has a very powerful command line interface and a wonderful daemon.
+Using pre-signed bitcoin transactions (PSBT) and [Hardware Wallet Interface](https://github.com/bitcoin-core/HWI) (HWI), it can also work with hardware wallets.
+At the moment it is very Linux-focused.
+The same applies to multi-signature setups.
 
 The goal of the Specter Desktop wallet is to make a convenient and user-friendly GUI around Bitcoin Core, focusing on multi-signature setups with air-gapped hardware wallets like Trezor, Ledger, COLDCARD or the Specter-DIY.
 
@@ -643,11 +743,15 @@ After install, you will see a new `MEMPOOL` option in the SSH main menu - it wil
 
 ##### JoinMarket
 
-JoinMarket is software to create a special kind of bitcoin transaction called a CoinJoin transaction. Its aim is to improve the confidentiality and privacy of bitcoin transactions.
+JoinMarket is software to create a special kind of bitcoin transaction called a CoinJoin transaction.
+Its aim is to improve the confidentiality and privacy of bitcoin transactions.
 
 <a href="https://www.youtube.com/watch?v=uGHRjilMhwY" target="_blank"><img src="pictures/video-joinmarket.png" alt="Video Tutorial" width="400"></a><br>--watch--> https://www.youtube.com/watch?v=uGHRjilMhwY
 
-A CoinJoin transaction requires other people to take part. The right resources (coins) have to be in the right place, at the right time, in the right quantity. This isn't a software or tech problem, it's an economic problem. JoinMarket works by creating a new kind of market that would allocate these resources in the best way.
+A CoinJoin transaction requires other people to take part.
+The right resources (coins) have to be in the right place, at the right time, in the right quantity.
+This isn't a software or tech problem, it's an economic problem.
+JoinMarket works by creating a new kind of market that would allocate these resources in the best way.
 
 For more details see [here](https://github.com/JoinMarket-Org/joinmarket-clientserver).
 
@@ -659,7 +763,9 @@ Extract the original Bitcoin Whitepaper as PDF directly from the blockchain of y
 
 ##### RTL Webinterface
 
-The RTL Webinterface is available as an LND & c-lightning control dashboard you can run in your browser with a nice GUI. It offers much more control over your Lightning node than the RaspiBlitz SSH menus. It's recommended to give it a try.
+The RTL Webinterface is available as an LND & c-lightning control dashboard you can run in your browser with a nice GUI.
+It offers much more control over your Lightning node than the RaspiBlitz SSH menus.
+It's recommended to give it a try.
 
 ![RTL](pictures/RTL-dashboard.png)
 
@@ -683,7 +789,8 @@ After install, you will see a new `THUB` option in the SSH main menu - it will g
 
 ##### Lightning Terminal (LIT) with loop, pool & faraday
 
-Lightning Terminal (LiT) is a browser-based interface for managing channel liquidity on LND. It bundles the former single tools called loop, pool & faraday with an easy to use browser interface.
+Lightning Terminal (LiT) is a browser-based interface for managing channel liquidity on LND.
+It bundles the former single tools called loop, pool & faraday with an easy to use browser interface.
 
 ![LIT](pictures/lit.png)
 
@@ -727,13 +834,15 @@ https://github.com/curly60e/pyblock/blob/master/README.md
 
 ##### Channel Tools (chantools)
 
-This tool provides helper functions that can be used to rescue funds locked in LND channels in case LND itself cannot run properly any more. Also some other useful command line features.
+This tool provides helper functions that can be used to rescue funds locked in LND channels in case LND itself cannot run properly any more.
+Also some other useful command line features.
 
 https://github.com/guggero/chantools
 
 ##### Sphinx Relay Server
 
-The Sphinx App allows chat over the Lightning Network with LND and ties into the idea of [Podcasting 2.0](https://u.today/father-of-podcasting-integrates-bitcoin-lightning-into-his-app). To use the mobile app with your own RaspiBlitz you need to install the [Sphinx Relay Server](https://github.com/stakwork/sphinx-relay/blob/master/README.md).
+The Sphinx App allows chat over the Lightning Network with LND and ties into the idea of [Podcasting 2.0](https://u.today/father-of-podcasting-integrates-bitcoin-lightning-into-his-app).
+To use the mobile app with your own RaspiBlitz you need to install the [Sphinx Relay Server](https://github.com/stakwork/sphinx-relay/blob/master/README.md).
 
 ![SPHINX](https://github.com/stakwork/sphinx-relay/raw/master/public/relay.jpg)
 
@@ -741,7 +850,9 @@ After install, you will see a new `SPHINX` option in the SSH main menu - it will
 
 ##### C-Lightning RTL Webinterface
 
-The same RTL as above but running with c-lightning node. Can run parallel to the LND version. See details above.
+The same RTL as above but running with c-lightning node.
+Can run parallel to the LND version.
+See details above.
 
 ##### C-Lightning Sparko Webwallet
 
@@ -778,7 +889,10 @@ At the moment the following mobile wallets are supported - some are only availab
 * [SendMany (Android)](https://github.com/fusion44/sendmany/blob/master/README.md) (only LND)
 * [Sphinx Chat App (iOS/Android)](https://sphinx.chat/) (only LND)
 
-Mobile wallets work as a remote control app for your RaspiBlitz. First you need to install the apps on your phone - a QR code with the links to the app stores are displayed. Then you need to `pair` them with your RaspiBlitz - also via a QR code displayed on the LCD. If you run your RaspiBlitz without an LCD, there is the fallback option to display that QR code on the terminal as ASCII code (which might involve lowering your terminal's font size).
+Mobile wallets work as a remote control app for your RaspiBlitz.
+First you need to install the apps on your phone - a QR code with the links to the app stores are displayed.
+Then you need to `pair` them with your RaspiBlitz - also via a QR code displayed on the LCD.
+If you run your RaspiBlitz without an LCD, there is the fallback option to display that QR code on the terminal as ASCII code (which might involve lowering your terminal's font size).
 
 ##### Electrum Rust Server
 
@@ -809,7 +923,9 @@ Here are the following export options to get the Macaroon and TLS files to be us
 
 ###### SSH Download
 
-SCP is a SSH-like command used to transfer files. If we're able to SSH into the RaspiBlitz then using SCP to transfer files should also work. If you choose this option, RaspiBlitz will print prepared SCP commands you can copy+paste to run in a second terminal.
+SCP is a SSH-like command used to transfer files.
+If we're able to SSH into the RaspiBlitz then using SCP to transfer files should also work.
+If you choose this option, RaspiBlitz will print prepared SCP commands you can copy+paste to run in a second terminal.
 
 This method is recommended to export to:
 * [Zap Desktop Wallet](https://github.com/LN-Zap/zap-desktop)
@@ -818,18 +934,22 @@ This method is recommended to export to:
 
 Opens an ad-hoc web server so that you can download the files in your local network through the browser.
 
-*This is the least secure way to transfer those files - everybody in your local network has access to those file during download. Remember with the Admin-Macaroon somebody could take over your node and spend all your funds. Just use as last fallback.*
+*This is the least secure way to transfer those files - everybody in your local network has access to those file during download.
+Remember with the Admin-Macaroon somebody could take over your node and spend all your funds.
+Just use as last fallback.*
 
 ####### Hex-String
 
-The Macaroons and TLS.cert files can be copy+pasted as Hex-Strings from RaspiBlitz to any other app that supports that format. If you choose this option, RaspiBlitz will print all the files for you as Hex-String to do so.
+The Macaroons and TLS.cert files can be copy+pasted as Hex-Strings from RaspiBlitz to any other app that supports that format.
+If you choose this option, RaspiBlitz will print all the files for you as Hex-String to do so.
 
 This method is recommended to export to:
 * [Joule Browser Wallet](https://lightningjoule.com)
 
 #### SUBSCRIBE: Subscription Services
 
-The RaspiBlitz offers now also Subscriptions. These might be free or paid third-party services.
+The RaspiBlitz offers now also Subscriptions.
+These might be free or paid third-party services.
 
 ![MainMenu-Services](pictures/subscriptions.png)
 
@@ -839,29 +959,40 @@ At the moment, the following subscription services are available:
 
 ##### IP2TOR (paid)
 
-IP2TOR is a tunnel service where you can run your RaspiBlitz anonymously behind TOR but you rent a port on a clearnet IP through which you can make services of your RaspiBlitz easy reachable for everybody on the internet. You don't need to care about your local router or firewall settings. You can pay for this service directly through Lightning from your RaspiBlitz as subscription.
+IP2TOR is a tunnel service where you can run your RaspiBlitz anonymously behind TOR but you rent a port on a clearnet IP through which you can make services of your RaspiBlitz easy reachable for everybody on the internet.
+You don't need to care about your local router or firewall settings.
+You can pay for this service directly through Lightning from your RaspiBlitz as subscription.
 
 At first you select what services of your RaspiBlitz you like to tunnel through a IP2TOR bridge. 
 
-You will get a list of available IP2TOR bridge offerings. Select `OK` on an IP2TOR bridge offering and you will see more details on it, such as how many satoshis the subscription will cost you. Your node should be funded and have channels open already at this point.
+You will get a list of available IP2TOR bridge offerings.
+Select `OK` on an IP2TOR bridge offering and you will see more details on it, such as how many satoshis the subscription will cost you.
+Your node should be funded and have channels open already at this point.
 
-Then you get a list of available IP2TOR bridge offerings. By selecting `OK` on a IP2TOR bridge offering you can get more details on it and you will also see how many satoshis the subscription will cost you - your node should be funded and you should have channels open at this point.
+Then you get a list of available IP2TOR bridge offerings.
+By selecting `OK` on a IP2TOR bridge offering you can get more details on it and you will also see how many satoshis the subscription will cost you - your node should be funded and you should have channels open at this point.
 
-If you choose `AGREE` on the details of a IP2TOR bridge offering the RaspiBlitz tries for you to setup the IP2TOR bridge. If everything worked you will find now the subscription under `MAINMENU` > `SUBSCRIBE` > `LIST My Subscriptions` where you can cancel it again.
+If you choose `AGREE` on the details of a IP2TOR bridge offering the RaspiBlitz tries for you to setup the IP2TOR bridge.
+If everything worked you will find now the subscription under `MAINMENU` > `SUBSCRIBE` > `LIST My Subscriptions` where you can cancel it again.
 
 To try out the IP2TOR tunnel choose in `MAINMENU` the extra menu point of the Service you choose the bridge for and it should give you now an updated URL or try calling the API on the IP and Port that is displayed under the details of the subscription in the `LIST My Subscriptions` section.
 
 ##### HTTPS with LetsEncrypt (free)
 
-If you want a web service, like BTCPay Server or LNbits, to be available to the outside internet (like with IP2TOR) people expect you to offer an HTTPS address so that the communication between the client and your RaspiBlitz is encrypted. You could use the self-signed HTTPS certificate that RaspiBlitz is offering you, but this will give users Security Warnings in their browser and is not very user friendly. That's where you can use a LetsEncrypt Subscription to get a free valid HTTPS certificate that is excepted without warning from almost all common browsers. 
+If you want a web service, like BTCPay Server or LNbits, to be available to the outside internet (like with IP2TOR) people expect you to offer an HTTPS address so that the communication between the client and your RaspiBlitz is encrypted.
+You could use the self-signed HTTPS certificate that RaspiBlitz is offering you, but this will give users Security Warnings in their browser and is not very user friendly.
+That's where you can use a LetsEncrypt Subscription to get a free valid HTTPS certificate that is excepted without warning from almost all common browsers 
 
 Because you also need a domain name for that you will need to open a free account, the following are presently supported, would be good to add more with the help of the community: 
 [DuckDNS.org](https://www.duckdns.org)
 [DYNU.com](https://www.dynu.com) (AT THE MOMENT NOT AVAILABLE)
 
-When you create a new LetsEncrypt subscription, you will be asked for your subdomain on DuckDNS and the auth-token of your DuckDNS account. Then RaspiBlitz tries to setup everything for you. If everything worked, you will find the subscription under `MAINMENU` > `SUBSCRIBE` > `LIST My Subscriptions`, where you can cancel it at any time if you wish.
+When you create a new LetsEncrypt subscription, you will be asked for your subdomain on DuckDNS and the auth-token of your DuckDNS account.
+Then RaspiBlitz tries to setup everything for you.
+If everything worked, you will find the subscription under `MAINMENU` > `SUBSCRIBE` > `LIST My Subscriptions`, where you can cancel it at any time if you wish.
 
-To try out the IP2TOR tunnel, go into `MAINMENU` and the extra menu point of the Service you want to use the bridge for. It should give you an updated URL to call your service.
+To try out the IP2TOR tunnel, go into `MAINMENU` and the extra menu point of the Service you want to use the bridge for.
+It should give you an updated URL to call your service.
 
 HTTPS can be a hairy topic, you can try using a SSL Checker to help you quickly diagnose problems with your SSL certificate installation: [www.sslshopper.com/ssl-checker.html](https://www.sslshopper.com/ssl-checker.html)
 
@@ -885,7 +1016,8 @@ Use this if you want to report a software problem with your RaspiBlitz, so that 
 
 ##### BACKUP-LND: Backup your LND data (Rescue-File)
 
-This stops your RaspiBlitz and creates an LND-Rescue ZIP file that you can download via SCP to your laptop. This can be used to move your LND id, wallet & channels to another RaspiBlitz.
+This stops your RaspiBlitz and creates an LND-Rescue ZIP file that you can download via SCP to your laptop.
+This can be used to move your LND id, wallet & channels to another RaspiBlitz.
 
 *NOTICE: If you start your RaspiBlitz after this backup again the backup is outdated and using it can risk losing your channel funds.*
 
@@ -904,19 +1036,28 @@ Multiple options to repair/backup your c-lightning node:
 
 ##### MIGRATION: Migrate Blitz Data to new Hardware
 
-This stops your RaspiBlitz and creates a Migration ZIP file you can download/export per SCP to your laptop. This contains all the important data from your RaspiBlitz including LND, your Blitz configuration and also data from your installed apps. Can be used to migrate your RaspiBlitz to a new hardware - for example if you want to replace the HDD with a SSD. For details on how to import a Migration File [see here](README.md#import-a-migration-file).
+This stops your RaspiBlitz and creates a Migration ZIP file you can download/export per SCP to your laptop.
+This contains all the important data from your RaspiBlitz including LND, your Blitz configuration and also data from your installed apps.
+Can be used to migrate your RaspiBlitz to a new hardware - for example if you want to replace the HDD with a SSD.
+For details on how to import a Migration File [see here](README.md#import-a-migration-file).
 
 *NOTICE: If you start your RaspiBlitz after exporting the migration file again it is outdated and using it can risk losing your channel funds.*
 
 ##### COPY-SOURCE: Offer your Blockchain to another RaspiBlitz for Setup
 
-To expedite the setup process, you can connect another RaspiBlitz and copy over your blockchain data to it. Your RaspiBlitz will be `offline` during that process and it can take between 4 to 6 hours.
+To expedite the setup process, you can connect another RaspiBlitz and copy over your blockchain data to it.
+Your RaspiBlitz will be `offline` during that process and it can take between 4 to 6 hours.
 
-Make sure both RaspiBlitzes are connected to the same local network. During setup with the new RaspiBlitz, choose the `COPY` option to get the blockchain data and then select the source computer `RASPIBLITZ`. Now you can choose the `COPY-SOURCE` option, enter the IP address of the _new_ RaspiBlitz and its Password A (not yours), after which the process should start automatically.
+Make sure both RaspiBlitzes are connected to the same local network.
+During setup with the new RaspiBlitz, choose the `COPY` option to get the blockchain data and then select the source computer `RASPIBLITZ`.
+Now you can choose the `COPY-SOURCE` option, enter the IP address of the _new_ RaspiBlitz and its Password A (not yours), after which the process should start automatically.
 
 ##### RESET-CHAIN: Delete Blockchain and Re-Download
 
-Use this option if your blockchain data got corrupted. It will keep your LND data. You can even keep your channels open. Just keep in mind that your Lightning node will appear offline to the network until you have re-downloaded the blockchain.
+Use this option if your blockchain data got corrupted.
+It will keep your LND data.
+You can even keep your channels open.
+Just keep in mind that your Lightning node will appear offline to the network until you have re-downloaded the blockchain.
 
 ##### RESET-HDD: Delete HDD data but keep blockchain
 
@@ -948,21 +1089,27 @@ The options are explained in detail:
 
 ![UpdateMenu](pictures/update.png)
 
-*Please note that the RaspiBlitz does not support any form of automatic (over the air) updates. This is to ensure that there can be no remote control of your node from a central server.*
+*Please note that the RaspiBlitz does not support any form of automatic (over the air) updates.
+This is to ensure that there can be no remote control of your node from a central server.*
 
 ##### RELEASE: Update RaspiBlitz to a new Version
 
-This is a common way to update your RaspiBlitz. Choose this option to prepare your RaspiBlitz for a new SD card image containing the new version release.
+This is a common way to update your RaspiBlitz.
+Choose this option to prepare your RaspiBlitz for a new SD card image containing the new version release.
 
 ##### PATCH: Patch RaspiBlitz code
 
-With Patching you have now an easy way to sync your RaspiBlitz code/scripts with the official RaspiBlitz GitHub Repo or even your own forked GitHub Repo. This is an option for people that report bugs and we like to offer them a quick script update (patch) between RaspiBlitz releases or for people who want to develop on the RaspiBlitz and sync code between their IDE, forked GitHub and their RaspiBlitz.
+With Patching you have now an easy way to sync your RaspiBlitz code/scripts with the official RaspiBlitz GitHub Repo or even your own forked GitHub Repo.
+This is an option for people that report bugs and we like to offer them a quick script update (patch) between RaspiBlitz releases or for people who want to develop on the RaspiBlitz and sync code between their IDE, forked GitHub and their RaspiBlitz.
 
 ##### LND: Interim LND Update
 
-Sometimes there is a new LND release that has some breaking changes that once you updated the LND database cannot be reversed (like the update from 0.9.2 to 0.10.0). In these cases RaspiBlitz will offer you an _optional_ update. This is where you then can update LND.
+Sometimes there is a new LND release that has some breaking changes that once you updated the LND database cannot be reversed (like the update from 0.9.2 to 0.10.0).
+In these cases RaspiBlitz will offer you an _optional_ update.
+This is where you then can update LND.
 
-If you choose this you get the option to do this `VERIFIED` that means it offers you the optional LND update we tested the RaspiBlitz with or `RECKLESS` which will just grab the latest LND release from the GitHub releases page (also Release Candidates) and install it with no further guarantees and verification checks. The `RECKLESS` option is aimed at people that run nodes to test new releases and how they work with existing RaspiBlitz apps.
+If you choose this you get the option to do this `VERIFIED` that means it offers you the optional LND update we tested the RaspiBlitz with or `RECKLESS` which will just grab the latest LND release from the GitHub releases page (also Release Candidates) and install it with no further guarantees and verification checks.
+The `RECKLESS` option is aimed at people that run nodes to test new releases and how they work with existing RaspiBlitz apps.
 
 ##### BITCOIN: Interim Bitcoin Update
 
@@ -986,31 +1133,39 @@ In the terminal running the command `raspiblitz` will return you to the SSH main
 
 As mentioned above you can export a Migration File from your RaspiBlitz with `MAINMENU > REPAIR > MIGRATION` and store it on your laptop.
 
-A Migration file contains all the important data from your RaspiBlitz, like your LND data, Bitcoin Wallet, raspiblitz.config, Tor/SSH keys, and also installed apps. You can use this to migrate your RaspiBlitz to new hardware.
+A Migration file contains all the important data from your RaspiBlitz, like your LND data, Bitcoin Wallet, raspiblitz.config, Tor/SSH keys, and also installed apps.
+You can use this to migrate your RaspiBlitz to new hardware.
 
 If you want to import it again to a new RaspiBlitz (for example with an updated HDD/SSD), you can choose the `FROMBACKUP` option on the first setup dialogue of a fresh SD card image.
 
 ![SSH0](pictures/ssh0-welcome2.png)
 
-If you start MIGRATION you be get asked whether you would like to use a existing blockchain on the hard drive/SSD and delete the rest, or whether you'd prefer to format the entire drive. Once that's done you are shown instructions on how to upload the migration file (use the password `raspiblitz` when asked on executing the upload command):
+If you start MIGRATION you be get asked whether you would like to use a existing blockchain on the hard drive/SSD and delete the rest, or whether you'd prefer to format the entire drive.
+Once that's done you are shown instructions on how to upload the migration file (use the password `raspiblitz` when asked on executing the upload command):
 
 ![MIGRATION1](pictures/migration1.png)
 
-After this you will be asked to set a new password A, and your RaspiBlitz will go into recovery/provision process. Then RaspiBlitz might give you the option again to self-sync or copy the blockchain from another computer/blitz, and afterwards a final reboot.
+After this you will be asked to set a new password A, and your RaspiBlitz will go into recovery/provision process.
+Then RaspiBlitz might give you the option again to self-sync or copy the blockchain from another computer/blitz, and afterwards a final reboot.
 
 Then the blockchain needs to sync up and you should be back to normal.
 
 ## Make a RaspiBlitz out of your Umbrel or MyNode
 
-Another kind of migration is when you already run a full node with the Umbrel or myNode software and you like to change it to RaspiBlitz without closing channels. You basically have all the hardware needed and just need to change software. You don't need the [LCD from the shopping list](#amazon-shopping-list-buy-parts--build-it-yourself) - RaspiBlitz can also run without an LCD.
+Another kind of migration is when you already run a full node with the Umbrel or myNode software and you like to change it to RaspiBlitz without closing channels.
+You basically have all the hardware needed and just need to change software.
+You don't need the [LCD from the shopping list](#amazon-shopping-list-buy-parts--build-it-yourself) - RaspiBlitz can also run without an LCD.
 
-*NOTE: This migration is still experimental. You will still use the terminal to setup & manage your RaspiBlitz. If that is too technical for you please wait for the RaspiBlitz v1.8, which will introduce a WebUI for your browser that will make the migration to RaspiBlitz more familiar to your old node user experience.*
+*NOTE: This migration is still experimental.
+You will still use the terminal to setup & manage your RaspiBlitz.
+If that is too technical for you please wait for the RaspiBlitz v1.8, which will introduce a WebUI for your browser that will make the migration to RaspiBlitz more familiar to your old node user experience.*
 
 Before you start migration:
 * if you have on-chain funds on your old node - make sure to have the backup seed words
 * if you have lightning channels open on your old node - make sure to have downloaded the latest Static Channel Backup file to your laptop
 
-Also be aware that at the moment RaspiBlitz can only transfer your blockchain and LND wallet data (including channels) over to RaspiBlitz. Any data/pairing of additional apps cannot be transferred and may get lost.
+Also be aware that at the moment RaspiBlitz can only transfer your blockchain and LND wallet data (including channels) over to RaspiBlitz.
+Any data/pairing of additional apps cannot be transferred and may get lost.
 
 Instructions for Migration:
 * shutdown your old node
@@ -1023,10 +1178,14 @@ Now RaspiBlitz should show you that old data from your node was detected and off
 
 * If you choose to continue it will prepare the data & reboot.
 * The RaspiBlitz recover/update modus is starting - that will take a while and finally reboot.
-* Login by SSH as before and reset the passwords (`FINAL RECOVERY LOGIN` on LCD). Then a final reboot will happen.
-* Login by SSH with your new password A & unlock LND wallet with password C. Now blockchain needs to catch up and then your RaspiBlitz should be ready and show you (under INFO) your on-chain & channel balance.
+* Login by SSH as before and reset the passwords (`FINAL RECOVERY LOGIN` on LCD).
+Then a final reboot will happen.
+* Login by SSH with your new password A & unlock LND wallet with password C.
+Now blockchain needs to catch up and then your RaspiBlitz should be ready and show you (under INFO) your on-chain & channel balance.
 
-If you don't have an LCD or HDMI monitor connected it might be a bit difficult to see what state your RaspiBlitz is in. Just (re-)try to login by SSH again after the reboots. It can take some time after a reboot before the operating system and SSH service is started, so just keep trying at intervals until successful.
+If you don't have an LCD or HDMI monitor connected it might be a bit difficult to see what state your RaspiBlitz is in.
+Just (re-)try to login by SSH again after the reboots.
+It can take some time after a reboot before the operating system and SSH service is started, so just keep trying at intervals until successful.
 
 ## Interface / APIs
 
@@ -1049,7 +1208,8 @@ If you activate Tor then your LND gRPC & REST APIs will also be reachable public
 
 ### Backup for On-Chain- & Channel-Funds
 
-Since LND v0.6 (and RaspiBlitz v1.2), a feature called Static-Channel-Backups is available. Within RaspiBlitz this is used when a `channel.backup` file is mentioned.
+Since LND v0.6 (and RaspiBlitz v1.2), a feature called Static-Channel-Backups is available.
+Within RaspiBlitz this is used when a `channel.backup` file is mentioned.
 
 At this point in time it is the best way to backup and protect your channel funds on RaspiBlitz, so it's recommended to make use of it.
 
@@ -1057,9 +1217,13 @@ To recover your funds this way you will need two things:
 - the 24-word seed
 - the latest `channel.backup` file
 
-You should have written down the word seed during wallet setup; keep it at a safe (offline) location. The `channel.backup` is stored on the HDD and updated by LND every time a new channel is opened or closed. The latest version of this file is needed to recover all your funds. In case your HDD gets damaged RaspiBlitz always keeps a copy of the latest version of the `channel.backup` file on the SD card within the sub-directories of: `/home/admin/.lnd/data/chain/`.
+You should have written down the word seed during wallet setup; keep it at a safe (offline) location.
+The `channel.backup` is stored on the HDD and updated by LND every time a new channel is opened or closed.
+The latest version of this file is needed to recover all your funds.
+In case your HDD gets damaged RaspiBlitz always keeps a copy of the latest version of the `channel.backup` file on the SD card within the sub-directories of: `/home/admin/.lnd/data/chain/`.
 
-If you want to go one step further in securing your funds against total loss of the RaspiBlitz (gets completely damaged, stolen or lost), then you can additionally set up an off-location or cloud backup of the `channel.backup` file. The file itself is encrypted by your word seed so it's acceptable to store the file with untrusted third parties for backup purposes (if you want). 
+If you want to go one step further in securing your funds against total loss of the RaspiBlitz (gets completely damaged, stolen or lost), then you can additionally set up an off-location or cloud backup of the `channel.backup` file.
+The file itself is encrypted by your word seed so it's acceptable to store the file with untrusted third parties for backup purposes (if you want) 
 
 This video explains in detail how you can set further back Static Channel information:
 
@@ -1069,7 +1233,9 @@ The following options are also explained here shortly:
 
 #### A) DropBox Backup Target
 
-Toggle the StaticChannelBackup option to DropBox in the `SETTINGS` menu of your RaspiBlitz. It will ask you for the Dropbox-Authtoken. This is how you can get this token:
+Toggle the StaticChannelBackup option to DropBox in the `SETTINGS` menu of your RaspiBlitz.
+It will ask you for the Dropbox-Authtoken.
+This is how you can get this token:
 
 Go to your web browser, do the following:
 
@@ -1093,27 +1259,32 @@ Go to your web browser, do the following:
 
     Now go back to the 'Settings' tab and under 'OAuth2', choose 'no expiration' under 'Access token expiration' then click the 'Generate' button. You will now see a long string of letters and numbers appear. This is your **Dropbox-Authtoken**. Make sure to copy the complete token string .. there might be more if you scroll to the right in the token field. 
 
-To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` in your Dropbox. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
+To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` in your Dropbox.
+You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
 
 #### B) SCP Backup Target
 
 *You can also backup the StaticChannelBackup file to your own server, but this needs manual setup:*
 
-In the `/mnt/hdd/raspiblitz.conf` the parameter `scpBackupTarget='[USER]@[SERVER]:[DIRPATH-WITHOUT-ENDING-/]'` can be set to activate this feature. On the remote server, the public key of the RaspiBlitz root user needs to be added to the `authorized_keys` file so that no password is needed for the background script to make the backup.
+In the `/mnt/hdd/raspiblitz.conf` the parameter `scpBackupTarget='[USER]@[SERVER]:[DIRPATH-WITHOUT-ENDING-/]'` can be set to activate this feature.
+On the remote server, the public key of the RaspiBlitz root user needs to be added to the `authorized_keys` file so that no password is needed for the background script to make the backup.
 
 The script `/home/admin/config.scripts/internet.sshpubkey.sh` helps on initialization (init); it will show and transfer ssh-pubkey to a remote server.
 
-To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` on your remote server. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
+To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` on your remote server.
+You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
 
 #### C) Local Backup Target (USB Thumbdrive)
 
 *You can also backup the StaticChannelBackup to another local drive, e.g. a USB stick:*
 
-You can use a small USB thumb drive (everything over 120MB is fine). Please don't use a second HDD/SSD for this because that might drain too much power and could hurt the security of your data more than it helps.
+You can use a small USB thumb drive (everything over 120MB is fine).
+Please don't use a second HDD/SSD for this because that might drain too much power and could hurt the security of your data more than it helps.
 
 To activate this feature, go to `MAINMENU` > `SETTINGS` > `StaticChannelBackup on USB Drive` and follow the instructions.
 
-To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` in the specified location. You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
+To test it, try opening or closing a channel and then check if you can find a copy of `channel.backup` in the specified location.
+You can check the background-script logs to see details on errors: `sudo journalctl -f -u background`
 
 ## Updating RaspiBlitz to new Version
 
@@ -1129,28 +1300,37 @@ If you have a RaspiBlitz v1.0 or v1.1 or higher do the following:
 * Remove power
 * Remove SD card
 
-Now download the new RaspiBlitz SD card image and write it to your SD card. Yes, you simply overwrite the old one -- it's OK! The RaspiBlitz stores all your personal data on the HDD. See details about latest SD card image [here](#installing-the-software).
+Now download the new RaspiBlitz SD card image and write it to your SD card.
+Yes, you simply overwrite the old one -- it's OK! The RaspiBlitz stores all your personal data on the HDD.
+See details about latest SD card image [here](#installing-the-software).
 
 *If you have done manual changes to the system (installed packages, added scripts, etc.), you might need to take some additional steps before overwriting your SD card - see [FAQ](FAQ.md#why-do-i-need-to-re-burn-my-sd-card-for-an-update).*
 
-If done successfully simply put the SD card into the RaspiBlitz and power on again. Then follow the instructions on the display ... and don't worry, you don't need to re-download the blockchain again. It is worth noting here that your SSH password will be reset to `raspiblitz`. You will be prompted to change this once the update is finished.
+If done successfully simply put the SD card into the RaspiBlitz and power on again.
+Then follow the instructions on the display ... and don't worry, you don't need to re-download the blockchain again.
+It is worth noting here that your SSH password will be reset to `raspiblitz`.
+You will be prompted to change this once the update is finished.
 
 * [Why do I need to re-burn my SD card for an update?](FAQ.md#why-do-i-need-to-re-burn-my-sd-card-for-an-update)
 
 ## Build the SD Card Image
 
-A ready-to-use SD card image of RaspiBlitz is provided by us for download, to get everybody started quickly (see above). But if you want to build that image yourself - here is a quick guide:
+A ready-to-use SD card image of RaspiBlitz is provided by us for download, to get everybody started quickly (see above).
+But if you want to build that image yourself - here is a quick guide:
 
 * Get a latest RaspiOS 64-bit: [DOWNLOAD](https://downloads.raspberrypi.org/raspios_arm64/images).
 * Write the image to an SD card: [TUTORIAL](https://www.raspberrypi.org/documentation/installation/installing-images/README.md).
 * Add a file called `ssh` to the root of the SD card when mounted on your laptop to enable SSH login.
 * Start the card on a Raspi and login via SSH with `ssh pi@[IP-OF-YOUR-RASPI]`. Password is `raspberry`.
 
-Now you are ready to start the SD card build script (check the code to see if the installation and config are OK for you). Copy the following command into your terminal and execute:
+Now you are ready to start the SD card build script (check the code to see if the installation and config are OK for you).
+Copy the following command into your terminal and execute:
 
 `wget https://raw.githubusercontent.com/rootzoll/raspiblitz/v1.7/build_sdcard.sh && sudo bash build_sdcard.sh`
 
-As you can see from the URL, you can find the build script in this Git repo under `build_sdcard.sh`. You can check what gets installed and configured in detail. Feel free to post improvements as pull requests.
+As you can see from the URL, you can find the build script in this Git repo under `build_sdcard.sh`.
+You can check what gets installed and configured in detail.
+Feel free to post improvements as pull requests.
 
 The whole build process takes a while.
 At the end the LCD drivers get installed and a reboot is needed.
@@ -1162,7 +1342,8 @@ If you do not want to continue with the installation at this moment, and use thi
 Once you see the LCD going white and the activity LED of the pi starts going dark you can unplug power and remove the SD card.
 You have now built your own RaspiBlitz SD card image.
 
-*Note: If you plan to use your self-build SD card as a MASTER copy and distribute it: Use a smaller 8GB card for that. This way it's ensured that it will fit on every 16 GB card recommended for RaspiBlitz later on.*
+*Note: If you plan to use your self-build SD card as a MASTER copy and distribute it: Use a smaller 8GB card for that.
+This way it's ensured that it will fit on every 16 GB card recommended for RaspiBlitz later on.*
 
 * [Can I run RaspiBlitz on other computers than RaspberryPi?](FAQ.md#can-i-run-raspiblitz-on-other-computers-than-raspberrypi)
 * [How can I build an SD card other than the master branch?](FAQ.md#how-can-i-build-an-sd-card-other-then-the-master-branch)
@@ -1181,7 +1362,9 @@ Do you still have more questions? Check the [RaspiBlitz-FAQ-Archive](FAQ.md).
 
 ## Community Development
 
-Everybody is welcome to join, improve, and extend the RaspiBlitz - it's a work in progress. [Check the issues](https://github.com/rootzoll/raspiblitz/issues) if you wanna help out or add new ideas. You find the scripts used for RaspiBlitz interactions on the device at `/home/admin` or in this Git repo's subfolder `home.admin`.
+Everybody is welcome to join, improve, and extend the RaspiBlitz - it's a work in progress.
+[Check the issues](https://github.com/rootzoll/raspiblitz/issues) if you wanna help out or add new ideas.
+You find the scripts used for RaspiBlitz interactions on the device at `/home/admin` or in this Git repo's subfolder `home.admin`.
 
 To start your Deep Dive into the RaspiBlitz project, the following YouTube video (July 2020) is recommended: [https://www.youtube.com/watch?v=QXUGg45CWLo](https://www.youtube.com/watch?v=QXUGg45CWLo)
 


### PR DESCRIPTION
First commit fixes grammatical and spelling issues.

Second commit is optional, but splits paragraphs into "one line per sentence", which makes (future) manipulation of sections much easier with text editors, as lines can be moved, removed or joined with ease. Markdown automatically joins lines without a white-space line between them during output so this has no effect on the end result.

Let me know if you want me to drop the second commit.