### PR TITLE
Use special bonus script to show connection details for Alby

### DIFF
--- a/home.admin/99connectMenu.sh
+++ b/home.admin/99connectMenu.sh
@@ -70,18 +70,7 @@ case $CHOICE in
     exit 0;;
 
   ALBY)
-      websiteLink="https://getalby.com"
-      sudo /home/admin/config.scripts/blitz.display.sh image /home/admin/raspiblitz/pictures/app_alby.png
-    whiptail --title "Install Alby on your web browser" \
-    --yes-button "Continue" \
-    --no-button "Website" \
-    --yesno "Visit the website and install the browser extension then click --> Continue." 12 65
-    if [ $? -eq 1 ]; then
-    whiptail --title " Website Link " --msgbox "\
-To install app open the following link:\n
-${websiteLink}\n" 11 70
-    fi
-    /home/admin/config.scripts/bonus.lndconnect.sh alby tor
+    /home/admin/config.scripts/bonus.alby.sh
     exit 0;
   ;;
 

--- a/home.admin/config.scripts/bonus.alby.sh
+++ b/home.admin/config.scripts/bonus.alby.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# https://github.com/getAlby/lightning-browser-extension
+
+# command info
+echo "config script to connect to Alby - The Bitcoin Lightning App for your Browser"
+
+
+# 1. TOR or IP (optional - default IP)
+forceTOR=0
+if [ "$1" == "tor" ]; then
+  forceTOR=1
+fi
+
+# check and load raspiblitz config
+# to know which network is running
+source /home/admin/raspiblitz.info
+source /mnt/hdd/raspiblitz.conf
+
+# generate data parts
+hex_macaroon=$(sudo xxd -plain /home/bitcoin/.lnd/data/chain/${network}/${chain}net/admin.macaroon | tr -d '\n')
+cert=$(sudo grep -v 'CERTIFICATE' /mnt/hdd/lnd/tls.cert | tr -d '=' | tr '/+' '_-' | tr -d '\n')
+
+#### ADAPT PARAMETERS BASED RASPIBLITZ CONFIG
+
+# get the local IP as default host
+if [ ${#host} -eq 0 ]; then
+    host=$(hostname -I | awk '{print $1}')
+fi
+
+# change host to dynDNS if set
+if [ ${#dynDomain} -gt 0 ]; then
+  host="${dynDomain}"
+fi
+
+tor_host=$(sudo cat /mnt/hdd/tor/lndrest/hostname)
+# tunnel thru TOR if running and supported by the wallet
+if [ ${forceTOR} -eq 1 ]; then
+  host=$tor_host
+  if [ "${host}" == "" ]; then
+    echo "# setting up onion service ..."
+    /home/admin/config.scripts/tor.onion-service.sh lndrest 8080 8080
+    host=$(sudo cat /mnt/hdd/tor/lndrest/hostname)
+  fi
+fi
+
+# tunnel thru SSH-Reverse-Tunnel if activated for that port
+if [ ${#sshtunnel} -gt 0 ]; then
+  isForwarded=$(echo ${sshtunnel} | grep -c "${port}<")
+  if [ ${isForwarded} -gt 0 ]; then
+    if [ "${port}" == "10009" ]; then
+      host=$(echo $sshtunnel | cut -d '@' -f2 | cut -d ' ' -f1 | cut -d ':' -f1)
+      port=$(echo $sshtunnel | awk '{split($0,a,"10009<"); print a[2]}' | cut -d ' ' -f1 | sed 's/[^0-9]//g')
+      echo "# using ssh-tunnel --> host ${host} port ${port}"
+    elif [ "${port}" == "8080" ]; then
+      host=$(echo $sshtunnel | cut -d '@' -f2 | cut -d ' ' -f1 | cut -d ':' -f1)
+      port=$(echo $sshtunnel | awk '{split($0,a,"8080<"); print a[2]}' | cut -d ' ' -f1 | sed 's/[^0-9]//g')
+      echo "# using ssh-tunnel --> host ${host} port ${port}"
+    fi
+  fi
+fi
+
+echo
+whiptail --title " Alby - The Lightning App for your Browser" --msgbox "Visit https://getAlby.com and install Alby for your browser.
+
+Then open Alby and add a new lightning account.
+
+Select RaspiBlitz.
+
+Your RaspiBlitz connection details for Alby will be shown on the next screen.
+
+" 16 67
+
+clear
+
+echo "---------------------------------------------------"
+echo "Use the following connection details in Alby:"
+echo ""
+echo "# REST API host:"
+echo "https://${host}:8080"
+if [ $(echo "${host}" | grep -c '192.168') -gt 0 ]; then
+  echo "# Make sure you are on the same local network (WLAN same as LAN - use WIFI not cell network on phone)."
+fi
+if [ ${#usingIP2TOR} -gt 0 ] && [ ${forceTOR} -eq 0 ]; then
+  echo "Your IP2TOR bridge '${usingIP2TOR}' is used for this connection."
+fi
+if [ "${host}" != "${tor_host}" ]; then
+  if [ "${tor_host}" != "" ]; then
+    echo "# Alternatively you can also connect through Tor:"
+    echo "https://${tor_host}:8080"
+  fi
+fi
+
+echo ""
+echo "# Macaroon (HEX format)"
+echo "${hex_macaroon}"
+echo "# Note: these are your admin credentials"
+
+
+echo ""
+echo "Press ENTER to return to main menu."
+read key
+clear

--- a/home.admin/config.scripts/bonus.lndconnect.sh
+++ b/home.admin/config.scripts/bonus.lndconnect.sh
@@ -4,7 +4,7 @@
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
  echo "# config script to connect mobile apps with lnd connect"
  echo "# will autodetect dyndns, sshtunnel or TOR"
- echo "# bonus.lndconnect.sh [zap-ios|zap-android|zeus-ios|zeus-android|shango-ios|shango-android|sendmany-android|fullynoded-lnd|alby] [?ip|tor] [?key-value]"
+ echo "# bonus.lndconnect.sh [zap-ios|zap-android|zeus-ios|zeus-android|shango-ios|shango-android|sendmany-android|fullynoded-lnd] [?ip|tor] [?key-value]"
  exit 1
 fi
 
@@ -107,14 +107,6 @@ elif [ "${targetWallet}" = "zeus-android" ]; then
     forceTOR=1
     host=$(sudo cat /mnt/hdd/tor/lndrest8080/hostname)
     connectInfo="- start the Zeus Wallet --> lndconnect\n- scan the QR code \n- activate 'Tor' option \n- activate 'Certification Verification' option\n- save Node Config"
-
-elif [ "${targetWallet}" = "alby" ]; then
-
-    port="8080"
-    usingIP2TOR="LND-REST-API"
-    forceTOR=1
-    host=$(sudo cat /mnt/hdd/tor/lndrest8080/hostname)
-    connectInfo="- open Alby --> enter password \n- select RaspiBlitz from connectors \n- enter lndconnect URL \n- Continue \n- Alby companion app required for Tor"
 
 elif [ "${targetWallet}" = "sendmany-android" ]; then
 


### PR DESCRIPTION
This PR builds on #3031

[Alby](https://getalby.com/) is a lightning app for desktop browsers and thus it is not possible for users to scan a lndconnect QR code. PR 3031 reused the current bonus.lndconnect.sh script which displays a QR code. This is not really usable for Alby. 
This new bonus.alby.sh script prints Alby connection details that can be copied and pasted into Alby.


Note: this is the first time I am writing some RaspiBlitz code, I am not sure how correct this is. 
I've tried to test the script by c&p it to my running node. 