### PR TITLE
increase timeoutsec to avoid re-entering the password lnd

### DIFF
--- a/home.admin/config.scripts/lnd.install.sh
+++ b/home.admin/config.scripts/lnd.install.sh
@@ -145,7 +145,7 @@ EnvironmentFile=/mnt/hdd/raspiblitz.conf
 ExecStartPre=-/home/admin/config.scripts/lnd.check.sh prestart ${CHAIN}
 ExecStart=/usr/local/bin/lnd --configfile=/home/bitcoin/.lnd/${netprefix}lnd.conf
 Restart=always
-TimeoutSec=120
+TimeoutSec=240
 RestartSec=30
 StandardOutput=null
 StandardError=journal


### PR DESCRIPTION
Related to the issue #2622 

Adding more time will avoid service to restart and having to re-enter password