### PR TITLE
Check if the mempool SQL file exists before attempting to import it

### DIFF
--- a/home.admin/config.scripts/bonus.mempool.sh
+++ b/home.admin/config.scripts/bonus.mempool.sh
@@ -130,7 +130,9 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo mariadb -e "CREATE DATABASE mempool;"
     sudo mariadb -e "GRANT ALL PRIVILEGES ON mempool.* TO 'mempool' IDENTIFIED BY 'mempool';"
     sudo mariadb -e "FLUSH PRIVILEGES;"
-    mariadb -umempool -pmempool mempool < mariadb-structure.sql
+    if [ -f "mariadb-structure.sql" ]; then
+      mariadb -umempool -pmempool mempool < mariadb-structure.sql
+    fi
 
     echo "# npm install for mempool explorer (frontend)"
 


### PR DESCRIPTION
The SQL file was removed on Mempool v2.3.0 to let the backend handle the initial table creation.

This change keeps the script compatible with previous versions.