### PR TITLE
Catch 404 errors and add logs when when tor bridges are deleted

### DIFF
--- a/home.admin/config.scripts/blitz.subscriptions.ip2tor.py
+++ b/home.admin/config.scripts/blitz.subscriptions.ip2tor.py
@@ -151,6 +151,9 @@ def apiGetHosts(session, shopurl):
         response = session.get(url)
     except Exception as e:
         raise BlitzError("failed HTTP request", {'url': url}, e)
+    if response.status_code == 404:
+        raise BlitzError("failed HTTP code, cancel the old tor bridge subscription and create a new one",
+                         {'status_code': response.status_code})
     if response.status_code != 200:
         raise BlitzError("failed HTTP code", {'status_code': response.status_code})
 


### PR DESCRIPTION
PR to address [issue 2263](https://github.com/rootzoll/raspiblitz/issues/2263). Catching 404 errors and including a log message when tor bridge's have expired. 

I'd welcome comments as this is my first commit to this project.