### PR TITLE
Fix for Installation failure: Permission denied

### DIFF
--- a/home.admin/config.scripts/blitz.git-verify.sh
+++ b/home.admin/config.scripts/blitz.git-verify.sh
@@ -32,8 +32,8 @@ PGPpubkeyFingerprint="$3"
 
 
 wget -O /dev/shm/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
-gpg --import --import-options show-only /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc
-fingerprint=$(gpg --show-keys /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
+gpg --import --import-options show-only /dev/shm/pgp_keys_${PGPsigner}.asc
+fingerprint=$(gpg --show-keys /dev/shm/pgp_keys_${PGPsigner}.asc 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
 if [ "${fingerprint}" -lt 1 ]; then
   echo
   echo "# !!! WARNING --> the PGP fingerprint is not as expected for ${PGPsigner}" >&2
@@ -41,8 +41,8 @@ if [ "${fingerprint}" -lt 1 ]; then
   echo "# Exiting" >&2
   exit 7
 fi
-gpg --import /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc
-rm /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc
+gpg --import /dev/shm/pgp_keys_${PGPsigner}.asc
+rm /dev/shm/pgp_keys_${PGPsigner}.asc
 
 trap 'rm -f "$_temp"' EXIT
 _temp="$(mktemp -p /dev/shm/)"

--- a/home.admin/config.scripts/blitz.git-verify.sh
+++ b/home.admin/config.scripts/blitz.git-verify.sh
@@ -31,7 +31,7 @@ PGPpubkeyLink="$2"
 PGPpubkeyFingerprint="$3"
 
 
-wget -O /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
+wget -O /dev/shm/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
 gpg --import --import-options show-only /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc
 fingerprint=$(gpg --show-keys /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
 if [ "${fingerprint}" -lt 1 ]; then

--- a/home.admin/config.scripts/blitz.git-verify.sh
+++ b/home.admin/config.scripts/blitz.git-verify.sh
@@ -31,7 +31,7 @@ PGPpubkeyLink="$2"
 PGPpubkeyFingerprint="$3"
 
 
-wget -O /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
+sudo -u bitcoin wget -O /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
 gpg --import --import-options show-only /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc
 fingerprint=$(gpg --show-keys /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
 if [ "${fingerprint}" -lt 1 ]; then

--- a/home.admin/config.scripts/blitz.git-verify.sh
+++ b/home.admin/config.scripts/blitz.git-verify.sh
@@ -31,7 +31,7 @@ PGPpubkeyLink="$2"
 PGPpubkeyFingerprint="$3"
 
 
-sudo -u bitcoin wget -O /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
+wget -O /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc "${PGPpubkeyLink}"
 gpg --import --import-options show-only /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc
 fingerprint=$(gpg --show-keys /var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc 2>/dev/null | grep "${PGPpubkeyFingerprint}" -c)
 if [ "${fingerprint}" -lt 1 ]; then

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -149,7 +149,7 @@ if [ "$1" = "install" ]; then
   echo "- Reset to version $CLVERSION"
   sudo -u bitcoin git reset --hard $CLVERSION
 
-  sudo -u admin /home/admin/config.scripts/blitz.git-verify.sh \
+  sudo -u bitcoin /home/admin/config.scripts/blitz.git-verify.sh \
    "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${CLVERSION}" || exit 1
 
   installDependencies

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -149,7 +149,7 @@ if [ "$1" = "install" ]; then
   echo "- Reset to version $CLVERSION"
   sudo -u bitcoin git reset --hard $CLVERSION
 
-  sudo -u bitcoin /home/admin/config.scripts/blitz.git-verify.sh \
+  sudo -u admin /home/admin/config.scripts/blitz.git-verify.sh \
    "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${CLVERSION}" || exit 1
 
   installDependencies


### PR DESCRIPTION
Trying to install currently results in:

```
#8 444.0 # *** INSTALL C-LIGHTNING v0.10.2 BINARY ***
#8 444.0 # only binary install to system
#8 444.0 # no configuration, no systemd service
#8 444.0
#8 444.0 - Cloning https://github.com/ElementsProject/lightning.git
#8 444.0
#8 444.1 Cloning into 'lightning'...
#8 455.5
#8 455.5 - Reset to version v0.10.2
#8 455.8 HEAD is now at 12689674c doc: Update CHANGELOG.md for v0.10.2 release
#8 455.8 /var/cache/raspiblitz/pgp_keys_cdecker.asc: Permission denied
#8 455.8 gpg: directory '/home/bitcoin/.gnupg' created
#8 455.8 gpg: keybox '/home/bitcoin/.gnupg/pubring.kbx' created
#8 455.8 gpg: can't open '/var/cache/raspiblitz/pgp_keys_cdecker.asc': No such file or directory
#8 455.8
#8 455.8 # !!! WARNING --> the PGP fingerprint is not as expected for cdecker
#8 455.8 # Should contain PGP: A26D6D9FE088ED58
#8 455.8 # Exiting
```

I believe this is because the wget isn't running as the bitcoin user as it did before in cl.install.sh (now commented out)