### PR TITLE
dev: add codeowners file for branch protection

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# For info see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, these users will be requested for review when someone opens a pull request.
+
+* @rootzoll @openoms


### PR DESCRIPTION
This adds a `CODEOWNERS` file.

This has the following function:

- the people mentioned in there get assigned as reviewers on PRs.
- You can protect the repository from other contributors merging things by requiring a review from the codeowners, see the screenshot below:

![image](https://user-images.githubusercontent.com/9399034/201171392-a3487c28-b214-4cc0-9de8-52c5d41fb02e.png)


For more info see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
