### PR TITLE
(webui): disable yarn 3 telemetry

### DIFF
--- a/home.admin/config.scripts/blitz.web.ui.sh
+++ b/home.admin/config.scripts/blitz.web.ui.sh
@@ -49,6 +49,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   /home/admin/config.scripts/bonus.nodejs.sh on
   source <(/home/admin/config.scripts/bonus.nodejs.sh info)
   sudo npm install --global yarn
+  ${NODEPATH}/yarn config set --home enableTelemetry 0
   ${NODEPATH}/yarn install
   ${NODEPATH}/yarn build
 


### PR DESCRIPTION
Thanks to Aaron, we are now using yarn 3 as dependency management, 

This disables the opt-out telemetry on the whole machine, see https://yarnpkg.com/advanced/telemetry#how-can-i-disable-it 

Not tested on a real raspiblitz yet but it's just setting a flag in yarn, thus won't break anything.