### PR TITLE
Bugfix: bad subsititution

### DIFF
--- a/home.admin/config.scripts/bonus.go.sh
+++ b/home.admin/config.scripts/bonus.go.sh
@@ -28,7 +28,7 @@ case "$1" in
     goOSversion=$(dpkg --print-architecture)
     if [ ${goOSversion} = "armv6l" ]; then
       checksum=${armv6lChecksum}
-    elif [ ${goOSversion{} = "arm64" ]; then
+    elif [ ${goOSversion} = "arm64" ]; then
       checksum=${arm64Checksum}
     elif [ ${goOSversion} = "amd64" ]; then
       checksum=${amd64Checksum}


### PR DESCRIPTION
Fix for error:

/home/admin/config.scripts/bonus.go.sh: line 31: ${goOSversion{}: bad substitution