### PR TITLE
Update FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -216,7 +216,7 @@ But first you need to make sure that the public server you are using is supporti
 ```
 RSAAuthentication yes
 PubkeyAuthentication yes
-GatewayPorts yes
+GatewayPorts clientspecified
 AllowTcpForwarding yes
 ClientAliveInterval 60
 ClientAliveCountMax 2
@@ -249,7 +249,7 @@ Make sure the `/etc/ssh/sshd_config` has the following lines at the end:
 ```
 RSAAuthentication yes
 PubkeyAuthentication yes
-GatewayPorts yes
+GatewayPorts clientspecified
 AllowTcpForwarding yes
 AuthorizedKeysFile  /etc/ssh/authorized_keys/%u
 ```


### PR DESCRIPTION
I found out that setting `GatewayPorts` to `yes` will prevent a client to bind only to `localhost`. Setting `clientspecified` will allow the autossh client to chose whether to bind to localhost or all interfaces. 

If the server is set to `clientspecified` then to bind to `0.0.0.0` our autossh-tunnel scripts must additionally set `*:` for each forwarding.

e.g. change this `-R 9735:localhost:9735 -R 10009:localhost:10009` into `-R *:9735:localhost:9735 -R *:10009:localhost:10009`.

This PR **does not yet include** changes to our autossh-tunnel scripts.

References:
https://serverfault.com/a/982387/301290
https://www.ssh.com/academy/ssh/tunneling/example 
https://serverfault.com/questions/526782/ssh-reverse-port-forward-bind-to-address#comment1430019_907640
