### PR TITLE
Remove extra open bracket in line 31 of bonus.go.sh

### DIFF
--- a/home.admin/config.scripts/bonus.go.sh
+++ b/home.admin/config.scripts/bonus.go.sh
@@ -28,7 +28,7 @@ case "$1" in
     goOSversion=$(dpkg --print-architecture)
     if [ ${goOSversion} = "armv6l" ]; then
       checksum=${armv6lChecksum}
-    elif [ ${goOSversion{} = "arm64" ]; then
+    elif [ ${goOSversion} = "arm64" ]; then
       checksum=${arm64Checksum}
     elif [ ${goOSversion} = "amd64" ]; then
       checksum=${amd64Checksum}


### PR DESCRIPTION
Line 31, `elif [ ${goOSversion{} = "arm64" ]; then` has an extra open bracket causing the script to fail if arm64 is the local architecture and this line is executed. Removing the extra bracket will fix the code.