### PR TITLE
lnd.check.sh -> harden rpc user/pass parsing against double entries

### DIFF
--- a/home.admin/config.scripts/lnd.check.sh
+++ b/home.admin/config.scripts/lnd.check.sh
@@ -158,12 +158,20 @@ if [ "$1" == "prestart" ]; then
   if [ "${RPCPSW}" == "" ]; then
     RPCPSW=$(cat /mnt/hdd/${network}/${network}.conf | grep "^${network}d.rpcpassword=" | cut -d "=" -f2 | tail -n 1)
   fi
+  if [ "${RPCPSW}" == "" ]; then
+    1>&2 echo "FAIL: 'rpcpassword' not found in /mnt/hdd/${network}/${network}.conf"
+    exit 11
+  fi
   setting ${lndConfFile} ${insertLine} "${network}d\.rpcpass" "${RPCPSW}"
 
   # SET/UPDATE rpcuser
   RPCUSER=$(cat /mnt/hdd/${network}/${network}.conf | grep "^rpcuser=" | cut -d "=" -f2 | tail -n 1)
   if [ "${RPCUSER}" == "" ]; then
     RPCUSER=$(cat /mnt/hdd/${network}/${network}.conf | grep "^${network}d.rpcuser=" | cut -d "=" -f2 | tail -n 1)
+  fi
+  if [ "${RPCUSER}" == "" ]; then
+    1>&2 echo "FAIL: 'rpcuser' not found in /mnt/hdd/${network}/${network}.conf"
+    exit 12
   fi
   setting ${lndConfFile} ${insertLine} "${network}d\.rpcuser" "${RPCUSER}"
 

--- a/home.admin/config.scripts/lnd.check.sh
+++ b/home.admin/config.scripts/lnd.check.sh
@@ -154,11 +154,17 @@ if [ "$1" == "prestart" ]; then
   setting ${lndConfFile} ${insertLine} "${network}d\.zmqpubrawblock" "tcp\:\/\/127\.0\.0\.1\:${zmqprefix}332"
 
   # SET/UPDATE rpcpass
-  RPCPSW=$(cat /mnt/hdd/${network}/${network}.conf | grep "rpcpassword=" | cut -d "=" -f2)
+  RPCPSW=$(cat /mnt/hdd/${network}/${network}.conf | grep "^rpcpassword=" | tail -1 | cut -d "=" -f2 | tail -n 1)
+  if [ "${RPCPSW}" == "" ]; then
+    RPCPSW=$(cat /mnt/hdd/${network}/${network}.conf | grep "^${network}d.rpcpassword=" | cut -d "=" -f2 | tail -n 1)
+  fi
   setting ${lndConfFile} ${insertLine} "${network}d\.rpcpass" "${RPCPSW}"
 
   # SET/UPDATE rpcuser
-  RPCUSER=$(cat /mnt/hdd/${network}/${network}.conf | grep "rpcuser=" | cut -d "=" -f2)
+  RPCUSER=$(cat /mnt/hdd/${network}/${network}.conf | grep "^rpcuser=" | cut -d "=" -f2 | tail -n 1)
+  if [ "${RPCUSER}" == "" ]; then
+    RPCUSER=$(cat /mnt/hdd/${network}/${network}.conf | grep "^${network}d.rpcuser=" | cut -d "=" -f2 | tail -n 1)
+  fi
   setting ${lndConfFile} ${insertLine} "${network}d\.rpcuser" "${RPCUSER}"
 
   # SET/UPDATE rpchost


### PR DESCRIPTION
old comments were getting multiple lines - breaking setting values in lnd.conf, leading to lnd not working. this should make the rpc user/pass parsing more robust 