### PR TITLE
blitzapi: wait 60 sec for restart

### DIFF
--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -91,6 +91,7 @@ Type=simple
 Restart=always
 StandardOutput=journal
 StandardError=journal
+RestartSec=60
 
 # Hardening measures
 PrivateTmp=true


### PR DESCRIPTION
Running a testnet node the blitzapi restarts continuously causing high load.
Slowing it down down to restart only after 60 seconds.
related: https://github.com/rootzoll/raspiblitz/issues/3137


The error  (caused by the CLN is not yet implemented):
```
May 25 18:33:32 raspberrypi systemd[1]: Started BlitzBackendAPI.
May 25 18:33:34 raspberrypi python[1159428]: Traceback (most recent call last):
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
May 25 18:33:34 raspberrypi python[1159428]:     return _run_code(code, main_globals, None,
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
May 25 18:33:34 raspberrypi python[1159428]:     exec(code, run_globals)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/uvicorn/__main__.py", line 4, in <module>
May 25 18:33:34 raspberrypi python[1159428]:     uvicorn.main()
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1128, in __call__
May 25 18:33:34 raspberrypi python[1159428]:     return self.main(*args, **kwargs)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1053, in main
May 25 18:33:34 raspberrypi python[1159428]:     rv = self.invoke(ctx)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 1395, in invoke
May 25 18:33:34 raspberrypi python[1159428]:     return ctx.invoke(self.callback, **ctx.params)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/click/core.py", line 754, in invoke
May 25 18:33:34 raspberrypi python[1159428]:     return __callback(*args, **kwargs)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/uvicorn/main.py", line 425, in main
May 25 18:33:34 raspberrypi python[1159428]:     run(app, **kwargs)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/uvicorn/main.py", line 447, in run
May 25 18:33:34 raspberrypi python[1159428]:     server.run()
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/uvicorn/server.py", line 68, in run
May 25 18:33:34 raspberrypi python[1159428]:     return asyncio.run(self.serve(sockets=sockets))
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
May 25 18:33:34 raspberrypi python[1159428]:     return loop.run_until_complete(main)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
May 25 18:33:34 raspberrypi python[1159428]:     return future.result()
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/uvicorn/server.py", line 76, in serve
May 25 18:33:34 raspberrypi python[1159428]:     config.load()
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/uvicorn/config.py", line 448, in load
May 25 18:33:34 raspberrypi python[1159428]:     self.loaded_app = import_from_string(self.app)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/local/lib/python3.9/dist-packages/uvicorn/importer.py", line 21, in import_from_string
May 25 18:33:34 raspberrypi python[1159428]:     module = importlib.import_module(module_str)
May 25 18:33:34 raspberrypi python[1159428]:   File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
May 25 18:33:34 raspberrypi python[1159428]:     return _bootstrap._gcd_import(name[level:], package, level)
May 25 18:33:34 raspberrypi python[1159428]:   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
May 25 18:33:34 raspberrypi python[1159428]:   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
May 25 18:33:34 raspberrypi python[1159428]:   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
May 25 18:33:34 raspberrypi python[1159428]:   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
May 25 18:33:34 raspberrypi python[1159428]:   File "<frozen importlib._bootstrap_external>", line 790, in exec_module
May 25 18:33:34 raspberrypi python[1159428]:   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
May 25 18:33:34 raspberrypi python[1159428]:   File "./app/main.py", line 27, in <module>
May 25 18:33:34 raspberrypi python[1159428]:     from app.repositories.bitcoin import (
May 25 18:33:34 raspberrypi python[1159428]:   File "./app/repositories/bitcoin.py", line 19, in <module>
May 25 18:33:34 raspberrypi python[1159428]:     from app.utils import SSE, bitcoin_config, bitcoin_rpc_async, send_sse_message
May 25 18:33:34 raspberrypi python[1159428]:   File "./app/utils.py", line 93, in <module>
May 25 18:33:34 raspberrypi python[1159428]:     lightning_config = LightningConfig()
May 25 18:33:34 raspberrypi python[1159428]:   File "./app/utils.py", line 84, in __init__
May 25 18:33:34 raspberrypi python[1159428]:     raise NameError(
May 25 18:33:34 raspberrypi python[1159428]: NameError: Node type "cl" is unknown. Use "lnd" or "clightning"
May 25 18:33:35 raspberrypi systemd[1]: blitzapi.service: Main process exited, code=exited, status=1/FAILURE
May 25 18:33:35 raspberrypi systemd[1]: blitzapi.service: Failed with result 'exit-code'.
May 25 18:33:35 raspberrypi systemd[1]: blitzapi.service: Consumed 2.351s CPU time.
```