### PR TITLE
Update electrs to 0.9.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - New: Verify git commits and tags everywhere possible [issue](https://github.com/rootzoll/raspiblitz/issues/2686)
 - Update: C-lightning v0.10.2 [details](https://github.com/ElementsProject/lightning/releases/tag/v0.10.2)
 - Update: BTCPayServer v1.3.3 with UPDATE option [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.3.3)
-- Update: Electrum Server in Rust (electrs) v0.9.2 [details](https://github.com/romanz/electrs/blob/v0.9.2/RELEASE-NOTES.md)
+- Update: Electrum Server in Rust (electrs) v0.9.3 [details](https://github.com/romanz/electrs/blob/v0.9.3/RELEASE-NOTES.md)
 - Update: JoinMarket v0.9.3 [details](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.2)
 - Update: JoininBox v0.6.3 [details](https://github.com/openoms/joininbox/releases/tag/v0.6.1)
 - Update: Thunderhub v0.12.31 [details](https://github.com/apotdevin/thunderhub/releases/tag/v0.12.31)

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/romanz/electrs/releases
-ELECTRSVERSION="v0.9.2"
+ELECTRSVERSION="v0.9.3"
 # https://github.com/romanz/electrs/commits/master
 # ELECTRSVERSION="3041e89cd2fb377541b929d852ef6298c2d4e60a"
 

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -308,7 +308,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     # https://github.com/romanz/electrs/blob/master/doc/usage.md#configuration-files-and-environment-variables
     sudo -u electrs mkdir /home/electrs/.electrs 2>/dev/null
     echo "
-verbose = 2
 timestamp = true
 jsonrpc_import = true
 index-batch-size = 10


### PR DESCRIPTION
[Release notes here](https://github.com/romanz/electrs/blob/v0.9.3/RELEASE-NOTES.md).
This update dropped the `verbose` option, so I had to remove that. I haven't looked into your update/migration logic yet, not sure if there is anything required to update an existing config file, so @rootzoll please tell me if this is needed.