### PR TITLE
Bitcoinminds.org to be made available as a service in Raspiblitz

### DIFF
--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -43,7 +43,7 @@ if [ "${network}" == "bitcoin" ]; then
   OPTIONS+=(a 'BTC Mempool Space' ${mempoolExplorer})
   OPTIONS+=(j 'BTC JoinMarket+JoininBox menu' ${joinmarket})
   OPTIONS+=(w 'BTC Download Bitcoin Whitepaper' ${whitepaper})
-  OPTIONS+=(v 'BTC BitcoinMinds.org in Local' ${bitcoinminds})
+  OPTIONS+=(v 'BTC Install BitcoinMinds.org' ${bitcoinminds})
 fi
 
 

--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -27,6 +27,7 @@ if [ ${#chantools} -eq 0 ]; then chantools="off"; fi
 if [ ${#sparko} -eq 0 ]; then sparko="off"; fi
 if [ ${#spark} -eq 0 ]; then spark="off"; fi
 if [ ${#tallycoinConnect} -eq 0 ]; then tallycoinConnect="off"; fi
+if [ ${#bitcoinminds} -eq 0 ]; then bitcoinminds="off"; fi
 
 # show select dialog
 echo "run dialog ..."
@@ -42,6 +43,7 @@ if [ "${network}" == "bitcoin" ]; then
   OPTIONS+=(a 'BTC Mempool Space' ${mempoolExplorer})
   OPTIONS+=(j 'BTC JoinMarket+JoininBox menu' ${joinmarket})
   OPTIONS+=(w 'BTC Download Bitcoin Whitepaper' ${whitepaper})
+  OPTIONS+=(v 'BTC BitcoinMinds.org in Local' ${bitcoinminds})
 fi
 
 
@@ -498,6 +500,21 @@ if [ "${whitepaper}" != "${choice}" ]; then
   fi
 else
   echo "Whitepaper setting unchanged."
+fi
+
+# BitcoinMinds process choice
+choice="off"; check=$(echo "${CHOICES}" | grep -c "v")
+if [ ${check} -eq 1 ]; then choice="on"; fi
+if [ "${bitcoinminds}" != "${choice}" ]; then
+  echo "BitcoinMinds setting changed."
+  anychange=1
+  sudo -u admin /home/admin/config.scripts/bonus.bitcoinminds.sh ${choice}
+  source /mnt/hdd/raspiblitz.conf
+  if [ "${bitcoinminds}" =  "on" ]; then
+    sudo -u admin /home/admin/config.scripts/bonus.bitcoinminds.sh menu
+  fi
+else
+  echo "BitcoinMinds setting unchanged."
 fi
 
 # sparko process choice

--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -394,3 +394,20 @@ function qr() {
   echo "(To shrink QR code: MacOS press CMD- / Linux press CTRL-)"
   echo
 }
+
+# command: bm
+# switch to the bitcoinminds user for the 'BitcoinMinds.org' in your local environment
+function bm() {
+  if [ $(grep -c "bitcoinminds=on"  < /mnt/hdd/raspiblitz.conf) -eq 1 ]; then
+    echo ""
+    echo "# ***"
+    echo "# Switching to the bitcoinminds user with the command: 'sudo su - bitcoinminds'"
+    echo "# ***"
+    echo ""
+    sudo su - bitcoinminds
+    echo "# Use command 'raspiblitz' to return to menu"
+  else
+    echo "BitcoinMinds script is not installed - to install run:"
+    echo "sudo /home/admin/config.scripts/bonus.bitcoinminds.sh on"
+  fi
+}

--- a/home.admin/config.scripts/bonus.bitcoinminds.sh
+++ b/home.admin/config.scripts/bonus.bitcoinminds.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+BitcoinMindsVersion="v0.1"
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+  echo "# config script to download and run from your Raspiblitz the BitcoinMinds.org website"
+  echo "# on: installs BitcoinMinds.org and runs a local server"
+  echo "# off: removes all the code"
+  echo "# bonus.bitcoinminds.sh [on|off|menu]"
+  echo "# BitcoinMinds.org installation script $BitcoinMindsVersion"
+  exit 1
+fi
+
+source /mnt/hdd/raspiblitz.conf
+
+# add default value to raspi config if needed
+if ! grep -Eq "^bitcoinminds=" /mnt/hdd/raspiblitz.conf; then
+  echo "bitcoinminds=off" >> /mnt/hdd/raspiblitz.conf
+fi
+
+# show info menu
+if [ "$1" = "menu" ]; then
+  dialog --title " BitcoinMinds.org Info" --msgbox "
+This service downloads the full BitcoinMinds.org website in your Raspiblitz, so you can access its interface and Bitcoin resources from your local network, regardless of the internet connection.
+Use the command 'bm' from the console to start the server.
+" 11 78
+  exit 0
+fi
+
+
+# switch on
+if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+
+    echo ""
+    echo "# ***"
+    echo "# Installing BitcoinMinds.org in your Raspiblitz ..."
+    echo "# ***"
+    echo ""
+
+    # create user
+    sudo adduser --disabled-password --gecos "" bitcoinminds 2>/dev/null
+
+    # add local directory to path and set PATH for the user
+    sudo bash -c "echo 'PATH=\$PATH:/home/bitcoinminds/.local/bin' >> /home/bitcoinminds/.profile"
+    sudo bash -c "echo 'PATH=\$PATH:/home/bitcoinminds/.local/share/composer' >> /home/bitcoinminds/.profile"
+
+    cd /home/bitcoinminds
+
+    echo ""
+    echo "# ***"
+    echo "# Downloading BitcoinMinds.org from GitHub ..."
+    echo "# ***"
+    echo ""
+    sudo -u bitcoinminds git clone https://github.com/raulcano/bitcoinminds.git 2>/dev/null
+
+    echo ""
+    echo "# ***"
+    echo "# Installing packages ..."
+    echo "# ***"
+    echo ""
+    cd /home/bitcoinminds/bitcoinminds/bitcoinminds-ui
+    sudo -u bitcoinminds npm install
+
+    echo ""
+    echo "# ***"
+    echo "# Setting the autostart script for user bitcoinminds"
+    echo "# ***"
+    echo "
+cd /home/bitcoinminds/bitcoinminds/bitcoinminds-ui
+npm run serve
+" | sudo -u bitcoinminds tee -a /home/bitcoinminds/.bashrc
+
+
+   # setting value in raspi blitz config
+    sudo sed -i "s/^bitcoinminds=.*/bitcoinminds=on/g" /mnt/hdd/raspiblitz.conf
+   
+    echo ""
+    echo "# ***"
+    echo "# OK - BitcoinMinds installed. Type 'bm' in the console to start the environment."
+    echo "# ***"
+    echo ""
+
+  exit 0
+fi
+
+# switch off
+if [ "$1" = "0" ] || [ "$1" = "off" ]; then
+  isInstalled=1
+  if [ ${isInstalled} -eq 1 ]; then
+    
+    echo ""
+    echo "# ***"
+    echo "# Removing BitcoinMinds..."
+    echo "# ***"
+    echo ""
+    # setting value in raspi blitz config
+    sudo sed -i "s/^bitcoinminds=.*/bitcoinminds=off/g" /mnt/hdd/raspiblitz.conf
+    
+    # Remove user and stuff here
+    sudo userdel -rf bitcoinminds 2>/dev/null
+
+    echo ""
+    echo "# ***"
+    echo "# OK - BitcoinMinds removed."
+    echo "# ***"
+    echo ""
+  else
+    echo "# BitcoinMinds has not been installed yet."
+  fi
+  exit 0
+fi

--- a/home.admin/config.scripts/bonus.bitcoinminds.sh
+++ b/home.admin/config.scripts/bonus.bitcoinminds.sh
@@ -75,6 +75,9 @@ npm run serve
    # setting value in raspi blitz config
     sudo sed -i "s/^bitcoinminds=.*/bitcoinminds=on/g" /mnt/hdd/raspiblitz.conf
    
+  # add a firewall entry so the web UI is accessible from the local network
+    sudo ufw allow 11026 comment 'bitcoinminds'
+
     echo ""
     echo "# ***"
     echo "# OK - BitcoinMinds installed. Type 'bm' in the console to start the environment."

--- a/home.admin/config.scripts/bonus.bitcoinminds.sh
+++ b/home.admin/config.scripts/bonus.bitcoinminds.sh
@@ -103,6 +103,9 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     # Remove user and stuff here
     sudo userdel -rf bitcoinminds 2>/dev/null
 
+    # delete firewall entry
+    sudo ufw delete allow 11026 comment 'bitcoinminds'
+
     echo ""
     echo "# ***"
     echo "# OK - BitcoinMinds removed."

--- a/home.admin/config.scripts/bonus.bitcoinminds.sh
+++ b/home.admin/config.scripts/bonus.bitcoinminds.sh
@@ -68,7 +68,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     echo "# ***"
     echo "
 cd /home/bitcoinminds/bitcoinminds/bitcoinminds-ui
-npm run serve
+npm run serve -- --port 11026
 " | sudo -u bitcoinminds tee -a /home/bitcoinminds/.bashrc
 
 


### PR DESCRIPTION
With this PR I would like to enable a new Raspiblitz service to allow any Raspi to host and run fully the BitcoinMinds.org site.
This pull request adds 3 things:
- A bonus script to download the code from the bitcoinminds.org repo https://github.com/raulcano/bitcoinminds
- A menu item to enable and disable this service.
- A command 'bm' to start the server (npm run serve) and make the site available to be visited from the LAN

I leave this PR in draft until I have properly tested it in my Raspiblitz.

NOTE: this PR replaces a deleted one #2415 

![image](https://user-images.githubusercontent.com/1665639/125067940-2cc8ed80-e0b5-11eb-82d4-a97cdab0989b.png)

![image](https://user-images.githubusercontent.com/1665639/125067994-3eaa9080-e0b5-11eb-9a46-0d72517a31b2.png)

![image](https://user-images.githubusercontent.com/1665639/126797304-78295cec-380c-40de-b199-bd85b3a0f673.png)

![image](https://user-images.githubusercontent.com/1665639/126798783-259e5d2e-8e9f-41cf-85cd-08b2fa49347e.png)

![image](https://user-images.githubusercontent.com/1665639/126800234-3e91b0f8-7be4-4f7b-bc75-ffd104d5802d.png)

![image](https://user-images.githubusercontent.com/1665639/126805248-88ef3164-1dcb-413d-a4a7-753359848f53.png)
