### PR TITLE
Add lsb-release to apt install

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -297,7 +297,8 @@ echo -e "\n*** SOFTWARE UPDATE ***"
 # psmisc -> install killall, fuser
 # ufw -> firewall
 # sqlite3 -> database
-general_utils="policykit-1 htop git curl bash-completion vim jq dphys-swapfile bsdmainutils autossh telnet vnstat parted dosfstools btrfs-progs fbi sysbench build-essential dialog bc python3-dialog unzip whois"
+# lsb-release -> needed to know which distro version we're running to add APT sources
+general_utils="policykit-1 htop git curl bash-completion vim jq dphys-swapfile bsdmainutils autossh telnet vnstat parted dosfstools btrfs-progs fbi sysbench build-essential dialog bc python3-dialog unzip whois lsb-release"
 python_dependencies="python3-venv python3-dev python3-wheel python3-jinja2 python3-pip"
 server_utils="rsync net-tools xxd netcat openssh-client openssh-sftp-server sshpass psmisc ufw sqlite3"
 [ "${baseimage}" = "armbian" ] && armbian_dependencies="armbian-config" # add armbian-config


### PR DESCRIPTION
Add `lsb-release` to apt install because some `debian-minimal` templates (like the one included with Proxmox) don't include it by default and it's needed to add Tor sources to APT:

Fixes https://github.com/rootzoll/raspiblitz/issues/3229