### PR TITLE
set LANG=en_US.utf8 when using grep 'Good signature'

### DIFF
--- a/home.admin/config.scripts/bitcoin.install.sh
+++ b/home.admin/config.scripts/bitcoin.install.sh
@@ -38,7 +38,7 @@ if [ "$1" = "install" ]; then
   
   # download signed binary sha256 hash sum file and check
   sudo -u admin wget https://bitcoincore.org/bin/bitcoin-core-${bitcoinVersion}/SHA256SUMS.asc
-  verifyResult=$(gpg --verify SHA256SUMS.asc 2>&1)
+  verifyResult=$(LANG=en_US.utf8; gpg --verify SHA256SUMS.asc 2>&1)
   goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
   echo "goodSignature(${goodSignature})"
   correctKey=$(echo ${verifyResult} | grep "${laanwjPGP}" -c)

--- a/home.admin/config.scripts/bitcoin.update.sh
+++ b/home.admin/config.scripts/bitcoin.update.sh
@@ -177,7 +177,7 @@ if [ "${mode}" = "tested" ]||[ "${mode}" = "reckless" ]||[ "${mode}" = "custom" 
     exit 1
   fi
   
-  verifyResult=$(gpg --verify SHA256SUMS.asc 2>&1)
+  verifyResult=$(LANG=en_US.utf8; gpg --verify SHA256SUMS.asc 2>&1)
   goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
   echo "goodSignature(${goodSignature})"
   correctKey=$(echo ${verifyResult} | grep "${customKey}" -c)

--- a/home.admin/config.scripts/bonus.chantools.sh
+++ b/home.admin/config.scripts/bonus.chantools.sh
@@ -99,7 +99,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   sudo -u admin wget -N https://github.com/guggero/chantools/releases/download/v${pinnedVersion}/manifest-v${pinnedVersion}.sig
 
   echo "# running: gpg --verify manifest-v${pinnedVersion}.sig manifest-v${pinnedVersion}.txt"
-  verifyResult=$(gpg --verify manifest-v${pinnedVersion}.sig manifest-v${pinnedVersion}.txt 2>&1)
+  verifyResult=$(LANG=en_US.utf8; gpg --verify manifest-v${pinnedVersion}.sig manifest-v${pinnedVersion}.txt 2>&1)
   echo "# verifyResult(${verifyResult})"
   goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
   echo "# goodSignature(${goodSignature})"

--- a/home.admin/config.scripts/bonus.faraday.sh
+++ b/home.admin/config.scripts/bonus.faraday.sh
@@ -145,7 +145,7 @@ if [ "${mode}" = "on" ] || [ "${mode}" = "1" ]; then
   echo "# checking PGP finger print"
   gpg --import ./pgp_keys.asc
   sleep 3
-  verifyResult=$(gpg --verify manifest-v${version}.txt.sig 2>&1)
+  verifyResult=$(LANG=en_US.utf8; gpg --verify manifest-v${version}.txt.sig 2>&1)
   goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
   echo "goodSignature='${goodSignature}'"
   correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${PGPcheck}" -c)

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -203,7 +203,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     fi
     gpg --import ./pgp_keys.asc
     sleep 3
-    verifyResult=$(gpg --verify manifest-v${LITVERSION}.sig manifest-v${LITVERSION}.txt 2>&1)
+    verifyResult=$(LANG=en_US.utf8; gpg --verify manifest-v${LITVERSION}.sig manifest-v${LITVERSION}.txt 2>&1)
     goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
     echo "goodSignature(${goodSignature})"
     correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${GPGcheck}" -c)

--- a/home.admin/config.scripts/bonus.lndmanage.sh
+++ b/home.admin/config.scripts/bonus.lndmanage.sh
@@ -52,7 +52,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   echo "# checking signing keys ..."
   gpg --import sigingkey.gpg
-  verifyResult=$(gpg --verify lndmanage-${lndmanageVersion}-py3-none-any.whl.asc 2>&1)
+  verifyResult=$(LANG=en_US.utf8; gpg --verify lndmanage-${lndmanageVersion}-py3-none-any.whl.asc 2>&1)
   goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
   correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${gpgFingerprint}" -c)
   echo "goodSignature='${goodSignature}'"

--- a/home.admin/config.scripts/bonus.pool.sh
+++ b/home.admin/config.scripts/bonus.pool.sh
@@ -134,7 +134,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     fi
     gpg --import ./pgp_keys.asc
     sleep 3
-    verifyResult=$(gpg --verify manifest-${poolVersion}.txt.sig manifest-${poolVersion}.txt 2>&1)
+    verifyResult=$(LANG=en_US.utf8; gpg --verify manifest-${poolVersion}.txt.sig manifest-${poolVersion}.txt 2>&1)
     goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
     echo "goodSignature(${goodSignature})"
     correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${GPGcheck}" -c)

--- a/home.admin/config.scripts/lnd.install.sh
+++ b/home.admin/config.scripts/lnd.install.sh
@@ -112,7 +112,7 @@ if [ "$1" = "install" ] ; then
   fi
   gpg --import ./pgp_keys.asc
   sleep 3
-  verifyResult=$(gpg --verify manifest-${PGPauthor}-v${lndVersion}.sig manifest-v${lndVersion}.txt 2>&1)
+  verifyResult=$(LANG=en_US.utf8; gpg --verify manifest-${PGPauthor}-v${lndVersion}.sig manifest-v${lndVersion}.txt 2>&1)
   goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
   echo "goodSignature(${goodSignature})"
   correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${PGPcheck}" -c)

--- a/home.admin/config.scripts/lnd.update.sh
+++ b/home.admin/config.scripts/lnd.update.sh
@@ -189,7 +189,7 @@ if [ "${mode}" = "verified" ]; then
   echo "# checking PGP finger print"
   gpg --import ./pgp_keys.asc
   sleep 3
-  verifyResult=$(gpg --verify manifest-${PGPauthor}-v${lndUpdateVersion}.sig manifest-v${lndUpdateVersion}.txt 2>&1)
+  verifyResult=$(LANG=en_US.utf8; gpg --verify manifest-${PGPauthor}-v${lndUpdateVersion}.sig manifest-v${lndUpdateVersion}.txt 2>&1)
   goodSignature=$(echo ${verifyResult} | grep 'Good signature' -c)
   echo "goodSignature='${goodSignature}'"
   correctKey=$(echo ${verifyResult} | tr -d " \t\n\r" | grep "${lndUpdatePGPcheck}" -c)


### PR DESCRIPTION
avoid the edge cases when `grep 'Good signature'` fails in non-English environments

Related discussion: https://github.com/bitcoin/bitcoin/issues/25395#issuecomment-1163594630