### PR TITLE
blitzapi: fix permissions

### DIFF
--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -276,6 +276,7 @@ if [ "$1" = "update-code" ]; then
   if [ "${apiActive}" != "0" ]; then
     echo "# Update Web API CODE"
     systemctl stop blitzapi
+    sudo chown -R blitzapi:blitzapi /home/blitzapi/blitz_api
     cd /home/blitzapi/blitz_api
     currentBranch=$(sudo -u blitzapi git rev-parse --abbrev-ref HEAD)
     echo "# updating local repo ..."


### PR DESCRIPTION
After set to venv and user blitzapi, it could be owned by root. Fix permissions with chown to blitzapi user for update-code.