### PR TITLE
fix webui routing, fixes #2723

### DIFF
--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -27,7 +27,7 @@ server {
 
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
+		try_files $uri $uri/ /index.html =404;
 
 	}
 


### PR DESCRIPTION
This fixes the problem of subroutes like /login, /home, ... not being recognized by nginx and returning a 404.

Still got an issue with routing (always returning to /home on F5 when logged in, even on other routes), but that's most likely an app issue, not nginx.

This fixes #2723 