### PR TITLE
use --show-keys for gpg fingerprint listing

### DIFF
--- a/home.admin/config.scripts/blitz.git-verify.sh
+++ b/home.admin/config.scripts/blitz.git-verify.sh
@@ -33,7 +33,7 @@ PGPpubkeyFingerprint="$3"
 
 wget -O /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
 gpg --import --import-options show-only /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc
-fingerprint=$(gpg /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
+fingerprint=$(gpg --show-keys /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
 if [ "${fingerprint}" -lt 1 ]; then
   echo
   echo "# !!! WARNING --> the PGP fingerprint is not as expected for ${PGPsigner}" >&2

--- a/home.admin/config.scripts/bonus.chantools.sh
+++ b/home.admin/config.scripts/bonus.chantools.sh
@@ -66,10 +66,10 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     OSversion="amd64"
   fi
   SHA256=$(grep -i "linux-$OSversion" manifest-v$pinnedVersion.txt | cut -d " " -f1)
-  echo 
+  echo
   echo "# Channel Tools v${pinnedVersion} for ${OSversion}"
   echo "# SHA256 hash: $SHA256"
-  echo 
+  echo
 
   # get binary
   binaryName="chantools-linux-${OSversion}-v${pinnedVersion}.tar.gz"
@@ -85,8 +85,8 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   fi
 
   # check gpg finger print
-  gpg ./pgp_keys.asc
-  fingerprint=$(sudo gpg "${downloadDir}/pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
+  gpg --show-keys ./pgp_keys.asc
+  fingerprint=$(sudo gpg --show-keys "${downloadDir}/pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
   if [ ${fingerprint} -lt 1 ]; then
     echo
     echo "# !!! BUILD WARNING --> Channel Tools PGP author not as expected"

--- a/home.admin/config.scripts/bonus.faraday.sh
+++ b/home.admin/config.scripts/bonus.faraday.sh
@@ -20,7 +20,7 @@ PGPkeys="https://keybase.io/carlakirkcohen/pgp_keys.asc"
 PGPcheck="15E7ECF257098A4EF91655EB4CA7FE54A6213C91"
 
 # 1. parameter [info|verified|reckless]
-mode="$1" 
+mode="$1"
 
 # GATHER DATA
 source /home/admin/raspiblitz.info
@@ -90,7 +90,7 @@ if [ "${mode}" = "on" ] || [ "${mode}" = "1" ]; then
 
   echo "# INSTALL bonus.faraday.sh version: ${version}"
 
-  echo 
+  echo
   echo "# clean & change into download directory"
   sudo rm -r ${downloadDir}/*
   cd "${downloadDir}"
@@ -131,17 +131,17 @@ if [ "${mode}" = "on" ] || [ "${mode}" = "1" ]; then
     exit 1
   fi
 
-  echo 
+  echo
   echo "# getting gpg finger print"
-  gpg ./pgp_keys.asc
-  fingerprint=$(sudo gpg "${downloadDir}/pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
+  gpg --show-keys ./pgp_keys.asc
+  fingerprint=$(sudo gpg --show-keys "${downloadDir}/pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
   if [ ${fingerprint} -lt 1 ]; then
     echo "error='PGP author check failed'"
     exit 1
   fi
   echo "fingerprint='${fingerprint}'"
 
-  echo 
+  echo
   echo "# checking PGP finger print"
   gpg --import ./pgp_keys.asc
   sleep 3
@@ -198,7 +198,7 @@ if [ "${mode}" = "on" ] || [ "${mode}" = "1" ]; then
   sudo /usr/sbin/usermod --append --groups lndsigner faraday
   sudo /usr/sbin/usermod --append --groups lndwalletkit faraday
   sudo /usr/sbin/usermod --append --groups lndrouter faraday
- 
+
   # install service
   echo "*** Install systemd ***"
   echo "
@@ -268,7 +268,7 @@ if [ "${mode}" = "off" ] || [ "${mode}" = "0" ]; then
   /home/admin/config.scripts/blitz.conf.sh set faraday "off"
 
   exit 1
- 
+
 fi
 
 echo "error='parameter not known'"

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -191,8 +191,8 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     fi
 
     echo "# check gpg finger print"
-    gpg --keyid-format LONG ./pgp_keys.asc
-    fingerprint=$(gpg --keyid-format LONG "./pgp_keys.asc" 2>/dev/null \
+    gpg --show-keys --keyid-format LONG ./pgp_keys.asc
+    fingerprint=$(gpg --show-keys --keyid-format LONG "./pgp_keys.asc" 2>/dev/null \
     | grep "${PGPcheck}" -c)
     if [ ${fingerprint} -lt 1 ]; then
       echo ""
@@ -321,7 +321,7 @@ alias lit-frcli=\"frcli --rpcserver=localhost:8443 \
 
   # setting value in raspi blitz config
   /home/admin/config.scripts/blitz.conf.sh set lit "on"
-  
+
   # Hidden Service if Tor is active
   if [ "${runBehindTor}" = "on" ]; then
     # make sure to keep in sync with tor.network.sh script
@@ -333,7 +333,7 @@ alias lit-frcli=\"frcli --rpcserver=localhost:8443 \
     sudo /home/admin/config.scripts/bonus.rtl.sh connect-services
     sudo systemctl restart RTL 2>/dev/null
   fi
-  
+
   source <(/home/admin/_cache.sh get state)
   if [ "${state}" == "ready" ]; then
     echo "# OK - the litd.service is enabled, system is ready so starting service"

--- a/home.admin/config.scripts/bonus.pool.sh
+++ b/home.admin/config.scripts/bonus.pool.sh
@@ -32,7 +32,7 @@ sudo systemctl stop poold 2>/dev/null
 # switch on
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   echo "# installing pool"
-  
+
   echo "# remove LiT to avoid interference with accounts (data is preserved)"
   /home/admin/config.scripts/bonus.lit.sh off
 
@@ -41,7 +41,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
     # create dedicated user
     sudo adduser --disabled-password --gecos "" pool
-    
+
     echo "# persist settings in app-data"
     echo "# make sure the data directory exists"
     sudo mkdir -p /mnt/hdd/app-data/.pool
@@ -49,7 +49,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo rm -rf /home/pool/.pool # not a symlink.. delete it silently
     sudo ln -s /mnt/hdd/app-data/.pool/ /home/pool/.pool
     sudo chown pool:pool -R /mnt/hdd/app-data/.pool
-    
+
     # set PATH for the user
     sudo bash -c "echo 'PATH=$PATH:/home/pool/go/bin/' >> /home/pool/.profile"
 
@@ -77,7 +77,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
       PGPcheck="03DB6322267C373B"
     fi
 
-    echo "Detect CPU architecture ..." 
+    echo "Detect CPU architecture ..."
     isARM=$(uname -m | grep -c 'arm')
     isAARCH64=$(uname -m | grep -c 'aarch64')
     isX86_64=$(uname -m | grep -c 'x86_64')
@@ -99,7 +99,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
       OSversion="arm64"
     elif [ ${isX86_64} -eq 1 ] ; then
       OSversion="amd64"
-    fi 
+    fi
     SHA256=$(grep -i "linux-$OSversion" manifest-${poolVersion}.txt | cut -d " " -f1)
 
     echo
@@ -122,8 +122,8 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     fi
 
     echo "# check gpg finger print"
-    gpg --keyid-format LONG ./pgp_keys.asc
-    fingerprint=$(gpg --keyid-format LONG "./pgp_keys.asc" 2>/dev/null \
+    gpg --show-keys --keyid-format LONG ./pgp_keys.asc
+    fingerprint=$(gpg --show-keys --keyid-format LONG "./pgp_keys.asc" 2>/dev/null \
     | grep "${PGPcheck}" -c)
     if [ ${fingerprint} -lt 1 ]; then
       echo ""
@@ -156,10 +156,10 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     # get Go vars
     # source /etc/profile
     # cd /home/pool
-    # 
+    #
     # sudo -u pool git clone https://github.com/lightninglabs/pool.git || exit 1
     # cd /home/pool/pool
-    # # pin version 
+    # # pin version
     # sudo -u pool git reset --hard $pinnedVersion
     # # install to /home/pool/go/bin/
     # sudo -u pool /usr/local/go/bin/go install ./... || exit 1
@@ -190,7 +190,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
       proxy=""
     fi
 
-    # sudo nano /etc/systemd/system/poold.service 
+    # sudo nano /etc/systemd/system/poold.service
     echo "
 [Unit]
 Description=poold.service
@@ -217,7 +217,7 @@ WantedBy=multi-user.target
     sudo systemctl enable poold
     echo "# OK - the poold.service is now enabled"
 
-  else 
+  else
     echo "the poold.service already installed."
   fi
 
@@ -230,12 +230,12 @@ WantedBy=multi-user.target
   fi
   # setting value in raspi blitz config
   /home/admin/config.scripts/blitz.conf.sh set pool "on"
-  
+
   isInstalled=$(sudo -u pool /usr/local/bin/poold  | grep -c pool)
   if [ ${isInstalled} -gt 0 ]; then
     echo "
 # Usage and examples: https://github.com/lightninglabs/pool
-# Use the command: 'sudo su - pool' 
+# Use the command: 'sudo su - pool'
 # in the terminal to switch to the dedicated user.
 # Type 'pool' again to see the options.
 "
@@ -243,7 +243,7 @@ WantedBy=multi-user.target
     echo "# Failed to install Lightning Pool "
     exit 1
   fi
-  
+
   exit 0
 fi
 
@@ -265,7 +265,7 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     # delete the binary
     sudo rm /usr/local/bin/poold
     echo "# OK, the Pool Service is removed."
-  else 
+  else
     echo "# Pool is not installed."
   fi
 
@@ -284,7 +284,7 @@ fi
 #   UPSTREAM=${1:-'@{u}'}
 #   LOCAL=$(git rev-parse @)
 #   REMOTE=$(git rev-parse "$UPSTREAM")
-#   
+#
 #   if [ $LOCAL = $REMOTE ]; then
 #     TAG=$(git tag | sort -V | tail -1)
 #     echo "# You are up-to-date on version" $TAG
@@ -306,7 +306,7 @@ fi
 #       exit 1
 #     fi
 #   fi
-# 
+#
 #   echo "# At the latest in https://github.com/lightninglabs/pool/releases/"
 #   echo ""
 #   echo "# Starting the poold.service ... *** "

--- a/home.admin/config.scripts/lnd.install.sh
+++ b/home.admin/config.scripts/lnd.install.sh
@@ -40,7 +40,7 @@ if [ "${network}" == "" ]; then
 fi
 
 if [ "$1" = "info" ] ; then
-  
+
   # the version that this script installs by default
   echo "lndDefaultInstallVersion='${lndVersion}'"
 
@@ -91,10 +91,10 @@ if [ "$1" = "install" ] ; then
     echo "lnd binary already installed - done"
     exit 1
   fi
-  
+
   # get LND resources
   cd /home/admin/download || exit 1
-  
+
   # download lnd binary checksum manifest
   sudo -u admin wget -N https://github.com/lightningnetwork/lnd/releases/download/v${lndVersion}/manifest-v${lndVersion}.txt
 
@@ -102,7 +102,7 @@ if [ "$1" = "install" ] ; then
   sudo -u admin wget -N https://github.com/lightningnetwork/lnd/releases/download/v${lndVersion}/manifest-${PGPauthor}-v${lndVersion}.sig
   sudo -u admin wget --no-check-certificate -N -O "pgp_keys.asc" ${PGPpkeys}
   gpg --import --import-options show-only ./pgp_keys.asc
-  fingerprint=$(sudo gpg "pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
+  fingerprint=$(sudo gpg --show-keys "pgp_keys.asc" 2>/dev/null | grep "${PGPcheck}" -c)
   if [ ${fingerprint} -lt 1 ]; then
     echo ""
     echo "!!! BUILD WARNING --> LND PGP author not as expected"
@@ -144,7 +144,7 @@ if [ "$1" = "install" ] ; then
   echo "*** LND v${lndVersion} for ${lndOSversion} ***"
   echo "SHA256 hash: $lndSHA256"
   echo
-  
+
   # get LND binary
   binaryName="lnd-linux-${lndOSversion}-v${lndVersion}.tar.gz"
   if [ ! -f "./${binaryName}" ]; then
@@ -155,7 +155,7 @@ if [ "$1" = "install" ] ; then
   else
     echo "- using existing lnd binary"
   fi
-  
+
   # check binary was not manipulated (checksum test)
   echo "- checksum test"
   binaryChecksum=$(sha256sum ${binaryName} | cut -d " " -f1)
@@ -174,7 +174,7 @@ if [ "$1" = "install" ] ; then
     echo
     sleep 10
   fi
-  
+
   # install
   echo "- install LND binary"
   sudo -u admin tar -xzf ${binaryName}
@@ -186,7 +186,7 @@ if [ "$1" = "install" ] ; then
     echo "!!! BUILD FAILED --> Was not able to install LND"
     exit 1
   fi
-  
+
   correctVersion=$(sudo -u admin lnd --version | grep -c "${lndVersion}")
   if [ ${correctVersion} -eq 0 ]; then
     echo ""
@@ -298,9 +298,9 @@ rpclisten=0.0.0.0:1${rpcportmod}009
 restlisten=0.0.0.0:${portprefix}8080
 nat=false
 debuglevel=debug
-gc-canceled-invoices-on-startup=true 
-gc-canceled-invoices-on-the-fly=true 
-ignore-historical-gossip-filters=1 
+gc-canceled-invoices-on-startup=true
+gc-canceled-invoices-on-the-fly=true
+ignore-historical-gossip-filters=1
 sync-freelist=true
 stagger-initial-reconnect=true
 tlsautorefresh=1
@@ -317,7 +317,7 @@ bitcoin.node=bitcoind
     echo "# The file /home/bitcoin/.lnd/${netprefix}lnd.conf is already present"
   fi
 
-  # systemd service  
+  # systemd service
   removeParallelService
   echo "# Create /etc/systemd/system/.lnd.service"
   # based on https://github.com/lightningnetwork/lnd/blob/master/contrib/init/lnd.service
@@ -374,7 +374,7 @@ PrivateTmp=true
 [Install]
 WantedBy=multi-user.target
 " | sudo tee /etc/systemd/system/${netprefix}lnd.service
-  sudo systemctl enable ${netprefix}lnd 
+  sudo systemctl enable ${netprefix}lnd
   echo "# Enabled the ${netprefix}lnd.service"
   if [ "${state}" == "ready" ]; then
     sudo systemctl start ${netprefix}lnd
@@ -384,18 +384,18 @@ WantedBy=multi-user.target
   echo
   echo "# Add aliases ${netprefix}lncli, ${netprefix}lndlog, ${netprefix}lndconf"
   sudo -u admin touch /home/admin/_aliases
-  if [ $(grep -c "alias ${netprefix}lncli" < /home/admin/_aliases) -eq 0 ];then  
+  if [ $(grep -c "alias ${netprefix}lncli" < /home/admin/_aliases) -eq 0 ];then
     echo "\
 alias ${netprefix}lncli=\"sudo -u bitcoin /usr/local/bin/lncli\
  -n=${CHAIN} --rpcserver localhost:1${rpcportmod}009\"\
 " | sudo tee -a /home/admin/_aliases
   fi
-  if [ $(grep -c "alias ${netprefix}lndlog" < /home/admin/_aliases) -eq 0 ];then 
+  if [ $(grep -c "alias ${netprefix}lndlog" < /home/admin/_aliases) -eq 0 ];then
     echo "\
 alias ${netprefix}lndlog=\"sudo tail -n 30 -f /mnt/hdd/lnd/logs/${network}/${CHAIN}/lnd.log\"\
 " | sudo tee -a /home/admin/_aliases
   fi
-  if [ $(grep -c "alias ${netprefix}lndconf" < /home/admin/_aliases) -eq 0 ];then 
+  if [ $(grep -c "alias ${netprefix}lndconf" < /home/admin/_aliases) -eq 0 ];then
     echo "\
 alias ${netprefix}lndconf=\"sudo nano /home/bitcoin/.lnd/${netprefix}lnd.conf\"\
 " | sudo tee -a /home/admin/_aliases
@@ -405,7 +405,7 @@ alias ${netprefix}lndconf=\"sudo nano /home/bitcoin/.lnd/${netprefix}lnd.conf\"\
   walletExists=$(sudo ls /mnt/hdd/lnd/data/chain/${network}/${CHAIN}/wallet.db 2>/dev/null | grep -c "wallet.db")
   if [ "${initwallet}" == "1" ] && [ "${walletExists}" == "0" ]; then
       # only ask on mainnet for passwordC - for the testnet/signet its default 'raspiblitz'
-      if [ "${CHAIN}" == "mainnet" ]; then      
+      if [ "${CHAIN}" == "mainnet" ]; then
         tempFile="/var/cache/raspiblitz/passwordc.tmp"
         sudo /home/admin/config.scripts/blitz.setpassword.sh x "PASSWORD C - LND Wallet Password" ${tempFile}
         passwordC=$(sudo cat ${tempFile})
@@ -430,7 +430,7 @@ alias ${netprefix}lndconf=\"sudo nano /home/bitcoin/.lnd/${netprefix}lnd.conf\"\
 
   echo
   echo "# The installed LND version is: $(sudo -u bitcoin /usr/local/bin/lnd --version)"
-  echo   
+  echo
   echo "# To activate the aliases reopen the terminal or use:"
   echo "source ~/_aliases"
   echo "# Monitor the ${netprefix}lnd with:"
@@ -457,7 +457,7 @@ alias ${netprefix}lndconf=\"sudo nano /home/bitcoin/.lnd/${netprefix}lnd.conf\"\
 fi
 
 if [ "$1" = "display-seed" ]; then
-  
+
   # check if sudo
   if [ "$EUID" -ne 0 ]; then
     echo "Please run as root (with sudo)"
@@ -520,7 +520,7 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   /home/admin/config.scripts/blitz.conf.sh set ${netprefix}lnd "off"
   echo "# ${netprefix}lnd --> off"
 
-  # if lnd mainnet was default - remove 
+  # if lnd mainnet was default - remove
   if [ "${CHAIN}" == "mainnet" ] && [ "${lightning}" == "lnd" ]; then
     echo "# LND is REMOVED as default lightning implementation"
     /home/admin/config.scripts/blitz.conf.sh set lightning ""

--- a/home.admin/config.scripts/lnd.update.sh
+++ b/home.admin/config.scripts/lnd.update.sh
@@ -17,7 +17,7 @@ fi
 mode="$1"
 
 # RECOMMENDED UPDATE BY RASPIBLITZ TEAM
-# comment will be shown as "BEWARE Info" when option is choosen (can be multiple lines) 
+# comment will be shown as "BEWARE Info" when option is choosen (can be multiple lines)
 lndUpdateVersion="" # example: 0.13.2-beta .. keep empty if no newer version as sd card build is available
 lndUpdateComment="Please keep in mind that downgrading afterwards is not tested. Also not all additional apps are fully tested with the this update - but it looked good on first tests."
 
@@ -27,7 +27,7 @@ PGPauthor="roasbeef"
 lndUpdatePGPpkeys="https://keybase.io/roasbeef/pgp_keys.asc"
 lndUpdatePGPcheck="4AB7F8DA6FAEBB3B70B1F903BC13F65E2DC84465"
 
-# bitconner 
+# bitconner
 # PGPauthor="bitconner"
 # lndUpdatePGPpkeys="https://keybase.io/bitconner/pgp_keys.asc"
 # lndUpdatePGPcheck="9C8D61868A7C492003B2744EE7D737B67FA592C7"
@@ -122,7 +122,7 @@ if [ "${mode}" = "verified" ]; then
 
   # check for optional second parameter: forced update version
   # --> only does the verified update if its the given version
-  # this is needed for recovery/update. 
+  # this is needed for recovery/update.
   fixedUpdateVersion="$2"
   if [ ${#fixedUpdateVersion} -gt 0 ]; then
     echo "# checking for fixed version update: askedFor(${fixedUpdateVersion}) available(${lndUpdateVersion})"
@@ -136,7 +136,7 @@ if [ "${mode}" = "verified" ]; then
     fi
   fi
 
-  echo 
+  echo
   echo "# clean & change into download directory"
   sudo rm -r ${downloadDir}/*
   cd "${downloadDir}" || exit 1
@@ -175,17 +175,17 @@ if [ "${mode}" = "verified" ]; then
     exit 1
   fi
 
-  echo 
+  echo
   echo "# getting gpg finger print"
-  gpg ./pgp_keys.asc
-  fingerprint=$(sudo gpg "${downloadDir}/pgp_keys.asc" 2>/dev/null | grep "${lndUpdatePGPcheck}" -c)
+  gpg --show-keys ./pgp_keys.asc
+  fingerprint=$(sudo gpg --show-keys "${downloadDir}/pgp_keys.asc" 2>/dev/null | grep "${lndUpdatePGPcheck}" -c)
   if [ ${fingerprint} -lt 1 ]; then
     echo "error='PGP author check failed'"
     exit 1
   fi
   echo "fingerprint='${fingerprint}'"
 
-  echo 
+  echo
   echo "# checking PGP finger print"
   gpg --import ./pgp_keys.asc
   sleep 3
@@ -225,11 +225,11 @@ if [ "${mode}" = "reckless" ]; then
       echo "error='no download link'"
       exit 1
     fi
-  
+
     # clean & change into download directory
     sudo rm -r ${downloadDir}/*
     cd "${downloadDir}" || exit 1
-  
+
     # download binary
     echo "# downloading binary"
     binaryName=$(basename "${lndLatestDownload}")
@@ -239,7 +239,7 @@ if [ "${mode}" = "reckless" ]; then
       echo "error='download binary failed'"
       exit 1
     fi
-  
+
     # prepare install
     lndInterimsUpdateNew="reckless"
 


### PR DESCRIPTION
This uses `--show-keys` for the `gpg` command so the warning is gone and `gpg` doesn't have to guess what it has to do.

Sorry for the (automatic) removal of trailing spaces, editor does that automatically.

![image](https://user-images.githubusercontent.com/9399034/153674902-141f0aff-084a-45ef-a087-9fa7fa0bf792.png)

