### PR TITLE
fix localIP assignment and improve SSD detection

### DIFF
--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -163,7 +163,7 @@ if [ "$1" = "status" ]; then
     fi
 
     # try to detect if its an SSD 
-    isSSD=$(sudo smartctl -a /dev/sda | grep 'Rotation Rate' | grep -c "Solid State")
+    isSSD=$(sudo smartctl -a /dev/${hdd} | grep 'Rotation Rate' | grep -c "Solid State")
     echo "isSSD=${isSSD}"
 
     # display results from hdd & partition detection
@@ -384,7 +384,7 @@ if [ "$1" = "status" ]; then
     fi
     echo "hddRaspiVersion='${hddRaspiVersion}'"
 
-    isSSD=$(sudo smartctl -a /dev/sda | grep 'Rotation Rate' | grep -c "Solid State")
+    isSSD=$(sudo smartctl -a /dev/${hdd} | grep 'Rotation Rate' | grep -c "Solid State")
     echo "isSSD=${isSSD}"
 
     echo "datadisk='${hdd}'"

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -63,6 +63,7 @@ isBTRFS=$(btrfs filesystem show 2>/dev/null| grep -c 'BLITZSTORAGE')
 isRaid=$(btrfs filesystem df /mnt/hdd 2>/dev/null | grep -c "Data, RAID1")
 isZFS=$(zfs list 2>/dev/null | grep -c "/mnt/hdd")
 isSSD="0"
+isSMART="0"
 
 # determine if swap is external on or not
 externalSwapPath="/mnt/hdd/swapfile"
@@ -173,9 +174,16 @@ if [ "$1" = "status" ]; then
       echo "# WARNING: found invalid partition (${hddDataPartition}) - redacting"
       hddDataPartition=""
     fi
-
-    # try to detect if its an SSD 
-    isSSD=$(sudo smartctl -a /dev/${hdd} | grep 'Rotation Rate' | grep -c "Solid State")
+    
+    # try to detect if its an SSD
+    isSMART=$(sudo smartctl -a /dev/{hdd} | grep -c "Rotation Rate:")
+    if [ ${isSMART} -gt 0 ]; then
+    	#detect using smartmontools (preferred)
+        isSSD=$(sudo smartctl -a /dev/${hdd} | grep 'Rotation Rate' | grep -c "Solid State")
+    else
+    	#detect using using fall back method
+	isSSD=$(cat /sys/block/${hdd}/queue/rotational 2>/dev/null | grep -c 0)
+    fi 
     echo "isSSD=${isSSD}"
 
     # display results from hdd & partition detection
@@ -396,7 +404,15 @@ if [ "$1" = "status" ]; then
     fi
     echo "hddRaspiVersion='${hddRaspiVersion}'"
 
-    isSSD=$(sudo smartctl -a /dev/${hdd} | grep 'Rotation Rate' | grep -c "Solid State")
+    # try to detect if its an SSD
+    isSMART=$(sudo smartctl -a /dev/{hdd} | grep -c "Rotation Rate:")
+    if [ ${isSMART} -gt 0 ]; then
+    	#detect using smartmontools
+        isSSD=$(sudo smartctl -a /dev/${hdd} | grep 'Rotation Rate' | grep -c "Solid State")
+    else
+    	#detect using fall back
+	isSSD=$(cat /sys/block/${hdd}/queue/rotational 2>/dev/null | grep -c 0)
+    fi
     echo "isSSD=${isSSD}"
 
     echo "datadisk='${hdd}'"

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -163,7 +163,7 @@ if [ "$1" = "status" ]; then
     fi
 
     # try to detect if its an SSD 
-    isSSD=$(cat /sys/block/${hdd}/queue/rotational 2>/dev/null | grep -c 0)
+    isSSD=$(sudo smartctl -a /dev/sda | grep 'Rotation Rate' | grep -c "Solid State")
     echo "isSSD=${isSSD}"
 
     # display results from hdd & partition detection
@@ -384,7 +384,7 @@ if [ "$1" = "status" ]; then
     fi
     echo "hddRaspiVersion='${hddRaspiVersion}'"
 
-    isSSD=$(cat /sys/block/${hdd}/queue/rotational 2>/dev/null | grep -c 0)
+    isSSD=$(sudo smartctl -a /dev/sda | grep 'Rotation Rate' | grep -c "Solid State")
     echo "isSSD=${isSSD}"
 
     echo "datadisk='${hdd}'"

--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -38,6 +38,18 @@ if [ ${btrfsInstalled} -eq 0 ]; then
   exit 1
 fi
 
+# install smartmontools if needed
+smartmontoolsInstalled=$(dpkg -s smartmontools 2>/dev/null | grep -c "install ok installed")
+if [ ${smartmontoolsInstalled} -eq 0 ]; then
+  >&2 echo "# Installing smartmontools ..."
+  apt-get install -y smartmontools 1>/dev/null
+fi
+smartmontoolsInstalled=$(dpkg -s smartmontools 2>/dev/null | grep -c "install ok installed")
+if [ ${smartmontoolsInstalled} -eq 0 ]; then
+  echo "error='missing smartmontools package'"
+  exit 1
+fi
+
 ###################
 # STATUS
 ###################

--- a/home.admin/config.scripts/cl-plugin.sparko.sh
+++ b/home.admin/config.scripts/cl-plugin.sparko.sh
@@ -24,7 +24,7 @@ source <(/home/admin/config.scripts/network.aliases.sh getvars cl $2)
 if [ "$1" = "menu" ]; then
 
   # get network info
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/${netprefix}sparko/hostname)
   toraddresstext="Hidden Service address for the Tor Browser (QRcode on LCD):\n$toraddress"
   if [ ${#toraddress} -eq 0 ];then
@@ -51,7 +51,7 @@ ${toraddresstext}
 fi
 
 if [ $1 = connect ];then
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/${netprefix}sparko/hostname)
   accesskey=$(sudo cat ${CLCONF} | grep "^sparko-keys=" | cut -d= -f2 | cut -d';' -f1)
   url="https://${localip}:${portprefix}9000/"

--- a/home.admin/config.scripts/cl.rest.sh
+++ b/home.admin/config.scripts/cl.rest.sh
@@ -36,7 +36,7 @@ if [ "$1" = connect ];then
 
   echo "# Allowing port ${portprefix}6100 through the firewall"
   sudo ufw allow "${portprefix}6100" comment "${netprefix}clrest" 1>/dev/null
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   # hidden service to https://xx.onion
   /home/admin/config.scripts/tor.onion-service.sh ${netprefix}clrest 443 ${portprefix}6100 1>/dev/null
 

--- a/home.admin/config.scripts/cl.spark.sh
+++ b/home.admin/config.scripts/cl.spark.sh
@@ -22,7 +22,7 @@ systemdService="${netprefix}spark"
 if [ "$1" = "menu" ]; then
 
   # get network info
-  localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+  localip=$(hostname -I | awk '{print $1}')
   toraddress=$(sudo cat /mnt/hdd/tor/${netprefix}spark-wallet/hostname)
   toraddresstext="Hidden Service address for the Tor Browser (QRcode on LCD):\n$toraddress"
   if [ ${#toraddress} -eq 0 ];then

--- a/home.admin/config.scripts/internet.selfsignedcert.sh
+++ b/home.admin/config.scripts/internet.selfsignedcert.sh
@@ -6,7 +6,7 @@ sudo -u bitcoin mkdir /mnt/hdd/app-data/selfsignedcert
 cd /mnt/hdd/app-data/selfsignedcert || exit 1
 
 echo "# Create a self signed SSL certificate"
-localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+localip=$(hostname -I | awk '{print $1}')
 
 sudo -u bitcoin openssl genrsa -out selfsigned.key 2048
 #https://www.humankode.com/ssl/create-a-selfsigned-certificate-for-nginx-in-5-minutes

--- a/home.admin/config.scripts/internet.wifi.sh
+++ b/home.admin/config.scripts/internet.wifi.sh
@@ -11,7 +11,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
 fi
 
 wifiIsSet=$(sudo cat /etc/wpa_supplicant/wpa_supplicant.conf 2>/dev/null| grep -c "network=")
-wifiLocalIP=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep -E -i '([wlan][0-9]$)' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
+wifiLocalIP=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep -E -i '([wlan][0-9]$)*' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')
 connected=0
 if [ ${#wifiLocalIP} -gt 0 ]; then
   connected=1


### PR DESCRIPTION
**Fix localip assignment**:
use `localip=$(hostname -I | awk '{print $1}')` instead of `localip=$(ip addr | grep 'state UP' -A2 | grep -E -v 'docker0|veth' | grep 'eth0\|wlan0\|enp0' | tail -n1 | awk '{print $2}' | cut -f1 -d'/')`.  The former assignment seems to work on a wider range of hardware.
related: https://github.com/rootzoll/raspiblitz/commit/5d61d0b216b281ff7b99e0488c39390d1d5e038c#commitcomment-89042523

**Improve reliability of solid state drive detection**:
smartctl seems to be more compatible with a wider array of hardware.
`isSSD=$(cat /sys/block/${hdd}/queue/rotational 2>/dev/null | grep -c 0)` incorrectly sets SSD to false for Odroid HC2.  `isSSD=$(sudo smartctl -a /dev/sda | grep 'Rotation Rate' | grep -c "Solid State")` correctly identifies the SSD.
Related issue: https://github.com/rootzoll/raspiblitz/issues/3423#issue-1439092806