### PR TITLE
Fix missing brace in UPS section

### DIFF
--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -64,7 +64,7 @@ upsInfo=""
 if [ "${system_ups_status}" = "ONLINE" ]; then
   upsInfo="${color_gray}${upsBattery}"
 fi
-if [ "$system_ups_status}" = "ONBATT" ]; then
+if [ "${system_ups_status}" = "ONBATT" ]; then
   upsInfo="${color_red}${upsBattery}"
 fi
 if [ "${system_ups_status}" = "SHUTTING DOWN" ]; then


### PR DESCRIPTION
Add a missing curly brace which potentially affected `00infoBlitz.sh` script result.