### PR TITLE
prevent displaying 100.00%, although incorrect because of rounding

### DIFF
--- a/home.admin/config.scripts/bitcoin.monitor.sh
+++ b/home.admin/config.scripts/bitcoin.monitor.sh
@@ -156,11 +156,12 @@ if [ "$2" = "info" ]; then
   btc_blocks_behind=$((${btc_blocks_headers} - ${btc_blocks_verified}))
   btc_sync_initialblockdownload=$(echo "${blockchaininfo}" | jq -r '.initialblockdownload' | grep -c 'true')
   btc_sync_progress=$(echo "${blockchaininfo}" | jq -r '.verificationprogress')
-  btc_sync_percentage=$(echo ${btc_sync_progress} | awk '{printf( "%.2f%%", 100 * $1)}')
-  if [ "${btc_blocks_headers}" != "" ]  && [ "${btc_blocks_headers}" == "${btc_blocks_verified}" ]; then
+  if (( $(awk 'BEGIN { print( '${btc_sync_progress}'<0.99995 ) }') )); then
+    # #3620 prevent displaying 100.00%, although incorrect because of rounding
+    btc_sync_percentage=$(awk 'BEGIN { printf( "%.2f%%", 100 * '${btc_sync_progress}') }')
+  elif [ "${btc_blocks_headers}" != "" ] && [ "${btc_blocks_headers}" == "${btc_blocks_verified}" ]; then
     btc_sync_percentage="100.00"
-  elif [ "${btc_blocks_headers}" != "" ] && [ "${btc_blocks_behind}" != "" ] && [ ${btc_blocks_behind} -lt 50 ]; then
-    # #3620 prevent that on catching the last 50 blocks its already 100.00% 
+  else
     btc_sync_percentage="99.99"
   fi
 


### PR DESCRIPTION
Before it could happen that during sync progress it is displayed 100.00% although it really is below 100 (rounded up), see #3620.

https://github.com/rootzoll/raspiblitz/commit/0012aea9213fcb5f8d5676aca1cb5354380c7819
 is not perfect, because in a few years it will happen that it displays 100.00% and then comes back to 99.99%.

This fix prevents that it displays 100.00% if the progress reported by bitcoind is greater or equal 0.99995 but not yet done syncing/verifying. I tested that Bash is able to compare float numbers like this and it does display 100.00% even if the progress reported by bitcoind is not exactly 1 (as you mentioned this can happen).