### PR TITLE
#2891 seperation of install/on joinmarket

### DIFF
--- a/home.admin/config.scripts/bonus.jam.sh
+++ b/home.admin/config.scripts/bonus.jam.sh
@@ -25,7 +25,7 @@ fi
 
 # check and load raspiblitz config to know which network is running
 source $RASPIBLITZ_INFO
-source $RASPIBLITZ_CONF
+source $RASPIBLITZ_CONF 2>/dev/null
 
 # check if already installed & active
 isInstalled=$(compgen -u | grep -c ${USERNAME})

--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -44,20 +44,11 @@ PGPsigner="openoms"
 PGPpubkeyLink="https://github.com/openoms.gpg"
 PGPpubkeyFingerprint="13C688DB5B9C745DE4D2E4545BFB77609B081B65"
 
-source /mnt/hdd/raspiblitz.conf
+source /mnt/hdd/raspiblitz.conf 2>/dev/null
 
 # switch on
 if [ "$1" = "install" ]; then
   echo "# INSTALL JOINMARKET"
-
-  # check if running Tor
-  if [ ${runBehindTor} = on ]; then
-    echo "# OK, running behind Tor"
-  else
-    echo "# Not running Tor"
-    echo "# Activate Tor from the SERVICES menu before installing JoinMarket."
-    exit 1
-  fi
 
   # make sure the Bitcoin Core wallet is on
   /home/admin/config.scripts/network.wallet.sh on
@@ -87,11 +78,9 @@ if [ "$1" = "install" ]; then
     echo "# add the 'joinmarket' user"
     adduser --disabled-password --gecos "" joinmarket
 
-    echo "# setting PASSWORD_B as the password for the 'joinmarket' user"
-    PASSWORD_B=$(sudo cat /mnt/hdd/${network}/${network}.conf | grep rpcpassword | cut -c 13-)
-    echo "joinmarket:$PASSWORD_B" | sudo chpasswd
     # add to sudo group (required for installation)
     adduser joinmarket sudo
+
     # configure sudo for usage without password entry for the joinmarket user
     echo 'joinmarket ALL=(ALL) NOPASSWD:ALL' | EDITOR='tee -a' visudo
 
@@ -148,16 +137,10 @@ if [ "$1" = "install" ]; then
       echo "AllowOutboundLocalhost 1" | sudo tee -a /etc/tor/torsocks.conf
       sudo systemctl reload tor@default
     fi
+  
     # joinin.conf settings
     sudo -u joinmarket touch /home/joinmarket/joinin.conf
-    # add default Tor value to joinin.conf if needed
-    if ! grep -Eq "^runBehindTor" /home/joinmarket/joinin.conf; then
-      echo "runBehindTor=off" | sudo -u joinmarket tee -a /home/joinmarket/joinin.conf
-    fi
-    # setting Tor value in joinin config
-    if grep -Eq "^runBehindTor=on" /mnt/hdd/raspiblitz.conf; then
-      sudo -u joinmarket sed -i "s/^runBehindTor=.*/runBehindTor=on/g" /home/joinmarket/joinin.conf
-    fi
+    sudo -u joinmarket sed -i "s/^runBehindTor=.*/runBehindTor=on/g" /home/joinmarket/joinin.conf
 
     echo
     echo "##########"
@@ -209,11 +192,25 @@ fi
 # switch on
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
+  # check if running Tor
+  if [ "${runBehindTor}" = "on" ]; then
+    echo "# OK, running behind Tor"
+  else
+    echo "# Not running Tor"
+    echo "# Activate Tor from the SERVICES menu before installing JoinMarket."
+    exit 1
+  fi
+
   if [ -f /home/joinmarket/start.joininbox.sh ]; then
     echo "# Ok, Joininbox is present"
   else
     sudo /home/admin/config.scrips/bonus.joinmarket.sh install
   fi
+
+  # set password B
+  echo "# setting PASSWORD_B as the password for the 'joinmarket' user"
+  PASSWORD_B=$(sudo cat /mnt/hdd/${network}/${network}.conf | grep rpcpassword | cut -c 13-)
+  echo "joinmarket:$PASSWORD_B" | sudo chpasswd
 
   # configure joinmarket (includes a check if it is installed)
   if sudo -u joinmarket /home/joinmarket/start.joininbox.sh; then

--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -50,25 +50,6 @@ source /mnt/hdd/raspiblitz.conf 2>/dev/null
 if [ "$1" = "install" ]; then
   echo "# INSTALL JOINMARKET"
 
-  # make sure the Bitcoin Core wallet is on
-  /home/admin/config.scripts/network.wallet.sh on
-  if [ $(/usr/local/bin/bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf listwallets | grep -c wallet.dat) -eq 0 ];then
-    echo "# Create a non-descriptor wallet.dat"
-    /usr/local/bin/bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf -named createwallet wallet_name=wallet.dat descriptors=false
-  else
-    isDescriptor=$(/usr/local/bin/bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf -rpcwallet=wallet.dat getwalletinfo | grep -c '"descriptors": true,')
-    if [ "$isDescriptor" -gt 0 ]; then
-      # unload
-      bitcoin-cli unloadwallet wallet.dat
-      echo "# Move the wallet.dat with descriptors to /mnt/hdd/bitcoin/descriptors"
-      sudo mv /mnt/hdd/bitcoin/wallet.dat /mnt/hdd/bitcoin/descriptors
-      echo "# Create a non-descriptor wallet.dat"
-      bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf -named createwallet wallet_name=wallet.dat descriptors=false
-    else
-      echo "# The non-descriptor wallet.dat is loaded in bitcoind."
-    fi
-  fi
-
   if [ -f "/home/joinmarket/joinmarket-clientserver/jmvenv/bin/activate" ]; then
     echo "JoinMarket is already installed"
   else
@@ -205,6 +186,25 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     echo "# Ok, Joininbox is present"
   else
     sudo /home/admin/config.scrips/bonus.joinmarket.sh install
+  fi
+
+  # make sure the Bitcoin Core wallet is on
+  /home/admin/config.scripts/network.wallet.sh on
+  if [ $(/usr/local/bin/bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf listwallets | grep -c wallet.dat) -eq 0 ];then
+    echo "# Create a non-descriptor wallet.dat"
+    /usr/local/bin/bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf -named createwallet wallet_name=wallet.dat descriptors=false
+  else
+    isDescriptor=$(/usr/local/bin/bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf -rpcwallet=wallet.dat getwalletinfo | grep -c '"descriptors": true,')
+    if [ "$isDescriptor" -gt 0 ]; then
+      # unload
+      bitcoin-cli unloadwallet wallet.dat
+      echo "# Move the wallet.dat with descriptors to /mnt/hdd/bitcoin/descriptors"
+      sudo mv /mnt/hdd/bitcoin/wallet.dat /mnt/hdd/bitcoin/descriptors
+      echo "# Create a non-descriptor wallet.dat"
+      bitcoin-cli -conf=/mnt/hdd/bitcoin/bitcoin.conf -named createwallet wallet_name=wallet.dat descriptors=false
+    else
+      echo "# The non-descriptor wallet.dat is loaded in bitcoind."
+    fi
   fi
 
   # set password B

--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -60,7 +60,7 @@ if [ "$1" = "install" ]; then
     adduser --disabled-password --gecos "" joinmarket
 
     # add to sudo group (required for installation)
-    adduser joinmarket sudo
+    adduser joinmarket sudo || exit 1
 
     # configure sudo for usage without password entry for the joinmarket user
     echo 'joinmarket ALL=(ALL) NOPASSWD:ALL' | EDITOR='tee -a' visudo


### PR DESCRIPTION
`install` will run during sdcard build - where no HDD/SSD is available yet. This PR contains the most obvious fixes to spereate install & config more deeply - details see: https://github.com/rootzoll/raspiblitz/issues/2891#issuecomment-1358345174