### PR TITLE
Add LNDg to blitz.debug.sh

### DIFF
--- a/home.admin/config.scripts/blitz.debug.sh
+++ b/home.admin/config.scripts/blitz.debug.sh
@@ -314,6 +314,39 @@ else
   echo "- LIT is OFF by config"
 fi
 
+if [ "${lndg}" == "on" ]; then
+  echo
+  echo "*** LNDg Status ***"
+  sudo /home/admin/config.scripts/bonus.lndg.sh status
+  echo
+  echo "*** LNDg JOBS SYSTEMD STATUS ***"
+  sudo systemctl status jobs-lndg.service -n2 --no-pager
+  echo "sudo tail -n 5 lnd_jobs_error.log"
+  sudo tail -n 5 lnd_jobs_error.log
+  echo
+  echo "*** LNDg REBALANCER SYSTEMD STATUS ***"
+  sudo systemctl status rebalancer-lndg.service -n2 --no-pager
+  echo "sudo tail -n 5 lnd_rebalancer_error.log"
+  sudo tail -n 5 lnd_rebalancer_error.log
+  echo
+  echo "*** LNDg HTLC-STREAM SYSTEMD STATUS ***"
+  sudo systemctl status htlc-stream-lndg.service -n2 --no-pager
+  echo "sudo tail -n 5 lnd_htlc_stream_error.log"
+  sudo tail -n 5 lnd_htlc_stream_error.log
+  echo
+  echo "*** LNDg GUNICORN SERVER SYSTEMD STATUS ***"
+  sudo systemctl status gunicorn.service -n2 --no-pager
+  echo "sudo tail -n 5 gunicorn_error.log"
+  sudo tail -n 5 gunicorn_error.log
+  echo
+  echo "*** LAST 10 LNDg LOGS ***"
+  echo "sudo journalctl -u lndg -b --no-pager -n10"
+  sudo journalctl -u lndg -b --no-pager -n20
+  echo
+else
+  echo "- LNDg is OFF by config"
+fi
+
 if [ "${BTCPayServer}" == "on" ]; then
   echo
   echo "*** LAST 20 BTCPayServer LOGS ***"

--- a/home.admin/config.scripts/blitz.debug.sh
+++ b/home.admin/config.scripts/blitz.debug.sh
@@ -321,23 +321,23 @@ if [ "${lndg}" == "on" ]; then
   echo
   echo "*** LNDg JOBS SYSTEMD STATUS ***"
   sudo systemctl status jobs-lndg.service -n2 --no-pager
-  echo "sudo tail -n 5 lnd_jobs_error.log"
-  sudo tail -n 5 lnd_jobs_error.log
+  echo "sudo tail -n 5 /var/log/lnd_jobs_error.log"
+  sudo tail -n 5 /var/log/lnd_jobs_error.log
   echo
   echo "*** LNDg REBALANCER SYSTEMD STATUS ***"
   sudo systemctl status rebalancer-lndg.service -n2 --no-pager
-  echo "sudo tail -n 5 lnd_rebalancer_error.log"
-  sudo tail -n 5 lnd_rebalancer_error.log
+  echo "sudo tail -n 5 /var/log/lnd_rebalancer_error.log"
+  sudo tail -n 5 /var/log/lnd_rebalancer_error.log
   echo
   echo "*** LNDg HTLC-STREAM SYSTEMD STATUS ***"
   sudo systemctl status htlc-stream-lndg.service -n2 --no-pager
-  echo "sudo tail -n 5 lnd_htlc_stream_error.log"
-  sudo tail -n 5 lnd_htlc_stream_error.log
+  echo "sudo tail -n 5 /var/log/lnd_htlc_stream_error.log"
+  sudo tail -n 5 /var/log/lnd_htlc_stream_error.log
   echo
   echo "*** LNDg GUNICORN SERVER SYSTEMD STATUS ***"
   sudo systemctl status gunicorn.service -n2 --no-pager
-  echo "sudo tail -n 5 gunicorn_error.log"
-  sudo tail -n 5 gunicorn_error.log
+  echo "sudo tail -n 5 /var/log/gunicorn_error.log"
+  sudo tail -n 5 /var/log/gunicorn_error.log
   echo
   echo "*** LAST 10 LNDg LOGS ***"
   echo "sudo journalctl -u lndg -b --no-pager -n10"

--- a/home.admin/config.scripts/bonus.lndg.sh
+++ b/home.admin/config.scripts/bonus.lndg.sh
@@ -243,7 +243,7 @@ ExecStart=/home/lndg/lndg/.venv/bin/gunicorn lndg.wsgi -w 4 -b 0.0.0.0:8889
 Restart=always
 KillSignal=SIGQUIT
 Type=notify
-StandardError=syslog
+StandardError=append:/var/log/gunicorn_error.log
 NotifyAccess=all
 RestartSec=60s
 


### PR DESCRIPTION
Adds LNDg app to blitz.debug.sh for troubleshooting. Separates log output for gunicorn.service for easy debugging.