### PR TITLE
fix reverse proxy issue, bind to 0.0.0.0 on ExecStart

### DIFF
--- a/home.admin/config.scripts/bonus.lnbits.sh
+++ b/home.admin/config.scripts/bonus.lnbits.sh
@@ -781,7 +781,7 @@ After=bitcoind.service
 [Service]
 WorkingDirectory=/home/lnbits/lnbits
 ExecStartPre=/home/admin/config.scripts/bonus.lnbits.sh prestart
-ExecStart=/bin/sh -c 'cd /home/lnbits/lnbits && poetry run lnbits --port 5000'
+ExecStart=/bin/sh -c 'cd /home/lnbits/lnbits && poetry run lnbits --port 5000 --host 0.0.0.0'
 User=lnbits
 Restart=always
 TimeoutSec=120


### PR DESCRIPTION
lnbits needs to start and bind on 0.0.0.0, else it will only be reachable fia local and wont work with reverse proxies.

at the moment  host defaults to 127.0.0.1

https://github.com/lnbits/lnbits/issues/1658
