### PR TITLE
Add support for X708 UPS HAT

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -813,9 +813,11 @@ To change back to the code:
 
 A UPS (Uninterruptible Power Supply) is used to protect the RaspiBlitz against power outages. Normally you put it just between your normal power outlet and your RaspiBlitz and you are set. But some UPS offer a way to communicate with devices. This can be very useful for example if on a longer power outage the battery of the UPS runs low the RaspiBlitz could detect this and power down in a clean way - instead of a sudden stop that risks data loss or corruption.
 
-There is an experimental script to connect the RaspiBlitz to a UPS over USB cable build by APC - the Model tested with was [APC Back-UPS BX - BX700U-GR](https://www.amazon.de/APC-Back-UPS-Unterbrechungsfreie-Stromversorgung-BX700U-GR/dp/B00T7BYRCK) but it should work with every APC model offering a USB port.
-
+ - There is an experimental script to connect the RaspiBlitz to a UPS over USB cable build by APC - the Model tested with was [APC Back-UPS BX - BX700U-GR](https://www.amazon.de/APC-Back-UPS-Unterbrechungsfreie-Stromversorgung-BX700U-GR/dp/B00T7BYRCK) but it should work with every APC model offering a USB port. \
 To turn it on run from terminal: `/home/admin/config.scripts/blitz.ups.sh on apcusb`
+
+- There is also a script dealing with Geekworm/Suptronics [X708 UPS HAT](https://www.amazon.com/Geekworm-Raspberry-Management-Detection-Shutdown/dp/B08DNRYM4Y/). The tested model was x708v1.2. \
+To turn it on run from terminal: `/home/admin/config.scripts/blitz.ups.sh on x708`
 
 If you have other UPS models or ways to connect ... feel free to extend this script.
 


### PR DESCRIPTION
This adds a possibility to install X708 scripts with `blitz.ups.sh on x708`.

Succesfully tested the code on the `dev` branch with Raspberry Pi 4B+ and  X708 v1.2 UPS HAT.

- [x] The [`blitz.shutdown.sh`](https://github.com/rootzoll/raspiblitz/blob/v1.7/home.admin/config.scripts/blitz.shutdown.sh) is executed before cutting off the power to the Raspberry Pi

- [x] The I2C is being enabled to allow getting data from the on-board battery management chip. I haven't found any issues as referenced by #1058 

- [x] The battery voltage and AC state are correctly fetched by [`_background.scan.sh`](https://github.com/rootzoll/raspiblitz/blob/v1.7/home.admin/_background.scan.sh) and later displayed on the status window

- [x] Still, I'd like to know if it's alright to link to my repo for downloading the scripts or maybe it would be better to pack them and put somewhere along with other RaspiBlitz code.
