### PR TITLE
Bonus script to install CLN Watchtower client rust-teos ("The Eye of Satoshi")

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## What's new in Version 1.8.1 of RaspiBlitz?
 
+- New: CL Watchtower (The Eye of Satoshi) [details](https://github.com/talaia-labs/rust-teos/tree/master/watchtower-plugin)
 - New: Support of X708 UPS HAT [details](https://github.com/rootzoll/raspiblitz/pull/3087)
 - Update: LND v0.15.3 [details](https://github.com/lightningnetwork/lnd/releases/tag/v0.15.3-beta
 - Update: Core Lightning v0.12.1 [details](https://github.com/ElementsProject/lightning/releases/tag/v0.12.1)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ There are further Services that can be switched on:
 - **CL Spark Wallet** (WalletUI with BOLT12 offers) [details](https://github.com/shesek/spark-wallet#progressive-web-app)
 - **CL plugin: Sparko** (WalletUI & HTTP-RPC bridge) [details](https://github.com/fiatjaf/sparko#the-sparko-plugin)
 - **CL plugin: CLBOSS** (Automated Node Manager) [details](https://github.com/ZmnSCPxj/clboss#clboss-the-c-lightning-node-manager)
+- **CL plugin: The Eye of Satoshi** (Watchtower) [details](https://github.com/talaia-labs/rust-teos/tree/master/watchtower-plugin)
 - **Tallycoin Connect** (Use Tallycoin with your own node) [details](https://github.com/djbooth007/tallycoin_connect)
 - **ItchySats** (Non-custodial peer-to-peer CFD trading) [details](https://github.com/itchysats/itchysats)
 

--- a/home.admin/00settingsMenuBasics.sh
+++ b/home.admin/00settingsMenuBasics.sh
@@ -17,6 +17,7 @@ if [ ${#circuitbreaker} -eq 0 ]; then circuitbreaker="off"; fi
 if [ ${#clboss} -eq 0 ]; then clboss="off"; fi
 if [ ${#clEncryptedHSM} -eq 0 ]; then clEncryptedHSM="off"; fi
 if [ ${#clAutoUnlock} -eq 0 ]; then clAutoUnlock="off"; fi
+if [ ${#clWatchtowerClient} -eq 0 ]; then clWatchtowerClient="off"; fi
 if [ ${#blitzapi} -eq 0 ]; then blitzapi="off"; fi
 
 echo "# map LND to on/off"
@@ -95,6 +96,12 @@ if [ "${clAutoUnlock}" == "on" ]; then
   clAutoUnlockMenu='on'
 fi
 
+echo "# map clWatchtowerClient to on/off"
+clWatchtowerClientMenu='off'
+if [ "${clWatchtowerClient}" == "on" ]; then
+  clWatchtowerClientMenu='on'
+fi
+
 echo "# map keysend to on/off (may take time)"
 keysend="on"
 source <(sudo /home/admin/config.scripts/lnd.keysend.sh status)
@@ -142,6 +149,7 @@ OPTIONS+=(n 'CL CORE LIGHTNING NODE' ${clNode})
 if [ "${clNode}" == "on" ]; then
   OPTIONS+=(o '-CL CLBOSS Automatic Node Manager' ${clbossMenu})
   OPTIONS+=(h '-CL Wallet Encryption' ${clEncryptedHSMMenu})
+  OPTIONS+=(w '-CL Watchtower Client' ${clWatchtowerClientMenu})  
   if [ "${clEncryptedHSM}" == "on" ]; then
     OPTIONS+=(q '-CL Auto-Unlock' ${clAutoUnlockMenu})
   fi
@@ -493,6 +501,22 @@ if [ "${clAutoUnlock}" != "${choice}" ] && [ "${clNode}" == "on" ]; then
   needsReboot=0
 else
   echo "clAutoUnlock Setting unchanged."
+fi
+
+# clWatchtowerClient process choice
+choice="off"; check=$(echo "${CHOICES}" | grep -c "w")
+if [ ${check} -eq 1 ]; then choice="on"; fi
+if [ "${clWatchtowerClient}" != "${choice}" ] && [ "${clNode}" == "on" ]; then
+  echo "CL WATCHTOWER CLIENT Setting changed .."
+  anychange=1
+  if [ ${choice} = on ]; then
+    sudo /home/admin/config.scripts/cl-plugin.watchtower-client.sh on
+  else
+    sudo /home/admin/config.scripts/cl-plugin.watchtower-client.sh off
+  fi
+  needsReboot=0
+else
+  echo "CL WATCHTOWER CLIENT Setting unchanged."
 fi
 
 # parallel testnet process choice

--- a/home.admin/00settingsMenuBasics.sh
+++ b/home.admin/00settingsMenuBasics.sh
@@ -509,8 +509,14 @@ if [ ${check} -eq 1 ]; then choice="on"; fi
 if [ "${clWatchtowerClient}" != "${choice}" ] && [ "${clNode}" == "on" ]; then
   echo "CL WATCHTOWER CLIENT Setting changed .."
   anychange=1
+
   if [ ${choice} = on ]; then
-    sudo /home/admin/config.scripts/cl-plugin.watchtower-client.sh on
+    if /home/admin/config.scripts/cl-plugin.watchtower-client.sh info; then
+      sudo /home/admin/config.scripts/cl-plugin.watchtower-client.sh on
+    else
+      echo "CL WATCHTOWER CLIENT install was cancelled."
+      sleep 2
+    fi
   else
     sudo /home/admin/config.scripts/cl-plugin.watchtower-client.sh off
   fi

--- a/home.admin/_provision_.sh
+++ b/home.admin/_provision_.sh
@@ -419,6 +419,24 @@ else
     echo "Provisioning clHTTPplugin - keep default" >> ${logFile}
 fi
 
+# clboss
+if [ "${clboss}" = "on" ]; then
+    echo "Provisioning clboss - run config script" >> ${logFile}
+    /home/admin/_cache.sh set message "Setup clboss"
+    sudo -u admin /home/admin/config.scripts/cl-plugin.clboss.sh on >> ${logFile} 2>&1
+else
+    echo "Provisioning clboss - keep default" >> ${logFile}
+fi
+
+# clWatchtowerClient
+if [ "${clWatchtowerClient}" = "on" ]; then
+    echo "Provisioning clWatchtowerClient - run config script" >> ${logFile}
+    /home/admin/_cache.sh set message "Setup clWatchtowerClient"
+    sudo -u admin /home/admin/config.scripts/cl-plugin.watchtower-client.sh on >> ${logFile} 2>&1
+else
+    echo "Provisioning clWatchtowerClient - keep default" >> ${logFile}
+fi
+
 # SPARK
 if [ "${spark}" = "on" ]; then
     echo "Provisioning Spark Wallet - run config script" >> ${logFile}

--- a/home.admin/config.scripts/cl-plugin.watchtower-client.sh
+++ b/home.admin/config.scripts/cl-plugin.watchtower-client.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ];then
+  echo
+  echo "Install the rust-teos watchtower-client plugin for CLN"
+  echo "Usage:"
+  echo "cl-plugin.watchtower-client.sh on <testnet|mainnet|signet>"
+  echo "cl-plugin.watchtower-client.sh off <testnet|mainnet|signet> <purge>"
+  echo "cl-plugin.watchtower-client.sh info"
+  echo
+  exit 1
+fi
+
+echo "# cl-plugin.watchtower-client.sh $*"
+
+source <(/home/admin/config.scripts/network.aliases.sh getvars cl $2)
+source /mnt/hdd/raspiblitz.conf  #to get runBehindTor
+plugin="watchtower-client"
+
+if [ "$1" = info ]; then
+    echo "The Eye of Satoshi is a Lightning watchtower compliant with BOLT13, written in Rust."
+    echo ""
+    echo "To connect to a tower, use:"
+    echo "cl registertower <tower_id>"
+    echo ""
+    echo "Links with more info:"
+    echo "https://github.com/talaia-labs/rust-teos/tree/master/watchtower-plugin"
+fi
+
+
+if [ "$1" = "on" ];then
+
+  # rust for rust-teos, includes rustfmt
+  sudo -u bitcoin curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+  sudo -u bitcoin sh -s -- -y
+
+  #Cleanup existing
+  if [ -d "/home/bitcoin/cl-plugins-available/plugins/${plugin}/" ]; then
+    rm -rf "/home/bitcoin/cl-plugins-available/plugins/${plugin}/"
+  fi
+
+  #Clone source repository
+  cd /home/bitcoin/cl-plugins-available || exit 1
+  sudo -u bitcoin git clone https://github.com/talaia-labs/rust-teos.git
+  
+  #Compile
+  cd /home/bitcoin/cl-plugins-available/rust-teos || exit 1
+  sudo -u bitcoin /home/bitcoin/.cargo/bin/cargo install --path watchtower-plugin \
+      --target-dir /home/bitcoin/cl-plugins-available/${plugin}
+
+  #Symlink to enable
+  if [ ! -L  /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin} ]; then
+    echo "Running: sudo -u bitcoin ln -s /home/bitcoin/cl-plugins-available/${plugin}/release/${plugin} /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin}"
+    sudo -u bitcoin ln -s /home/bitcoin/cl-plugins-available/${plugin}/release/${plugin} /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin}
+  fi
+
+  #check if toronly node, then add watchtower-proxy config to CL 
+  if [ "$runBehindTor" = on ]; then
+    echo "watchtower-proxy=127.0.0.1:9050" | sudo tee -a ${CLCONF}
+  fi
+
+  # setting value in raspiblitz.conf
+  /home/admin/config.scripts/blitz.conf.sh set ${netprefix}clWatchtowerClient "on"
+
+  source <(/home/admin/_cache.sh get state)
+  if [ "${state}" == "ready" ]; then
+    echo "# Restart the ${netprefix}lightningd.service to activate watchtower-client"
+    sudo systemctl restart ${netprefix}lightningd
+  fi
+
+fi
+
+
+if [ "$1" = off ];then
+  # delete symlink
+  sudo rm -rf /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin}
+
+  # delete watchtower-proxy config line from ${CLCONF}
+  sudo sed -i '/watchtower-proxy=/d' ${CLCONF}
+
+  echo "# Restart the ${netprefix}lightningd.service to deactivate ${plugin}"
+  sudo systemctl restart ${netprefix}lightningd
+
+  # purge
+  if [ "$(echo "$@" | grep -c purge)" -gt 0 ];then
+    echo "# Delete plugin"
+    sudo rm -rf /home/bitcoin/cl-plugins-available/rust-teos*
+  fi
+
+  # setting value in raspi blitz config
+  /home/admin/config.scripts/blitz.conf.sh set ${netprefix}clWatchtowerClient "off"
+  echo "# watchtower-client was uninstalled for ${CHAIN}"
+
+fi
+

--- a/home.admin/config.scripts/cl-plugin.watchtower-client.sh
+++ b/home.admin/config.scripts/cl-plugin.watchtower-client.sh
@@ -19,14 +19,34 @@ source /mnt/hdd/raspiblitz.conf  #to get runBehindTor
 plugin="watchtower-client"
 pkg_dependencies="libssl-dev"
 
+
 if [ "$1" = info ]; then
-    echo "The Eye of Satoshi is a Lightning watchtower compliant with BOLT13, written in Rust."
-    echo ""
-    echo "To connect to a tower, use:"
-    echo "cl registertower <tower_id>"
-    echo ""
-    echo "Links with more info:"
-    echo "https://github.com/talaia-labs/rust-teos/tree/master/watchtower-plugin"
+	whiptail --title "The Eye of Satoshi CLN Watchtower" \
+    --yes-button "Install" \
+		--no-button "Cancel" \
+		--yesno "
+This is a watchtower client plugin to interact with an Eye of Satoshi tower, and
+eventually with any BOLT13 compliant watchtower.
+
+The plugin manages all the client-side logic to send appointment to a number of
+registered towers every time a new commitment transaction is generated.
+It also keeps a summary of the messages sent to the towers and their responses.
+
+Usage:
+
+cl registertower <tower_id>: registers the user id (compressed public key) with a given tower.
+cl gettowerinfo <tower_id>: gets all the locally stored data about a given tower.
+cl retrytower <tower_id>: tries to send pending appointment to a (previously) unreachable tower.
+cl abandontower <tower_id>: deletes all data associated with a given tower.
+cl listtowers: lists all registered towers.
+cl getappointment <tower_id> <locator>: queries a given tower about an appointment.
+cl getsubscriptioninfo <tower_id>: gets the subscription information by querying the tower.
+cl getappointmentreceipt <tower_id> <locator>: pulls a given appointment receipt from the local database.
+cl getregistrationreceipt <tower_id>: pulls the latest registration receipt from the local database.
+
+Links with more info:
+https://github.com/talaia-labs/rust-teos/tree/master/watchtower-plugin
+" 0 0
 fi
 
 

--- a/home.admin/config.scripts/cl-plugin.watchtower-client.sh
+++ b/home.admin/config.scripts/cl-plugin.watchtower-client.sh
@@ -38,7 +38,11 @@ if [ "$1" = "on" ];then
 
   #Cleanup existing
   if [ -d "/home/bitcoin/cl-plugins-available/plugins/${plugin}/" ]; then
-    rm -rf "/home/bitcoin/cl-plugins-available/plugins/${plugin}/"
+    sudo rm -rf "/home/bitcoin/cl-plugins-available/plugins/${plugin}/"
+  fi
+
+  if [ -d "/home/bitcoin/cl-plugins-available/rust-teos/" ]; then
+    sudo rm -rf "/home/bitcoin/cl-plugins-available/rust-teos/"
   fi
 
   #Clone source repository

--- a/home.admin/config.scripts/cl-plugin.watchtower-client.sh
+++ b/home.admin/config.scripts/cl-plugin.watchtower-client.sh
@@ -84,9 +84,11 @@ if [ "$1" = off ];then
 
   # purge
   if [ "$(echo "$@" | grep -c purge)" -gt 0 ];then
-    echo "# Delete plugin"
+    echo "# Delete plugin and source code"
     sudo rm -rf /home/bitcoin/cl-plugins-available/rust-teos*
+    sudo rm -rf /home/bitcoin/cl-plugins-available/${plugin}
   fi
+
 
   # setting value in raspi blitz config
   /home/admin/config.scripts/blitz.conf.sh set ${netprefix}clWatchtowerClient "off"

--- a/home.admin/config.scripts/cl-plugin.watchtower-client.sh
+++ b/home.admin/config.scripts/cl-plugin.watchtower-client.sh
@@ -17,6 +17,7 @@ echo "# cl-plugin.watchtower-client.sh $*"
 source <(/home/admin/config.scripts/network.aliases.sh getvars cl $2)
 source /mnt/hdd/raspiblitz.conf  #to get runBehindTor
 plugin="watchtower-client"
+pkg_dependencies="libssl-dev"
 
 if [ "$1" = info ]; then
     echo "The Eye of Satoshi is a Lightning watchtower compliant with BOLT13, written in Rust."
@@ -44,6 +45,9 @@ if [ "$1" = "on" ];then
   cd /home/bitcoin/cl-plugins-available || exit 1
   sudo -u bitcoin git clone https://github.com/talaia-labs/rust-teos.git
   
+  #Install additional dependencies
+  sudo apt-get install -y ${pkg_dependencies} > /dev/null
+
   #Compile
   cd /home/bitcoin/cl-plugins-available/rust-teos || exit 1
   sudo -u bitcoin /home/bitcoin/.cargo/bin/cargo install --path watchtower-plugin \


### PR DESCRIPTION
This adds a Bonus script and respective Menu items to install the Core Lightning Watchtower client "The Eye of Satoshi", as described in #3394

Status
- [x]  Tested successfully on amd64: install (`cl-plugin.watchtower-client.sh on`) | remove (`cl-plugin.watchtower-client.sh off`) | remove & purge (`cl-plugin.watchtower-client.sh off mainnet purge`)
- [x] Tested enabling/disabling through Menu
- [x]  Test on Raspi hardware (arm)  -- Help wanted
- [ ] Test with parallel testnet and signet enabled



Given this is my first development for the raspiblitz, I encourage review and feedback. In particular

- Am I cloning into the "correct" folder?
- Naming convention of the script and menu entries correct?
- Do we need this https://github.com/rootzoll/raspiblitz/pull/3404/files#diff-88d14d19c5add5919318691f372e9b09f415bdd2d8d62846b0cb2fc4c9f3f501R38-R41 cleanup before cloning?
- Does it make sense to use the `$runBehindTor` var? My itention is to check if this CLN node is tor-only, and if so, also connect the watchtower-client only via TOR. But if `$runBehindTor` setting only aplies to the bitcoind settings, then my check is obviously pointless..  
- Is it ok to use hardcoded value `9050` for TOR port? Or is there some raspi variable I should use instead?
- Should we pin a VERSION of `rust-teos` instead of cloning the latest?
- Are two commits fine, or is it recommended to rebase into one single commit, before opening a PR?

