### PR TITLE
stackingsats: allow more than one config, also complementing a base config

### DIFF
--- a/home.admin/config.scripts/bonus.stacking-sats-kraken.sh
+++ b/home.admin/config.scripts/bonus.stacking-sats-kraken.sh
@@ -95,7 +95,10 @@ set -e
 export NODE_OPTIONS="--no-deprecation"
 
 # load config
-set -a; source /mnt/hdd/app-data/stacking-sats-kraken/.env; set +a
+env="/mnt/hdd/app-data/stacking-sats-kraken/.env"
+set -a; . ${env}; set +a
+# alternative config
+test -f "${env}-"${2} && { set -a; . "${env}-"${2}; set +a; }
 
 # switch directory
 cd $(cd `dirname $0` && pwd)


### PR DESCRIPTION
enables usage of e.g.
* a base config aside one or more alternative complementing ones
* different stacking amounts
* different accounts (such as friends and family or business and private)
* test config aside a productive one

simply via 2nd cli parameter for `stacksats.sh` and more config files in `/mnt/hdd/app-data/stacking-sats-kraken` that look the same as `.env` but must be named `.env-param2` when calling e.g. `stacksats.sh "stack" "param2"`