### PR TITLE
add gzip to all nginx configs; add http2 support for all https nginx configs

### DIFF
--- a/home.admin/assets/nginx/sites-available/btcpay_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_ssl.conf
@@ -1,12 +1,14 @@
 ## btcpay_ssl.conf
 
 server {
-    listen 23001 ssl;
-    listen [::]:23001 ssl;
+    listen 23001 ssl http2;
+    listen [::]:23001 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_btcpay.log;
     error_log /var/log/nginx/error_btcpay.log;

--- a/home.admin/assets/nginx/sites-available/btcpay_tor.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_tor.conf
@@ -4,6 +4,8 @@ server {
     listen localhost:23002;
     server_name _;
 
+    include /etc/nginx/snippets/gzip-params.conf;
+
     access_log /var/log/nginx/access_btcpay.log;
     error_log /var/log/nginx/error_btcpay.log;
 

--- a/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcpay_tor_ssl.conf
@@ -1,11 +1,13 @@
 ## btcpay_tor_ssl.conf
 
 server {
-    listen localhost:23003 ssl;
+    listen localhost:23003 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_btcpay.log;
     error_log /var/log/nginx/error_btcpay.log;

--- a/home.admin/assets/nginx/sites-available/btcrpcexplorer_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcrpcexplorer_ssl.conf
@@ -2,11 +2,13 @@
 
 server {
     listen 3021 ssl;
-    listen [::]:3021 ssl;
+    listen [::]:3021 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;

--- a/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor.conf
+++ b/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor.conf
@@ -4,6 +4,8 @@ server {
     listen localhost:3022;
     server_name _;
 
+    include /etc/nginx/snippets/gzip-params.conf;
+
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;
 

--- a/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/btcrpcexplorer_tor_ssl.conf
@@ -1,11 +1,13 @@
 ## btcrpcexplorer_tor_ssl.conf
 
 server {
-    listen localhost:3023 ssl;
+    listen localhost:3023 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;

--- a/home.admin/assets/nginx/sites-available/joinmarket_webui_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/joinmarket_webui_ssl.conf
@@ -1,12 +1,14 @@
 ## joinmarket_webui_ssl.conf
 
 server {
-    listen 7501 ssl;
-    listen [::]:7501 ssl;
+    listen 7501 ssl http2;
+    listen [::]:7501 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_joinmarket_webui.log;
     error_log /var/log/nginx/error_joinmarket_webui.log;

--- a/home.admin/assets/nginx/sites-available/joinmarket_webui_tor.conf
+++ b/home.admin/assets/nginx/sites-available/joinmarket_webui_tor.conf
@@ -8,8 +8,7 @@ server {
     access_log /var/log/nginx/access_joinmarket_webui.log;
     error_log /var/log/nginx/error_joinmarket_webui.log;
 
-    gzip on;
-    gzip_types application/javascript application/json text/css image/svg+xml;
+    include /etc/nginx/snippets/gzip-params.conf;
 
     root /home/joinmarket/webui/build;
     index index.html;

--- a/home.admin/assets/nginx/sites-available/joinmarket_webui_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/joinmarket_webui_tor_ssl.conf
@@ -1,12 +1,14 @@
 ## joinmarket_webui_tor_ssl.conf
 
 server {
-    listen 7503 ssl;
-    listen [::1]:7503 ssl;
+    listen 7503 ssl http2;
+    listen [::1]:7503 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_joinmarket_webui.log;
     error_log /var/log/nginx/error_joinmarket_webui.log;

--- a/home.admin/assets/nginx/sites-available/lnbits_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/lnbits_ssl.conf
@@ -1,12 +1,14 @@
 ## lnbits_ssl.conf
 
 server {
-    listen 5001 ssl;
-    listen [::]:5001 ssl;
+    listen 5001 ssl http2;
+    listen [::]:5001 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_lnbits.log;
     error_log /var/log/nginx/error_lnbits.log;

--- a/home.admin/assets/nginx/sites-available/lnbits_tor.conf
+++ b/home.admin/assets/nginx/sites-available/lnbits_tor.conf
@@ -4,6 +4,8 @@ server {
     listen localhost:5002;
     server_name _;
 
+    include /etc/nginx/snippets/gzip-params.conf;
+
     access_log /var/log/nginx/access_lnbits.log;
     error_log /var/log/nginx/error_lnbits.log;
 

--- a/home.admin/assets/nginx/sites-available/lnbits_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/lnbits_tor_ssl.conf
@@ -1,11 +1,13 @@
 ## lnbits_tor_ssl.conf
 
 server {
-    listen localhost:5003 ssl;
+    listen localhost:5003 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_lnbits.log;
     error_log /var/log/nginx/error_lnbits.log;

--- a/home.admin/assets/nginx/sites-available/mempool_.conf
+++ b/home.admin/assets/nginx/sites-available/mempool_.conf
@@ -8,4 +8,6 @@ server {
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
     include /etc/nginx/snippets/mempool.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 }

--- a/home.admin/assets/nginx/sites-available/mempool_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/mempool_ssl.conf
@@ -3,11 +3,13 @@
 include /etc/nginx/snippets/mempool-http.conf;
 
 server {
-    listen 4081 ssl;
-    listen [::]:4081 ssl;
+    listen 4081 ssl http2;
+    listen [::]:4081 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
     include /etc/nginx/snippets/mempool.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 }

--- a/home.admin/assets/nginx/sites-available/mempool_tor.conf
+++ b/home.admin/assets/nginx/sites-available/mempool_tor.conf
@@ -7,4 +7,6 @@ server {
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
     include /etc/nginx/snippets/mempool.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 }

--- a/home.admin/assets/nginx/sites-available/mempool_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/mempool_tor_ssl.conf
@@ -1,10 +1,12 @@
 ## mempool_tor_ssl.conf
 
 server {
-    listen localhost:4083 ssl;
+    listen localhost:4083 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
     include /etc/nginx/snippets/mempool.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 }

--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -13,10 +13,7 @@ server {
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
 
-	gzip on;
-	gzip_vary on;
-	gzip_proxied any;
-	gzip_types *;
+	include /etc/nginx/snippets/gzip-params.conf;
 
 
 	# proxy for API

--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -3,10 +3,17 @@
 server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
+	listen 443 ssl http2;
+	listen [::]:443 ssl http2;
 
 	root /var/www/public;
 	index index.html;
 	server_name _;
+
+	ssl_certificate /mnt/hdd/app-data/nginx/tls.cert;
+    ssl_certificate_key /mnt/hdd/app-data/nginx/tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
 
 	# proxy for API
 	location /api/ {

--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -13,6 +13,11 @@ server {
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
 
+	gzip on;
+	gzip_vary on;
+	gzip_proxied any;
+	gzip_types *;
+
 
 	# proxy for API
 	location /api/ {

--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -10,9 +10,8 @@ server {
 	index index.html;
 	server_name _;
 
-	ssl_certificate /mnt/hdd/app-data/nginx/tls.cert;
-    ssl_certificate_key /mnt/hdd/app-data/nginx/tls.key;
-    ssl_protocols TLSv1.2 TLSv1.3;
+    include /etc/nginx/snippets/ssl-params.conf;
+    include /etc/nginx/snippets/ssl-certificate-app-data.conf;
 
 
 	# proxy for API

--- a/home.admin/assets/nginx/sites-available/rtl_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/rtl_ssl.conf
@@ -1,12 +1,14 @@
 ## rtl_ssl.conf
 
 server {
-    listen 3001 ssl;
-    listen [::]:3001 ssl;
+    listen 3001 ssl http2;
+    listen [::]:3001 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_rtl.log;
     error_log /var/log/nginx/error_rtl.log;

--- a/home.admin/assets/nginx/sites-available/rtl_tor.conf
+++ b/home.admin/assets/nginx/sites-available/rtl_tor.conf
@@ -4,6 +4,8 @@ server {
     listen localhost:3002;
     server_name _;
 
+    include /etc/nginx/snippets/gzip-params.conf;
+
     access_log /var/log/nginx/access_rtl.log;
     error_log /var/log/nginx/error_rtl.log;
 

--- a/home.admin/assets/nginx/sites-available/rtl_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/rtl_tor_ssl.conf
@@ -1,11 +1,13 @@
 ## rtl_tor_ssl.conf
 
 server {
-    listen localhost:3003 ssl;
+    listen localhost:3003 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_rtl.log;
     error_log /var/log/nginx/error_rtl.log;

--- a/home.admin/assets/nginx/sites-available/sphinxrelay_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/sphinxrelay_ssl.conf
@@ -1,12 +1,14 @@
 ## lnbits_ssl.conf
 
 server {
-    listen 3301 ssl;
-    listen [::]:3301 ssl;
+    listen 3301 ssl http2;
+    listen [::]:3301 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_sphinxrelay.log;
     error_log /var/log/nginx/error_sphinxrelay.log;

--- a/home.admin/assets/nginx/sites-available/sphinxrelay_tor.conf
+++ b/home.admin/assets/nginx/sites-available/sphinxrelay_tor.conf
@@ -4,6 +4,8 @@ server {
     listen localhost:3302;
     server_name _;
 
+    include /etc/nginx/snippets/gzip-params.conf;
+
     access_log /var/log/nginx/access_sphinxrelay.log;
     error_log /var/log/nginx/error_sphinxrelay.log;
 

--- a/home.admin/assets/nginx/sites-available/sphinxrelay_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/sphinxrelay_tor_ssl.conf
@@ -1,11 +1,13 @@
 ## sphinxrelay_tor_ssl.conf
 
 server {
-    listen localhost:3303 ssl;
+    listen localhost:3303 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_sphinxrelay.log;
     error_log /var/log/nginx/error_sphinxrelay.log;

--- a/home.admin/assets/nginx/sites-available/tallycoin_connect_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/tallycoin_connect_ssl.conf
@@ -1,12 +1,14 @@
 ## tallycoin_connect_ssl.conf
 
 server {
-    listen 8124 ssl;
-    listen [::]:8124 ssl;
+    listen 8124 ssl http2;
+    listen [::]:8124 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_tallycoin_connect.log;
     error_log /var/log/nginx/error_tallycoin_connect.log;

--- a/home.admin/assets/nginx/sites-available/tallycoin_connect_tor.conf
+++ b/home.admin/assets/nginx/sites-available/tallycoin_connect_tor.conf
@@ -5,6 +5,8 @@ server {
     listen [::]:8125;
     server_name _;
 
+    include /etc/nginx/snippets/gzip-params.conf;
+
     access_log /var/log/nginx/access_tallycoin_connect.log;
     error_log /var/log/nginx/error_tallycoin_connect.log;
 

--- a/home.admin/assets/nginx/sites-available/tallycoin_connect_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/tallycoin_connect_tor_ssl.conf
@@ -1,12 +1,14 @@
 ## tallycoin_connect_tor_ssl.conf
 
 server {
-    listen localhost:8126 ssl;
-    listen [::]:8126 ssl;
+    listen localhost:8126 ssl http2;
+    listen [::]:8126 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_tallycoin_connect.log;
     error_log /var/log/nginx/error_tallycoin_connect.log;

--- a/home.admin/assets/nginx/sites-available/thub_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/thub_ssl.conf
@@ -1,12 +1,14 @@
 ## thub_ssl.conf
 
 server {
-    listen 3011 ssl;
-    listen [::]:3011 ssl;
+    listen 3011 ssl http2;
+    listen [::]:3011 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;

--- a/home.admin/assets/nginx/sites-available/thub_tor.conf
+++ b/home.admin/assets/nginx/sites-available/thub_tor.conf
@@ -4,6 +4,8 @@ server {
     listen localhost:3012;
     server_name _;
 
+    include /etc/nginx/snippets/gzip-params.conf;
+
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;
 

--- a/home.admin/assets/nginx/sites-available/thub_tor_ssl.conf
+++ b/home.admin/assets/nginx/sites-available/thub_tor_ssl.conf
@@ -1,11 +1,13 @@
 ## thub_tor_ssl.conf
 
 server {
-    listen localhost:3013 ssl;
+    listen localhost:3013 ssl http2;
     server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data-tor.conf;
+
+    include /etc/nginx/snippets/gzip-params.conf;
 
     access_log /var/log/nginx/access_thub.log;
     error_log /var/log/nginx/error_thub.log;

--- a/home.admin/assets/nginx/snippets/gzip-params.conf
+++ b/home.admin/assets/nginx/snippets/gzip-params.conf
@@ -1,0 +1,6 @@
+# gzip-params.conf
+
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_types *;

--- a/home.admin/config.scripts/tor.network.sh
+++ b/home.admin/config.scripts/tor.network.sh
@@ -112,7 +112,7 @@ case "$1" in
 
     # ACTIVATE APPS OVER TOR
     . /mnt/hdd/raspiblitz.conf 2>/dev/null
-    /home/admin/config.scripts/tor.onion-service.sh web80 80 80
+    /home/admin/config.scripts/tor.onion-service.sh web80 80 80 443 443
     /home/admin/config.scripts/tor.onion-service.sh debuglogs 80 6969
     [ "${BTCRPCexplorer}" = "on" ] && /home/admin/config.scripts/tor.onion-service.sh btc-rpc-explorer 80 3022 443 3023
     [ "${rtlWebinterface}" = "on" ] && /home/admin/config.scripts/tor.onion-service.sh RTL 80 3002 443 3003


### PR DESCRIPTION
This enables http2 support to the HTTPS version of the index page.

Would be a nice addition when accessing the webui / the default index page over HTTPS.

I used the certificate & key from the `app-data/nginx` directory which I don't know if I should use.

No automatic redirect to the HTTPS version was currently set => needs to be discussed if we enable it bc it's a self-signed certificate and could lead to confusion if non-technical users connect to it over local IP.

As always proof image below. Tested on 1.7.2rc2:

![http2](https://user-images.githubusercontent.com/9399034/153727127-eca39c6a-c176-4017-9aaf-d79926904782.png)



EDIT:

I think the other services would also benefit from HTTP2 support. Should I do separate PRs for them or put them all in this one?

EDIT2: 

I also added `gzip` to compress the file sizes. It's not a big win for the index page, but the apps / webui would benefit very much from it.

The red line is the Request with http 1.1 & gzip off, blue http2 with gzip:

![image](https://user-images.githubusercontent.com/9399034/153742973-924e968e-3871-4dac-ae84-a42866c198a3.png)

