### PR TITLE
lit update to v0.8.3-alpha

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,8 @@
 ## What's new in Version 1.8.1 of RaspiBlitz?
 
 - New: Support of X708 UPS HAT [details](https://github.com/rootzoll/raspiblitz/pull/3087)
-- Update: LND v0.15.3 [details](https://github.com/lightningnetwork/lnd/releases/tag/v0.15.3-beta
+- Update: LND v0.15.4 [details](https://github.com/lightningnetwork/lnd/releases/tag/v0.15.4-beta
+- Update: Lightning Terminal v0.8.3-alpha [details](https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.8.3-alpha)
 - Update: Core Lightning v0.12.1 [details](https://github.com/ElementsProject/lightning/releases/tag/v0.12.1)
 - Update: RTL v0.13.0 with update option [details](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.12.3)
 - Update: Thunderhub v0.13.16 with balance sharing disabled [details](https://github.com/apotdevin/thunderhub/releases/tag/v0.13.16)
@@ -12,6 +13,7 @@
 - Update: Jam (JoinMarket Web UI) v0.1.2 [details](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.1.0)
 - Update: JoinMarket v0.9.8 [details](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.8)
 - Update: JoininBox v0.7.4 [details](https://github.com/openoms/joininbox/releases/tag/v0.7.3)
+- Update: Electrum Server in Rust (electrs) v0.9.9 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#099-jul-12-2022)
 - Info: Run RaspiBlitz on Proxmox [details](https://github.com/rootzoll/raspiblitz/tree/dev/alternative.platforms/Proxmox)
 
 ## What's new in Version 1.8.0c of RaspiBlitz?

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -186,7 +186,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
     echo "# check binary was not manipulated (checksum test)"
     wget -N https://github.com/lightninglabs/lightning-terminal/releases/download/v${LITVERSION}/manifest-v${LITVERSION}.sig
-    wget --no-check-certificate ${PGPpkeys}
+    wget --no-check-certificate -O ./pgp_keys.asc ${PGPpkeys}
     binaryChecksum=$(sha256sum ${binaryName} | cut -d " " -f1)
     if [ "${binaryChecksum}" != "${SHA256}" ]; then
       echo "# FAIL # Downloaded LiT BINARY not matching SHA256 checksum: ${SHA256}"

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/lightninglabs/lightning-terminal/releases
-LITVERSION="0.7.0-alpha"
+LITVERSION="0.8.3-alpha"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -12,13 +12,16 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
 fi
 
 # check who signed the release in https://github.com/lightninglabs/lightning-terminal/releases
-PGPsigner="guggero"
+PGPsigner="ellemouton"
 
-if [ $PGPsigner = guggero ];then
-  PGPpkeys="https://keybase.io/guggero/pgp_keys.asc"
+if [ $PGPsigner = ellemouton ];then
+  PGPpkeys="https://github.com/${PGPsigner}.gpg"
+  PGPcheck="D7D916376026F177"
+elif [ $PGPsigner = guggero ];then
+  PGPpkeys="https://keybase.io/${PGPsigner}/pgp_keys.asc"
   PGPcheck="03DB6322267C373B"
 elif [ $PGPsigner = roasbeef ];then
-  PGPpkeys="https://keybase.io/roasbeef/pgp_keys.asc "
+  PGPpkeys="https://keybase.io/${PGPsigner}/pgp_keys.asc "
   PGPcheck="3BBD59E99B280306"
 fi
 


### PR DESCRIPTION
The qustion here if really should stop running Lit over Tor?

This was to torify the Lightning Connect tunnel, but given the current state of Tor this might not make sense any more. 

Remember discussing with @kaloudis that the LN node ID is not exposed to the ligthning connect proxy server so it would not be assosiated with the IP address, right?