### PR TITLE
fix electrs is ready for btc-rpc-explorer prestart

### DIFF
--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -137,8 +137,9 @@ if [ "$1" = "prestart" ]; then
   if [ "${ElectRS}" == "on" ]; then
 
     # CHECK THAT ELECTRS INDEX IS BUILD (WAITLOOP)
-    # electrs listening in port 50001 means index is build
-    isElectrumReady=$(netstat -n | grep -c "50001")
+    # electrs listening in port 50001 means index is build 
+    # Use flags: t = tcp protocol only  /  a = list all connection states (includes LISTEN)  /  n = don't resolve names => no dns spam
+    isElectrumReady=$(netstat -tan | grep -c "50001")
     if [ "${isElectrumReady}" == "0" ]; then
       echo "# electrs is ON but not ready .. might still building index - kick systemd service into fail/wait/restart"
       exit 1


### PR DESCRIPTION
After reboot btc-rpc-explorer service gets trapped in a reboot loop as the check if elelctrs is running and ready always fails.
`netstat -n` does not show connections in LISTEN state.  
`netstat -tan` shows all tcp connections `-t` in all states `-a` without resolving names `-n` to prvent dns spam