### PR TITLE
don't delete old rescue files

### DIFF
--- a/home.admin/config.scripts/cl.backup.sh
+++ b/home.admin/config.scripts/cl.backup.sh
@@ -148,7 +148,7 @@ if [ ${mode} = "cl-export" ]; then
   sudo chown ${fileowner}:${fileowner} ${downloadPath}/cl-rescue.tar.gz 1>&2
 
   # delete old backups
-  rm ${downloadPath}/cl-rescue-*.tar.gz 2>/dev/null 1>/dev/null
+  # rm ${downloadPath}/cl-rescue-*.tar.gz 2>/dev/null 1>/dev/null
 
   # name with md5 checksum
   md5checksum=$(md5sum ${downloadPath}/cl-rescue.tar.gz | head -n1 | cut -d " " -f1)

--- a/home.admin/config.scripts/lnd.backup.sh
+++ b/home.admin/config.scripts/lnd.backup.sh
@@ -156,7 +156,7 @@ if [ ${mode} = "lnd-export" ]; then
   sudo chown ${fileowner}:${fileowner} ${downloadPath}/lnd-rescue.tar.gz 1>&2
 
   # delete old backups
-  rm ${downloadPath}/lnd-rescue-*.tar.gz 2>/dev/null 1>/dev/null
+  # rm ${downloadPath}/lnd-rescue-*.tar.gz 2>/dev/null 1>/dev/null
 
   # name with md5 checksum
   md5checksum=$(md5sum ${downloadPath}/lnd-rescue.tar.gz | head -n1 | cut -d " " -f1)


### PR DESCRIPTION
After going through a few recovery scenarios I think it is safer to keep all backups. 
The risk of filling up the SDcard is much less then losing potentially valuable data.
On download the rescue-files are identified with the md5sum, so should not cause any confusion:

https://github.com/rootzoll/raspiblitz/blob/cd2867d3f5c89ff54d054723a583f27e5d959d9e/home.admin/config.scripts/cl.backup.sh#L166

https://github.com/rootzoll/raspiblitz/blob/cd2867d3f5c89ff54d054723a583f27e5d959d9e/home.admin/config.scripts/lnd.backup.sh#L174