### PR TITLE
reduce arm64-rpi image size to 28G

### DIFF
--- a/ci/arm64-rpi/arm64-rpi.pkr.hcl
+++ b/ci/arm64-rpi/arm64-rpi.pkr.hcl
@@ -27,7 +27,7 @@ source "arm" "raspiblitz-arm64-rpi" {
     type         = "83"
   }
   image_path                   = "raspiblitz-arm64-rpi-${var.pack}.img"
-  image_size                   = "30G"
+  image_size                   = "28G"
   image_type                   = "dos"
   qemu_binary_destination_path = "/usr/bin/qemu-arm-static"
   qemu_binary_source_path      = "/usr/bin/qemu-arm-static"


### PR DESCRIPTION
related: #3053