### PR TITLE
Add staticIP config and fix 127.0.0.1

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -501,6 +501,10 @@ Yellow is OK. The RaspiBlitz can detect that it can reach a service on the port 
 
 For details on how to set port forwarding on your router model see: https://portforward.com
 
+### How can I set a fixed IP?
+
+Add an entry called `staticIP` in `raspiblitz.conf` to prevent external IP detection and force a fixed IP for your node.
+
 ### How do I fix a displayed Error in my Config?
 
 When the LCD display is telling you to do a config check:

--- a/home.admin/config.scripts/internet.dyndomain.sh
+++ b/home.admin/config.scripts/internet.dyndomain.sh
@@ -47,13 +47,17 @@ fi
 # FUNCTION updating dyndomain (if update URL is set)
 updateDynDNS()
 {
-  if [ ${#dynUpdateUrl} -gt 0 ]; then
-    echo "# calling: ${dynUpdateUrl}"
-    echo "# to update domain: ${dynDomain}"
-    curl -s --connect-timeout 6 ${dynUpdateUrl} 1>&2
+  if [ "${staticIP}" == "" ]; then
+    if [ ${#dynUpdateUrl} -gt 0 ]; then
+      echo "# calling: ${dynUpdateUrl}"
+      echo "# to update domain: ${dynDomain}"
+      curl -s --connect-timeout 6 ${dynUpdateUrl} 1>&2
+    else
+      echo "# dynUpdateUrl not set - not updating"
+    fi
   else
-    echo "# dynUpdateUrl not set - not updating"
-  fi 
+    echo "# staticIP is set - not updating"
+  fi
 }
 
 # UPDATE

--- a/home.admin/config.scripts/internet.sh
+++ b/home.admin/config.scripts/internet.sh
@@ -168,18 +168,29 @@ fi
 if [ ${runGlobal} -eq 1 ]; then
 
   ###########################################
+  # Static IP
+  # the static IP to override globalIP and publicIP detection
+  if [ "${staticIP}" != "" ]; then
+    echo "## static IP found: ${staticIP}"
+  fi
+
+  ###########################################
   # Global IP
   # the public IP that can be detected from outside
-  globalIP=""
-  echo "# getting public IP from third party service"
-  if [ "${ipv6}" == "on" ]; then
-    globalIP=$(curl -s -f -S -m 5 http://v6.ipv6-test.com/api/myip.php 2>/dev/null)
+  if [ "${staticIP}" == "" ]; then
+    globalIP=""
+    echo "# getting public IP from third party service"
+    if [ "${ipv6}" == "on" ]; then
+      globalIP=$(curl -s -f -S -m 5 http://v6.ipv6-test.com/api/myip.php 2>/dev/null)
+    else
+      globalIP=$(curl -s -f -S -m 5 http://v4.ipv6-test.com/api/myip.php 2>/dev/null)
+    fi
+    echo "##  curl returned:  ${globalIP}"
+    echo "##  curl exit code: ${?}"
   else
-    globalIP=$(curl -s -f -S -m 5 http://v4.ipv6-test.com/api/myip.php 2>/dev/null)
+    globalIP=${staticIP}
+    echo "##  staticIP as globalIP: ${staticIP}"
   fi
-  echo "##  curl returned:  ${globalIP}"
-  echo "##  curl exit code: ${?}"
-
 
   # sanity check on IP data
   # see https://github.com/rootzoll/raspiblitz/issues/371#issuecomment-472416349
@@ -199,20 +210,34 @@ if [ ${runGlobal} -eq 1 ]; then
     if [ "${ipv6}" == "on" ]; then
       globalIP="::1"
     else
-      globalIP="127.0.0.1"
+      if [ "${staticIP}" == "" ]; then
+        # only if publicIP is empty, dont prefer 127.0.0.1
+        if [ "${publicIP}" != "" ]; then
+          globalIP="${publicIP}"
+        else
+          globalIP="127.0.0.1"
+        fi
+      else
+        globalIP="${staticIP}"
+      fi
     fi
   fi
 
   ##########################################
   # Public IP
-  # the public that is maybe set by raspiblitz config file (overriding aut-detection)
+  # the public that is maybe set by raspiblitz config file (overriding auto-detection)
   if [ "${publicIP}" == "" ]; then
-    # if publicIP is not set by config ... use detected global IP
-    if [ "${ipv6}" == "on" ]; then
-      # use ipv6 with square brackets so that it can be used in http addresses like a IPv4
-      publicIP="[${globalIP}]"
+    if [ "${staticIP}" == "" ]; then
+      # if publicIP is not set by config ... use detected global IP
+      if [ "${ipv6}" == "on" ]; then
+        # use ipv6 with square brackets so that it can be used in http addresses like a IPv4
+        publicIP="[${globalIP}]"
+      else
+        publicIP="${globalIP}"
+      fi
     else
-      publicIP="${globalIP}"
+      # if a static IP was set, use it as public IP
+      publicIP="${staticIP}"
     fi
   fi
 


### PR DESCRIPTION
Add possibility of a staticIP config in Raspiblitz.conf to override globalIP and publicIP detection.

Skip dyndns in case of static ip usage

if curl fails accidentaly it could result in the wrong IP. Only prefer if publicIP is empty.