### PR TITLE
blitz.datadrive.sh: extra names for variables used in other scripts

### DIFF
--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -349,6 +349,8 @@ if [ "$1" = "status" ]; then
 
     echo "datadisk='${hdd}'"
     echo "datapartition='${hddDataPartition}'"
+    echo "hddCandidate='${hdd}'"
+    echo "hddPartitionCandidate='${hddDataPartition}'"
 
     # check if blockchain data is available
     hddBlocksBitcoin=$(sudo ls /mnt/hdd/bitcoin/blocks/blk00000.dat 2>/dev/null | grep -c '.dat')


### PR DESCRIPTION
Both variable names are used in other scripts