### PR TITLE
Small improvements to internet check (re: #2388)

### DIFF
--- a/home.admin/config.scripts/internet.sh
+++ b/home.admin/config.scripts/internet.sh
@@ -93,6 +93,14 @@ if [ "${peers}" != "0" ] && [ "${peers}" != "" ]; then
   online=1
 fi
 if [ ${online} -eq 0 ] && [ "${dnsServer}" != "" ]; then
+    # test with netcat to avoid firewall issues with ICMP packets
+    online=$(nc -v -z -w 3 ${dnsServer} 53 &> /dev/null && echo "1" || echo "0")
+fi
+if [ ${online} -eq 0 ]; then
+    # test with netcat to avoid firewall issues with ICMP packets
+    online=$(nc -v -z -w 3 8.8.8.8 53 &> /dev/null && echo "1" || echo "0")
+fi
+if [ ${online} -eq 0 ] && [ "${dnsServer}" != "" ]; then
   # re-test with user set dns server
   online=$(ping ${dnsServer} -c 1 -W 2 2>/dev/null | grep -c '1 received')
 fi


### PR DESCRIPTION
I rebooted my Pi today and it was struggling to get services running for some reason (impatience?), and saw the issues here related to internet.sh. I'm pretty sure my firewall is blocking ICMP packets to this subnet, so I switched it out to `nc`.

FWIW, I have a block in my internet.sh that's basically identical to #2596 that I included above the netcat checks in the interests of privacy. 
It's kind of hacky and I'm not super familiar with operating a tor node, so I omitted it from the PR:
```
if [ "$runBehindTor" == "1" ]; then
    # check with tor if enabled & listening
    torListen=$(netstat -ano | grep LISTEN | grep 9050)
    if [ ! -z "$torListen" ]; then
        istor=$(curl --socks5 localhost:9050 --socks5-hostname localhost:9050 -s https://check.torproject.org/ | cat | grep -m 1 Congratulations | xargs)
        online=$([ "$istor" == "Congratulations. This browser is configured to use Tor." ] && echo "1" || echo "0")
    fi
fi
```