### PR TITLE
btcpay v1.6.1, nbxplorer v2.3.28 with postgres

### DIFF
--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -3,9 +3,9 @@
 # Based on: https://gist.github.com/normandmickey/3f10fc077d15345fb469034e3697d0d0
 
 # https://github.com/dgarage/NBXplorer/tags
-NBXplorerVersion="v2.2.20"
+NBXplorerVersion="v2.3.28"
 # https://github.com/btcpayserver/btcpayserver/releases
-BTCPayVersion="v1.5.4"
+BTCPayVersion="v1.6.1"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -23,6 +23,87 @@ source /mnt/hdd/raspiblitz.conf
 # get cpu architecture
 source /home/admin/raspiblitz.info
 source <(/home/admin/_cache.sh get state)
+
+function postgresConfig() {
+  # https://github.com/rootzoll/raspiblitz/issues/3218
+  echo "# Install postgres"
+  sudo apt install -y postgresql
+
+  echo "# Move the postgres data to /mnt/hdd/app-data/postgresql"
+  # sudo -u postgres psql -c "show data_directory"
+  #  /var/lib/postgresql/13/main
+  if [ ! -d /var/lib/postgresql ]; then
+    sudo  mkdir -p /var/lib/postgresql/13/main
+    sudo chown -R postgres:postgres /var/lib/postgresql
+    # sudo pg_dropcluster 13 main
+    sudo pg_createcluster 13 main --start
+  fi
+  sudo systemctl stop postgresql 2>/dev/null
+  sudo rsync -av /var/lib/postgresql /mnt/hdd/app-data
+  sudo mv /var/lib/postgresql /var/lib/postgresql.bak
+  sudo rm -rf /var/lib/postgresql # not a symlink.. delete it silently
+  sudo ln -s /mnt/hdd/app-data/postgresql /var/lib/
+
+  sudo systemctl enable postgresql
+  sudo systemctl start postgresql
+
+  echo "# Generate the database"
+  sudo -u postgres psql -c "create database nbxplorermainnet;"
+  sudo -u postgres psql -c "create user nbxplorer with encrypted password 'raspiblitz';"
+  # change to ${newPassword} or use Passfile=
+  # sudo -u postgres psql -c "alter user btcpay with encrypted password '${newPassword}';"
+  # sudo -u btcpay sed -i "s/Password=*/Password='${newPassword}';/g" /home/btcpay/.nbxplorer/Main/settings.config
+  # sudo -u btcpay sed -i "s/Password=*/Password='${newPassword}';/g" /home/btcpay/.btcpayserver/Main/settings.config
+  sudo -u postgres psql -c "grant all privileges on database nbxplorermainnet to nbxplorer;"
+}
+
+function NBXplorerConfig() {
+  # https://docs.btcpayserver.org/Deployment/ManualDeploymentExtended/#4-create-a-configuration-file
+  echo
+  echo "# Getting RPC credentials from the bitcoin.conf"
+  RPC_USER=$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcuser | cut -c 9-)
+  PASSWORD_B=$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcpassword | cut -c 13-)
+  sudo -u btcpay mkdir -p /home/btcpay/.nbxplorer/Main
+  echo "\
+network=mainnet
+btc.rpc.user=${RPC_USER}
+btc.rpc.password=${PASSWORD_B}
+postgres=User ID=nbxplorer;Host=localhost;Port=5432;Application Name=nbxplorer;MaxPoolSize=20;Database=nbxplorermainnet;Password='raspiblitz';
+automigrate=1
+nomigrateevts=1
+" | sudo tee /home/btcpay/.nbxplorer/Main/settings.config
+  sudo chmod 600 /home/btcpay/.nbxplorer/Main/settings.config
+  sudo chown btcpay:btcpay /home/btcpay/.nbxplorer/Main/settings.config
+}
+
+function BtcPayConfig() {
+  # set thumbprint
+  FINGERPRINT=$(openssl x509 -noout -fingerprint -sha256 -inform pem -in /home/btcpay/.lnd/tls.cert | cut -d"=" -f2)
+  echo "# setting the LND TLS thumbprint for BTCPay"
+  # https://docs.btcpayserver.org/Deployment/ManualDeploymentExtended/#3-create-a-configuration-file
+  echo "
+### Global settings ###
+network=mainnet
+
+### Server settings ###
+port=23000
+bind=127.0.0.1
+externalurl=https://$BTCPayDomain
+
+### NBXplorer settings ###
+BTC.explorer.url=http://127.0.0.1:24444/
+BTC.lightning=type=lnd-rest;server=https://127.0.0.1:8080/;macaroonfilepath=/home/btcpay/admin.macaroon;certthumbprint=$FINGERPRINT
+
+### Database ###
+# keep sqlite for now as configured in the btcpayserver.service
+# postgres=User ID=btcpay;Password=urpassword;Application Name=btcpayserver;Host=localhost;Port=5432;Database=btcpay;
+explorer.postgres=User ID=nbxplorer;Host=localhost;Port=5432;Application Name=nbxplorer;MaxPoolSize=20;Database=nbxplorermainnet;Password='raspiblitz';
+" | sudo -u btcpay tee /home/btcpay/.btcpayserver/Main/settings.config
+  #doesNetworkEntryAlreadyExists=$(sudo cat /home/btcpay/.btcpayserver/Main/settings.config | grep -c '^network=')
+  #echo "# setting new LND TLS thumbprint for BTCPay"
+  #s="BTC.lightning=type=lnd-rest\;server=https\://127.0.0.1:8080/\;macaroonfilepath=/home/btcpay/admin.macaroon\;"
+  #sudo -u btcpay sed -i "s|^${s}certthumbprint=.*|${s}certthumbprint=$FINGERPRINT|g" /home/btcpay/.btcpayserver/Main/settings.config
+}
 
 if [ "$1" = "status" ]; then
 
@@ -181,29 +262,7 @@ if [ "$1" = "write-tls-macaroon" ]; then
     sudo ln -s "/home/btcpay/.lnd/data/chain/${network}/${chain}net/admin.macaroon" "/home/btcpay/admin.macaroon"
   fi
 
-  # set thumbprint
-  FINGERPRINT=$(openssl x509 -noout -fingerprint -sha256 -inform pem -in /home/btcpay/.lnd/tls.cert | cut -d"=" -f2)
-  doesNetworkEntryAlreadyExists=$(sudo cat /home/btcpay/.btcpayserver/Main/settings.config | grep -c '^network=')
-  if [ ${doesNetworkEntryAlreadyExists} -eq 0 ]; then
-    echo "# setting the LND TLS thumbprint for BTCPay"
-    echo "
-### Global settings ###
-network=mainnet
-
-### Server settings ###
-port=23000
-bind=127.0.0.1
-externalurl=https://$BTCPayDomain
-
-### NBXplorer settings ###
-BTC.explorer.url=http://127.0.0.1:24444/
-BTC.lightning=type=lnd-rest;server=https://127.0.0.1:8080/;macaroonfilepath=/home/btcpay/admin.macaroon;certthumbprint=$FINGERPRINT
-" | sudo -u btcpay tee -a /home/btcpay/.btcpayserver/Main/settings.config
-  else
-    echo "# setting new LND TLS thumbprint for BTCPay"
-    s="BTC.lightning=type=lnd-rest\;server=https\://127.0.0.1:8080/\;macaroonfilepath=/home/btcpay/admin.macaroon\;"
-    sudo -u btcpay sed -i "s|^${s}certthumbprint=.*|${s}certthumbprint=$FINGERPRINT|g" /home/btcpay/.btcpayserver/Main/settings.config
-  fi
+  BtcPayConfig
 
   if [ "${state}" == "ready" ]; then
     sudo systemctl restart btcpayserver
@@ -235,7 +294,7 @@ if [ "$1" = "cln-lightning-rpc-access" ]; then
   fi
 
   echo "
-In the BTCPayServer Lightning Wallet settings 'Connect to a Lightning node' page 
+In the BTCPayServer Lightning Wallet settings 'Connect to a Lightning node' page
 fill in the 'Connection configuration for your custom Lightning node:' box on with:
 
 type=clightning;server=unix:///home/bitcoin/.lightning/bitcoin/lightning-rpc
@@ -303,6 +362,10 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo ln -s /mnt/hdd/app-data/.btcpayserver /home/btcpay/ 2>/dev/null
     sudo chown -R btcpay:btcpay /home/btcpay/.btcpayserver
 
+    # POSTGRES
+    postgresConfig
+
+    # .NET
     echo
     echo "# Installing .NET"
     echo
@@ -329,7 +392,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
     dotNetName="dotnet-sdk-6.0.101-linux-${binaryVersion}.tar.gz"
     sudo rm /home/btcpay/${dotnetName} 2>/dev/null
-    sudo -u btcpay wget "${dotNetdirectLink}"
+    sudo -u btcpay wget "${dotNetdirectLink}" -O "${dotNetName}"
     # check binary is was not manipulated (checksum test)
     actualChecksum=$(sha512sum /home/btcpay/${dotNetName} | cut -d " " -f1)
     if [ "${actualChecksum}" != "${dotNetChecksum}" ]; then
@@ -392,12 +455,13 @@ After=bitcoind.service
 [Service]
 WorkingDirectory=/home/btcpay/NBXplorer
 ExecStart=/home/btcpay/dotnet/dotnet run --no-launch-profile --no-build \
- -c Release -p \"NBXplorer/NBXplorer.csproj\" -- \$@
+ -c Release --project \"NBXplorer/NBXplorer.csproj\" -- \$@
 User=btcpay
 Group=btcpay
 Type=simple
 PIDFile=/run/nbxplorer/nbxplorer.pid
 Restart=on-failure
+RestartSec=20
 
 # Hardening measures
 PrivateTmp=true
@@ -431,17 +495,7 @@ WantedBy=multi-user.target
       echo "# Because the system is not 'ready' the service 'nbxplorer' will not be started at this point .. its enabled and will start on next reboot"
     fi
 
-    echo
-    echo "# getting RPC credentials from the bitcoin.conf"
-    RPC_USER=$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcuser | cut -c 9-)
-    PASSWORD_B=$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcpassword | cut -c 13-)
-    sudo -u btcpay mkdir -p /home/btcpay/.nbxplorer/Main
-    echo "\
-btc.rpc.user=$RPC_USER
-btc.rpc.password=$PASSWORD_B
-" | sudo tee /home/btcpay/.nbxplorer/Main/settings.config
-    sudo chmod 600 /home/btcpay/.nbxplorer/Main/settings.config
-    sudo chown btcpay:btcpay /home/btcpay/.nbxplorer/Main/settings.config
+    NBXplorerConfig
 
     # whitelist localhost in bitcoind
     if ! sudo grep -Eq "^whitelist=127.0.0.1" /mnt/hdd/bitcoin/bitcoin.conf;then
@@ -464,15 +518,17 @@ btc.rpc.password=$PASSWORD_B
     cd /home/btcpay || exit 1
     echo "# Download the BTCPayServer source code ..."
     sudo -u btcpay git clone https://github.com/btcpayserver/btcpayserver.git 2>/dev/null
-    cd btcpayserver
+    cd btcpayserver || exit 1
     sudo -u btcpay git reset --hard $BTCPayVersion
 
     # sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh \
     #  "web-flow" "https://github.com/web-flow.gpg" "4AEE18F83AFDEB23" || exit 1
-    PGPsigner="Kukks"
-    PGPpubkeyLink="https://github.com/${PGPsigner}.gpg"
-    PGPpubkeyFingerprint="8E5530D9D1C93097"
-
+    PGPsigner="nicolasdorier"
+    PGPpubkeyLink="https://keybase.io/nicolasdorier/pgp_keys.asc"
+    PGPpubkeyFingerprint="AB4CFA9895ACA0DBE27F6B346618763EF09186FE"
+    #PGPsigner="Kukks"
+    #PGPpubkeyLink="https://github.com/${PGPsigner}.gpg"
+    #PGPpubkeyFingerprint="8E5530D9D1C93097"
     sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh \
      "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
 
@@ -493,7 +549,7 @@ After=nbxplorer.service
 
 [Service]
 ExecStart=/home/btcpay/dotnet/dotnet run --no-launch-profile --no-build \
- -c Release -p \"/home/btcpay/btcpayserver/BTCPayServer/BTCPayServer.csproj\" \
+ -c Release --project \"/home/btcpay/btcpayserver/BTCPayServer/BTCPayServer.csproj\" \
  -- --sqlitefile=sqllite.db
 User=btcpay
 Group=btcpay
@@ -620,6 +676,8 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo userdel -rf btcpay 2>/dev/null
   if [ ${deleteData} -eq 1 ]; then
     echo "# deleting data"
+    sudo -u postgres psql -c "drop database nbxplorermainnet;"
+    sudo -u postgres psql -c "drop user nbxplorer;"
     sudo rm -R /mnt/hdd/app-data/.btcpayserver/
   else
     echo "# keeping data"
@@ -633,49 +691,58 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
 fi
 
 if [ "$1" = "update" ]; then
+  echo "# Update NBXplorer"
+  cd /home/btcpay || exit 1
+  cd NBXplorer || exit 1
+  # fetch latest master
+  if [ "$(sudo -u btcpay git fetch 2>&1 | grep -c "Please tell me who you are")" -gt 0 ]; then
+    sudo -u btcpay git config user.email "you@example.com"
+    sudo -u btcpay git config user.name "Your Name"
+  fi
+  sudo -u btcpay git fetch
+  # unset $1
+  set --
+  UPSTREAM=${1:-'@{u}'}
+  LOCAL=$(git rev-parse @)
+  REMOTE=$(git rev-parse "$UPSTREAM")
 
-## don't update NBXplorer until https://github.com/rootzoll/raspiblitz/issues/3055 is solved
-#   echo "# Update NBXplorer"
-#   cd /home/btcpay || exit 1
-#   cd NBXplorer || exit 1
-#   # fetch latest master
-#   if [ "$(sudo -u btcpay git fetch 2>&1 | grep -c "Please tell me who you are")" -gt 0 ]; then
-#     sudo -u btcpay git config user.email "you@example.com"
-#     sudo -u btcpay git config user.name "Your Name"
-#   fi
-#   sudo -u btcpay git fetch
-#   # unset $1
-#   set --
-#   UPSTREAM=${1:-'@{u}'}
-#   LOCAL=$(git rev-parse @)
-#   REMOTE=$(git rev-parse "$UPSTREAM")
-#
-#   if [ $LOCAL = $REMOTE ]; then
-#     TAG=$(git tag | sort -V | tail -1)
-#     echo "# Up-to-date on version $TAG"
-#   else
-#     echo "# Pulling latest changes..."
-#     sudo -u btcpay git pull -p
-#     TAG=$(git tag | sort -V | tail -1)
-#     echo "# Reset to the latest release tag: $TAG"
-#     sudo -u btcpay git reset --hard $TAG
-#     sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh \
-#      "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
-#     echo "# Build NBXplorer ..."
-#     # from the build.sh with path
-#     sudo systemctl stop nbxplorer
-#     sudo -u btcpay /home/btcpay/dotnet/dotnet build -c Release NBXplorer/NBXplorer.csproj
-#
-#     # whitelist localhost in bitcoind
-#     if ! sudo grep -Eq "^whitelist=127.0.0.1" /mnt/hdd/bitcoin/bitcoin.conf;then
-#       echo "whitelist=127.0.0.1" | sudo tee -a /mnt/hdd/bitcoin/bitcoin.conf
-#       echo "# Restarting bitcoind"
-#       sudo systemctl restart bitcoind
-#     fi
-#
-#     sudo systemctl start nbxplorer
-#     echo "# Updated NBXplorer to $TAG"
-#   fi
+  if [ $LOCAL = $REMOTE ]; then
+    TAG=$(git tag | sort -V | tail -1)
+    echo "# Up-to-date on version $TAG"
+  else
+    echo "# Pulling latest changes..."
+    sudo -u btcpay git pull -p
+    TAG=$(git tag | sort -V | tail -1)
+    echo "# Reset to the latest release tag: $TAG"
+    sudo -u btcpay git reset --hard $TAG
+    PGPsigner="nicolasdorier"
+    PGPpubkeyLink="https://keybase.io/nicolasdorier/pgp_keys.asc"
+    PGPpubkeyFingerprint="AB4CFA9895ACA0DBE27F6B346618763EF09186FE"
+    sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh \
+     "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
+    echo "# Build NBXplorer ..."
+    # from the build.sh with path
+    sudo systemctl stop nbxplorer
+    sudo -u btcpay /home/btcpay/dotnet/dotnet build -c Release NBXplorer/NBXplorer.csproj
+    # whitelist localhost in bitcoind
+    if ! sudo grep -Eq "^whitelist=127.0.0.1" /mnt/hdd/bitcoin/bitcoin.conf;then
+      echo "whitelist=127.0.0.1" | sudo tee -a /mnt/hdd/bitcoin/bitcoin.conf
+      echo "# Restarting bitcoind"
+      sudo systemctl restart bitcoind
+    fi
+
+    postgresConfig
+
+    NBXplorerConfig
+
+    sudo systemctl start nbxplorer
+    echo "# Updated NBXplorer to $TAG"
+  fi
+
+  # always stop to BtcPayConfig
+  sudo systemctl stop btcpayserver
+
+  BtcPayConfig
 
   echo "# Update BTCPayServer"
   cd /home/btcpay || exit 1
@@ -712,6 +779,8 @@ if [ "$1" = "update" ]; then
     sudo systemctl start btcpayserver
     echo "# Updated BTCPayServer to $TAG"
   fi
+  # always start after BtcPayConfig
+  sudo systemctl start btcpayserver
   exit 0
 fi
 


### PR DESCRIPTION
related: #3217 #3218

* moves the nbxplorer backand to postgres in new installs and updates
* the postgresql data directory is moved and symlinked `/mnt/hdd/app-data/postgresql`

Postgres would be ready to be used by other apps as well like BTCPay shop database and possibly lnbits as well #2843 

the function `postgresConfig` can be edited out to it's own script or just reused for other apps with separate databases.