### PR TITLE
allow custom e-mail server port for notify

### DIFF
--- a/home.admin/config.scripts/blitz.notify.sh
+++ b/home.admin/config.scripts/blitz.notify.sh
@@ -36,6 +36,10 @@ if ! grep -Eq "^notifyMailServer=.*" /mnt/hdd/raspiblitz.conf; then
     echo "notifyMailServer=mail.example.com" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
 fi
 
+if ! grep -Eq "^notifyMailPort=.*" /mnt/hdd/raspiblitz.conf; then
+    echo "notifyMailPort=587" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
+fi
+
 if ! grep -Eq "^notifyMailHostname=.*" /mnt/hdd/raspiblitz.conf; then
     echo "notifyMailHostname=$(hostname)" | sudo tee -a /mnt/hdd/raspiblitz.conf >/dev/null
 fi
@@ -92,12 +96,12 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   cat << EOF | sudo tee /etc/msmtprc >/dev/null
 # Set default values for all following accounts.
 defaults
-port 587
 tls on
 tls_trust_file /etc/ssl/certs/ca-certificates.crt
 
 account mail
 host ${notifyMailServer}
+port ${notifyMailPort}
 from ${notifyMailFromAddress}
 auth on
 user ${notifyMailUser}


### PR DESCRIPTION
Allows to set a custom mail server port via `notifyMailPort` setting in `raspiblitz.conf`.