### PR TITLE
Fix localIP and torAddress gathering

### DIFF
--- a/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
+++ b/home.admin/config.scripts/bonus.btc-rpc-explorer.sh
@@ -85,7 +85,7 @@ if [ "$1" = "status" ]; then
     echo "installed=${installed}"
 
     # get network info
-    localIP=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+    localIP=$(hostname -I | awk '{print $1}')
     toraddress=$(sudo cat /mnt/hdd/tor/btc-rpc-explorer/hostname 2>/dev/null)
     fingerprint=$(openssl x509 -in /mnt/hdd/app-data/nginx/tls.cert -fingerprint -noout | cut -d"=" -f2)
 

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -145,7 +145,7 @@ if [ "$1" = "menu" ]; then
 
   # get status
   echo "# collecting status info ... (please wait)"
-  source <(sudo /home/admin/config.scripts/bonus.electrs.sh status)
+  source <(sudo /home/admin/config.scripts/bonus.electrs.sh status showAddress)
 
   if [ ${serviceInstalled} -eq 0 ]; then
     echo "# FAIL not installed"

--- a/home.admin/config.scripts/bonus.homer.sh
+++ b/home.admin/config.scripts/bonus.homer.sh
@@ -23,7 +23,7 @@ if [ "$1" = "menu" ]; then
   source <(sudo /home/admin/config.scripts/bonus.homer.sh status)
 
   # get network info
-  localip=$(ip addr | grep 'state UP' -A2 | egrep -v 'docker0' | grep 'eth0\|wlan0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localIP=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/homer/hostname 2>/dev/null)
   fingerprint=$(openssl x509 -in /mnt/hdd/app-data/nginx/tls.cert -fingerprint -noout | cut -d"=" -f2)
 


### PR DESCRIPTION
I fixed the commands used to gather the local ip addresses in `bonus.btc-rpc-explorer.sh` and `bonus.homer.sh` because previously, they were not able to retrieve the network cards with a prefix different from `eth0\|wlan0\|enp0` (in my case it was indeed `enp7s0` on a Debian amd64 machine).
Actually, many other scripts are already using this "new" logic.

Finally, in the `bonus.electrs.sh` I just added the second flag `showAddress` in order to show the tor address in the "status" menu.