### PR TITLE
CL install from source from github instead of zip

### DIFF
--- a/home.admin/config.scripts/blitz.git-verify.sh
+++ b/home.admin/config.scripts/blitz.git-verify.sh
@@ -50,8 +50,10 @@ _temp="$(mktemp -p /dev/shm/)"
 if [ $# -eq 3 ]; then
   commitHash="$(git log --oneline | head -1 | awk '{print $1}')"
   gitCommand="git verify-commit $commitHash"
+  commitOrTag="$commitHash commit"
 elif [ $# -eq 4 ]; then
   gitCommand="git verify-tag $4"
+  commitOrTag="$4 tag"
 fi
 echo "# running: ${gitCommand}"
 if ${gitCommand} 2>&1 >&"$_temp"; then
@@ -60,7 +62,7 @@ else
   goodSignature=0
 fi
 echo
-cat $_temp
+cat "$_temp"
 echo "# goodSignature(${goodSignature})"
 
 correctKey=$(tr -d " \t\n\r" < "$_temp" | grep "${PGPpubkeyFingerprint}" -c)
@@ -73,7 +75,7 @@ if [ "${correctKey}" -lt 1 ] || [ "${goodSignature}" -lt 1 ]; then
 else
   echo
   echo "##########################################################################"
-  echo "# OK --> the PGP signature of the checked out $commitHash commit is correct"
+  echo "# OK --> the PGP signature of the checked out ${commitOrTag} is correct"
   echo "##########################################################################"
   echo
   exit 0

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -10,12 +10,12 @@ CLVERSION=v0.10.2
 
 # https://github.com/ElementsProject/lightning/tree/master/contrib/keys
 # PGPsigner="rustyrussel"
-# PGPpkeys="https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/rustyrussell.txt"
-# PGPcheck="D9200E6CD1ADB8F1"
+# PGPpubkeyLink="https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/rustyrussell.txt"
+# PGPpubkeyFingerprint="D9200E6CD1ADB8F1"
 
 PGPsigner="cdecker"
-PGPpkeys="https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/cdecker.txt"
-PGPcheck="A26D6D9FE088ED58"
+PGPpubkeyLink="https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/${PGPsigner}.txt"
+PGPpubkeyFingerprint="A26D6D9FE088ED58"
 
 # help
 if [ $# -eq 0 ]||[ "$1" = "-h" ]||[ "$1" = "--help" ];then
@@ -60,68 +60,82 @@ if [ "$1" = "install" ]; then
   echo "# no configuration, no systemd service"
 
   # check if the binary is already installed
-  if [ $(sudo -u bitcoin lightning-cli --version 2>/dev/null | grep -c .) -gt 0 ]; then
+  if [ -f /usr/local/bin/lightningd ]; then
     echo "c-lightning binary already installed - done"
     exit 1
   fi
 
-  # prepare download dir
-  sudo rm -rf /home/bitcoin/download
-  sudo -u bitcoin mkdir -p /home/bitcoin/download
-  cd /home/bitcoin/download || exit 1
+## Install from zip
+#  # prepare download dir
+#  sudo rm -rf /home/bitcoin/download
+#  sudo -u bitcoin mkdir -p /home/bitcoin/download
+#  cd /home/bitcoin/download || exit 1
+#
+#  sudo -u bitcoin wget -O "pgp_keys.asc" ${PGPpubkeyLink}
+#  sudo -u bitcoin gpg --import --import-options show-only ./pgp_keys.asc
+#  fingerprint=$(gpg "pgp_keys.asc" 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
+#  if [ ${fingerprint} -lt 1 ]; then
+#    echo
+#    echo "!!! WARNING --> the PGP fingerprint is not as expected for ${PGPsigner}"
+#    echo "Should contain PGP: ${PGPpubkeyFingerprint}"
+#    echo "PRESS ENTER to TAKE THE RISK if you think all is OK"
+#    read key
+#  fi
+#  sudo -u bitcoin gpg --import ./pgp_keys.asc
+#
+#  sudo -u bitcoin wget https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/SHA256SUMS
+#  sudo -u bitcoin wget https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/SHA256SUMS.asc
+#  
+#  verifyResult=$(sudo -u bitcoin gpg --verify SHA256SUMS.asc 2>&1)
+#
+#  goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
+#  echo "goodSignature(${goodSignature})"
+#  correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${PGPpubkeyFingerprint}" -c)
+#  echo "correctKey(${correctKey})"
+#  if [ ${correctKey} -lt 1 ] || [ ${goodSignature} -lt 1 ]; then
+#    echo
+#    echo "!!! DOWNLOAD FAILED --> PGP verification not OK / signature(${goodSignature}) verify(${correctKey})"
+#    exit 1
+#  else
+#    echo 
+#    echo "****************************************************************"
+#    echo "OK --> the PGP signature of the C-lightning SHA256SUMS is correct"
+#    echo "****************************************************************"
+#    echo 
+#  fi
+#  
+#  sudo -u bitcoin wget https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/clightning-${CLVERSION}.zip
+#  
+#  hashCheckResult=$(sha256sum -c SHA256SUMS 2>&1)
+#  goodHash=$(echo ${hashCheckResult} | grep 'OK' -c)
+#  echo "goodHash(${goodHash})"
+#  if [ ${goodHash} -lt 1 ]; then
+#    echo
+#    echo "!!! BUILD FAILED --> Hash check not OK"
+#    exit 1
+#  else
+#    echo
+#    echo "********************************************************************"
+#    echo "OK --> the hash of the downloaded C-lightning source code is correct"
+#    echo "********************************************************************"
+#    echo
+#  fi
+#  
+#  sudo -u bitcoin unzip clightning-${CLVERSION}.zip
+#  cd clightning-${CLVERSION} || exit 1
 
-  sudo -u bitcoin wget -O "pgp_keys.asc" ${PGPpkeys}
-  sudo -u bitcoin gpg --import --import-options show-only ./pgp_keys.asc
-  fingerprint=$(gpg "pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
-  if [ ${fingerprint} -lt 1 ]; then
-    echo
-    echo "!!! WARNING --> the PGP fingerprint is not as expected for ${PGPsigner}"
-    echo "Should contain PGP: ${PGPcheck}"
-    echo "PRESS ENTER to TAKE THE RISK if you think all is OK"
-    read key
-  fi
-  sudo -u bitcoin gpg --import ./pgp_keys.asc
+  cd /home/bitcoin || exit 1
+  echo
+  echo "- Cloning https://github.com/ElementsProject/lightning.git"
+  echo
+  sudo -u bitcoin git clone https://github.com/ElementsProject/lightning.git
+  cd lightning || exit 1
+  echo
+  echo "- Reset to version $CLVERSION"
+  sudo -u bitcoin git reset --hard $CLVERSION
 
-  sudo -u bitcoin wget https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/SHA256SUMS
-  sudo -u bitcoin wget https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/SHA256SUMS.asc
-  
-  verifyResult=$(sudo -u bitcoin gpg --verify SHA256SUMS.asc 2>&1)
-
-  goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
-  echo "goodSignature(${goodSignature})"
-  correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${PGPcheck}" -c)
-  echo "correctKey(${correctKey})"
-  if [ ${correctKey} -lt 1 ] || [ ${goodSignature} -lt 1 ]; then
-    echo
-    echo "!!! DOWNLOAD FAILED --> PGP verification not OK / signature(${goodSignature}) verify(${correctKey})"
-    exit 1
-  else
-    echo 
-    echo "****************************************************************"
-    echo "OK --> the PGP signature of the C-lightning SHA256SUMS is correct"
-    echo "****************************************************************"
-    echo 
-  fi
-  
-  sudo -u bitcoin wget https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/clightning-${CLVERSION}.zip
-  
-  hashCheckResult=$(sha256sum -c SHA256SUMS 2>&1)
-  goodHash=$(echo ${hashCheckResult} | grep 'OK' -c)
-  echo "goodHash(${goodHash})"
-  if [ ${goodHash} -lt 1 ]; then
-    echo
-    echo "!!! BUILD FAILED --> Hash check not OK"
-    exit 1
-  else
-    echo
-    echo "********************************************************************"
-    echo "OK --> the hash of the downloaded C-lightning source code is correct"
-    echo "********************************************************************"
-    echo
-  fi
-  
-  sudo -u bitcoin unzip clightning-${CLVERSION}.zip
-  cd clightning-${CLVERSION} || exit 1
+  sudo -u bitcoin /home/admin/config.scripts/blitz.git-verify.sh \
+   "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${CLVERSION}" || exit 1
 
   installDependencies
 
@@ -142,7 +156,7 @@ if [ "$1" = "install" ]; then
   fi
   
   correctVersion=$(echo "${installed}" | grep -c "${CLVERSION:1}")
-  if [ ${correctVersion} -eq 0 ]; then
+  if [ "${correctVersion}" -eq 0 ]; then
     echo
     echo "!!! BUILD FAILED --> installed C-lightning is not version ${CLVERSION}"
     sudo -u bitcoin lightning-cli --version


### PR DESCRIPTION
installing from zip causes an error with the pyln-client:
https://github.com/rootzoll/raspiblitz/issues/2662#issue-1034847654
so switched to installation from source from github

left in the well tested code to install from zip, but commented out in case we would use it later