### PR TITLE
chantools update to v0.10.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - Update: Balance of Satoshis 11.50.0 (BOS) [details](https://github.com/alexbosworth/balanceofsatoshis/blob/master/CHANGELOG.md#11500)
 - Update: Re-Add connecting node with Zap mobile wallet iOS & Android
 - Update: additional redaction of private data in debug logs
+- Update: Channel Tools (chantools) v0.10.4 [details](https://github.com/guggero/chantools/releases/tag/v0.10.4)
 - Security: Verify git commits and tags everywhere possible [issue](https://github.com/rootzoll/raspiblitz/issues/2686)
 - Fixed: LND repair options, SEED+SCB and rescue-file restore, RESET options [issue](https://github.com/rootzoll/raspiblitz/issues/2832)
 - Info: All existing IP2Tor subscriptions need to be canceled & renewed to be functional again.

--- a/home.admin/config.scripts/bonus.chantools.sh
+++ b/home.admin/config.scripts/bonus.chantools.sh
@@ -6,7 +6,7 @@
 
 lndVersion=$(lncli -v | cut -d " " -f 3 | cut -d"." -f2)
 if [ $lndVersion -eq 14 ]; then
-  pinnedVersion="0.10.1"
+  pinnedVersion="0.10.4"
 else
   echo "# LND not installed or a version not tested with chantools"
   lncli -v


### PR DESCRIPTION
Bumps the version of `chantools` to v0.10.4 to fix a bug in the key derivation that lead to keys sometimes (with a chance of 1:256) not matching `lnd`'s keys.

Unfortunately I cannot test the install and signature verification of the latest version, as I don't have a RaspiBlitz running at the moment. But I didn't change anything with respect to PGP keys or how the signature is created, so everything should still work the same as in `v0.10.1`.