### PR TITLE
Copy ssh files to/from hdd with backward compatibility

### DIFF
--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -268,7 +268,7 @@ fi
 if [ -d "/var/cache/raspiblitz/hdd-inspect/ssh" ]; then
   # INIT OLD SSH HOST KEYS on Update/Recovery to prevent "Unknown Host" on ssh client
   echo "SSH SERVER CERTS RESTORE activating old SSH host keys" >> $logFile
-  /home/admin/config.scripts/blitz.ssh.sh restore /var/cache/raspiblitz/hdd-inspect >> $logFile
+  /home/admin/config.scripts/blitz.ssh.sh restore /var/cache/raspiblitz/hdd-inspect/ssh >> $logFile
 else
   echo "No SSH SERVER CERTS RESTORE because no /var/cache/raspiblitz/hdd-inspect/ssh" >> $logFile
 fi

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -240,7 +240,26 @@ if [ "$1" = "status" ]; then
             cp /mnt/hdd${subVolumeDir}/app-data/wpa_supplicant.conf /var/cache/raspiblitz/hdd-inspect/wpa_supplicant.conf 2>/dev/null
 
             # make copy of SSH keys to RAMDISK (if available)
-            cp -r /mnt/hdd${subVolumeDir}/ssh /var/cache/raspiblitz/hdd-inspect/ssh 2>/dev/null
+            # conversion to two directories
+            SSHBACKUPDIR="/mnt/hdd/ssh"
+            if [ -d "${SSHBACKUPDIR}/sshd" ] && [ -d "${SSHBACKUPDIR}/root_backup" ]; then
+               echo "SSH backup directory has 2 subdirectories. No conversion."
+            else
+               echo -n "SSH backup directory is 1 directory. Converting..."
+               DATE=$(date +%Y%m%d%H%M)
+               cp -a ${SSHBACKUPDIR} ${SSHBACKUPDIR}.old.bak.${DATE}
+               mkdir -p ${SSHBACKUPDIR}/root_backup
+               mkdir -p ${SSHBACKUPDIR}/sshd
+               cp -a $SSHBACKUPDIR/* ${DEFAULTBACKUPBASEDIR}/sshd
+               COPIED=$?
+               if [ COPIED == 0 ]; then
+                  echo "done"
+               else
+                  echo "FAILED"
+               fi
+            fi
+
+            cp -r /mnt/hdd${subVolumeDir}/ssh /var/cache/raspiblitz/hdd-inspect 2>/dev/null
 
           fi
         

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -259,7 +259,7 @@ if [ "$1" = "status" ]; then
                fi
             fi
 
-            cp -r /mnt/hdd${subVolumeDir}/ssh /var/cache/raspiblitz/hdd-inspect 2>/dev/null
+            cp -r /mnt/hdd${subVolumeDir}/ssh /var/cache/raspiblitz/hdd-inspect
 
           fi
         


### PR DESCRIPTION
The ssh files on the hdd are overwritten and the subdirectories on the hdd has changed (mine had none).
And to preserve timestamps.
The ssh files on the hdd can be in old or new directory structure and will be converted to the new directory structure.
Replaces #2814.

Please review.