### PR TITLE
Redirect nginx HTTP to HTTPS and change Port

### DIFF
--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -1,43 +1,46 @@
 # RaspiBlitz public.conf server configuration
 #
 server {
-	listen 80 default_server;
-	listen [::]:80 default_server;
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+    listen 80 default_server;
 
-	root /var/www/public;
-	index index.html;
-	server_name _;
+    server_name _;
+    return 301 https://$host:4443;
+}
+
+server {
+    listen 4443 ssl http2;
+
+    root /var/www/public;
+    index index.html;
+    server_name _;
 
     include /etc/nginx/snippets/ssl-params.conf;
     include /etc/nginx/snippets/ssl-certificate-app-data.conf;
 
-	include /etc/nginx/snippets/gzip-params.conf;
+    include /etc/nginx/snippets/gzip-params.conf;
 
 
-	# proxy for API
-	location /api/ {
-		proxy_pass        http://127.0.0.1:11111/;
-		proxy_set_header  X-Real-IP $remote_addr;
-		proxy_set_header  X-Forwarded-Host   $host;
-	}
+    # proxy for API
+    location /api/ {
+        proxy_pass        http://127.0.0.1:11111/;
+        proxy_set_header  X-Real-IP $remote_addr;
+        proxy_set_header  X-Forwarded-Host   $host;
+    }
 
-	# directory for acme challenge
-	location ^~ /.well-known/acme-challenge/ {
-		default_type "text/plain";
-		root /var/www/letsencrypt;
-	}
+    # directory for acme challenge
+    location ^~ /.well-known/acme-challenge/ {
+        default_type "text/plain";
+        root /var/www/letsencrypt;
+    }
 
-	location / {
-		# make sure to have https link to exact same host that was called
-		sub_filter '<a href="https://HOST_SET_BY_NGINX/' '<a href="https://$host/';
+    location / {
+        # make sure to have https link to exact same host that was called
+        sub_filter '<a href="https://HOST_SET_BY_NGINX/' '<a href="https://$host/';
 
-		# First attempt to serve request as file, then
-		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ /index.html =404;
+        # First attempt to serve request as file, then
+        # as directory, then fall back to displaying a 404.
+        try_files $uri $uri/ /index.html =404;
 
-	}
+    }
 
 }
-


### PR DESCRIPTION
Cause of in example LNBits service which is already set to 443, set WebUI on 4443

Never allow port 80 cause of missing encryption. Redirect it to HTTPS.