### PR TITLE
btcpay update v1.8.2, postgres database fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 - Update: RTL v0.13.0 with update option [details](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.12.3)
 - Update: Thunderhub v0.13.16 with balance sharing disabled [details](https://github.com/apotdevin/thunderhub/releases/tag/v0.13.16)
 - Update: LNbits 0.9.6 [details](https://github.com/lnbits/lnbits-legend/releases/tag/0.9.6)
-- Update: BTCPayServer 1.7.5 (using postgres for new installs) [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.7.5)
+- Update: BTCPayServer 1.8.0 (using postgres for new installs) [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.7.5)
 - Update: ItchySats 0.7.0 [details](https://github.com/itchysats/itchysats/releases/tag/0.7.0)
 - Update: Channel Tools (chantools) v0.10.5 [details](https://github.com/guggero/chantools/releases/tag/v0.10.5)
 - Update: JoinMarket v0.9.9 [details](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.9)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@
 - Update: RTL v0.13.0 with update option [details](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.12.3)
 - Update: Thunderhub v0.13.16 with balance sharing disabled [details](https://github.com/apotdevin/thunderhub/releases/tag/v0.13.16)
 - Update: LNbits 0.9.6 [details](https://github.com/lnbits/lnbits-legend/releases/tag/0.9.6)
-- Update: BTCPayServer 1.8.0 (using postgres for new installs) [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.7.5)
+- Update: BTCPayServer 1.8.2 (using postgres for new installs) [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.8.2)
 - Update: ItchySats 0.7.0 [details](https://github.com/itchysats/itchysats/releases/tag/0.7.0)
 - Update: Channel Tools (chantools) v0.10.5 [details](https://github.com/guggero/chantools/releases/tag/v0.10.5)
 - Update: JoinMarket v0.9.9 [details](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.9)

--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -3,9 +3,9 @@
 # Based on: https://gist.github.com/normandmickey/3f10fc077d15345fb469034e3697d0d0
 
 # https://github.com/dgarage/NBXplorer/tags
-NBXplorerVersion="v2.3.59"
+NBXplorerVersion="v2.3.62"
 # https://github.com/btcpayserver/btcpayserver/releases
-BTCPayVersion="v1.7.5"
+BTCPayVersion="v1.8.0"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -31,7 +31,7 @@ function NBXplorerConfig() {
     echo "# nbxplorermainnet database already exists"
   else
     echo "# Generate the database for nbxplorer"
-    sudo -u postgres psql -c "create database nbxplorermainnet;"
+    sudo -u postgres psql -c "CREATE DATABASE nbxplorermainnet TEMPLATE template0 LC_CTYPE 'C' LC_COLLATE 'C' ENCODING 'UTF8';"
     sudo -u postgres psql -c "create user nbxplorer with encrypted password 'raspiblitz';"
     sudo -u postgres psql -c "grant all privileges on database nbxplorermainnet to nbxplorer;"
   fi
@@ -68,7 +68,7 @@ function BtcPayConfig() {
       echo "# btcpaymainnet database already exists"
     else
       echo "# Generate the database for btcpay"
-      sudo -u postgres psql -c "create database btcpaymainnet;"
+      sudo -u postgres psql -c "CREATE DATABASE btcpaymainnet TEMPLATE template0 LC_CTYPE 'C' LC_COLLATE 'C' ENCODING 'UTF8';"
       sudo -u postgres psql -c "create user btcpay with encrypted password 'raspiblitz';"
       sudo -u postgres psql -c "grant all privileges on database btcpaymainnet to btcpay;"
     fi
@@ -696,6 +696,8 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
     echo "# deleting data"
     sudo -u postgres psql -c "drop database nbxplorermainnet;"
     sudo -u postgres psql -c "drop user nbxplorer;"
+    sudo -u postgres psql -c "drop database btcpaymainnet;"
+    sudo -u postgres psql -c "drop user btcpay;"
     sudo rm -R /mnt/hdd/app-data/.btcpayserver/
   else
     echo "# keeping data"

--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -5,7 +5,7 @@
 # https://github.com/dgarage/NBXplorer/tags
 NBXplorerVersion="v2.3.62"
 # https://github.com/btcpayserver/btcpayserver/releases
-BTCPayVersion="v1.8.0"
+BTCPayVersion="v1.8.2"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then


### PR DESCRIPTION
btcpay update and database creation modified to follow:
https://docs.btcpayserver.org/BTCPayServer/db-migration/

migration is not done yet automatically for old sqlite instances - will test migrating an old store first

cc @NicolasDorier

covers #3701 