### PR TITLE
#3272 blitz_api change to dev branch

### DIFF
--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -7,7 +7,7 @@
 
 # NORMALLY user/repo/version will be defined by calling script - see build_sdcard.sh
 # the following is just a fallback to try during development if script given branch does not exist
-FALLACK_BRANCH="refactor_system"
+FALLACK_BRANCH="dev"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ "$1" = "-help" ]; then


### PR DESCRIPTION
part of #3272 - merge as soon branch `refactor_system` got renamed to `dev` and `blitz-v1.9` is available - see:
https://github.com/fusion44/blitz_api/branches