### PR TITLE
[v1.8] fix c-lightning installation

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -787,6 +787,7 @@ if ${fatpack}; then
 
   # set build code as new default
   sudo rm -r /home/admin/assets/nginx/www_public
+  mkdir -p /home/admin/assets/nginx/www_public
   sudo cp -a /home/blitzapi/blitz_web/build/* /home/admin/assets/nginx/www_public
   sudo chown admin:admin /home/admin/assets/nginx/www_public
   sudo rm -r /home/blitzapi/blitz_web/build/*

--- a/home.admin/config.scripts/cl-plugin.cln-grpc.sh
+++ b/home.admin/config.scripts/cl-plugin.cln-grpc.sh
@@ -35,6 +35,8 @@ function buildGRPCplugin() {
       echo "* Adding Core Lightning ..."
       /home/admin/config.scripts/cl.install.sh install || exit 1
     fi
+    # install required dependency
+    sudo apt-get install protobuf-compiler -y
     # rust for cln-grpc, includes rustfmt
     sudo -u bitcoin curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
      sudo -u bitcoin sh -s -- -y

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -67,7 +67,11 @@ function buildAndInstallCLbinaries()
   sudo -u bitcoin make
   echo
   echo "- Install to /usr/local/bin/"
-  sudo make install || exit 1
+  sudo chown -R root:root $(pwd)
+  sudo make install
+  err=$?
+  sudo chown -R bitcoin:bitcoin $(pwd)
+  [ $err -eq 0 ] || exit 1
 }
 
 if [ "$1" = "install" ]; then


### PR DESCRIPTION
Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [ ] That its based against the `dev` brach - not the default release branch. 

^^ NO: This is a bug in the current release, I intend for this to go to the current branch.


Since a security update in git, `sudo make install` will fail due to a line in the makefile at the top that tries to work out the version of the git repository before executing the named command.

Related issue here: https://github.com/ElementsProject/lightning/issues/5189

I looked at a few options:
- ```git config --system --add safe.directory `pwd`'/*'```: This line does not work as git treats `*` as a special character, not a glob.
- ```git config --system --add safe.directory '*'```: works, but feels like a sledge hammer and is hard to reverse without making assumptions about what is already configured.

This PR simply `chown`s the directory (recursively) to `root` and then reverses the action after to `bitcoin`. Git will not reject commands if the folder is owned by the caller of git which in this case is `root`.

I also delayed the `exit 1` step to allow re-assigning `chown` to `bitcoin` before exiting.
