### PR TITLE
cln: use default normal feerate to withdraw all

### DIFF
--- a/home.admin/BBcashoutWallet.sh
+++ b/home.admin/BBcashoutWallet.sh
@@ -97,7 +97,7 @@ echo "******************************"
 # execute command
 if [ ${LNTYPE} = "cl" ];then
   # withdraw destination satoshi [feerate] [minconf] [utxos]
-  command="$lightningcli_alias withdraw ${address} all slow"
+  command="$lightningcli_alias withdraw ${address} all"
 elif [ ${LNTYPE} = "lnd" ];then
   command="$lncli_alias sendcoins --sweepall --addr=${address} --conf_target=36"
 fi


### PR DESCRIPTION
Use the default normal feerate to avoid:

```
lightning-cli withdraw bc1q.......... all slow

Result: {                                                                                                                                                     
   "code": -1,                                                                                                                                                
   "message": "Error broadcasting transaction: error code: -26\\nerror message:\\nmin relay fee not met, 110 < 111. Unsent tx discarded 0200............."                                                                                                         
}                                                                                                                                                             
```

Related: https://github.com/ElementsProject/lightning/issues/5995