### PR TITLE
Fix passing UPS battery info between scripts

### DIFF
--- a/home.admin/00infoBlitz.sh
+++ b/home.admin/00infoBlitz.sh
@@ -17,6 +17,7 @@ source <(/home/admin/_cache.sh get \
   system_ram_available_mb \
   system_ram_mb \
   system_ups_status \
+  system_ups_battery \
   system_cpu_load \
   system_temp_celsius \
   system_temp_fahrenheit \
@@ -62,10 +63,10 @@ fi
 ## get UPS info
 upsInfo=""
 if [ "${system_ups_status}" = "ONLINE" ]; then
-  upsInfo="${color_gray}${upsBattery}"
+  upsInfo="${color_gray}${system_ups_battery}"
 fi
 if [ "${system_ups_status}" = "ONBATT" ]; then
-  upsInfo="${color_red}${upsBattery}"
+  upsInfo="${color_red}${system_ups_battery}"
 fi
 if [ "${system_ups_status}" = "SHUTTING DOWN" ]; then
   upsInfo="${color_red}DOWN"

--- a/home.admin/_background.scan.sh
+++ b/home.admin/_background.scan.sh
@@ -193,6 +193,7 @@ do
     echo "updating: /home/admin/config.scripts/blitz.ups.sh status"
     source <(/home/admin/config.scripts/blitz.ups.sh status)
     /home/admin/_cache.sh set system_ups_status "${upsStatus}"
+    /home/admin/_cache.sh set system_ups_battery "${upsBattery}"
   fi
 
   #################


### PR DESCRIPTION
The background scan sourced the value of `$upsBattery` from the result of `blitz.ups.sh status` but didn't pass it further to the cache (from which the `00infoBlitz.sh` could look up the value).
Attached commit fixes this and enables proper display of voltage/capacity on the status screen.