### PR TITLE
migrated only relevant fixes from #3770

### DIFF
--- a/home.admin/config.scripts/blitz.fatpack.sh
+++ b/home.admin/config.scripts/blitz.fatpack.sh
@@ -24,7 +24,7 @@ echo "* Adding nodeJS Framework ..."
 /home/admin/config.scripts/bonus.nodejs.sh on || exit 1
 
 echo "* Optional Packages (may be needed for extended features)"
-apt_install qrencode secure-delete fbi msmtp unclutter xterm python3-pyqt5 xfonts-terminus apache2-utils nginx python3-jinja2 socat libatlas-base-dev hexyl autossh
+sudo apt install -y qrencode secure-delete fbi msmtp unclutter xterm python3-pyqt5 xfonts-terminus apache2-utils nginx python3-jinja2 socat libatlas-base-dev hexyl autossh
 
 echo "* Adding LND ..."
 /home/admin/config.scripts/lnd.install.sh install || exit 1
@@ -48,6 +48,7 @@ sudo /home/admin/config.scripts/blitz.web.ui.sh on "${defaultWEBUIuser}" "${defa
 
 # set build code as new www default
 sudo rm -r /home/admin/assets/nginx/www_public
+mkdir -p /home/admin/assets/nginx/www_public
 sudo cp -a /home/blitzapi/blitz_web/build/* /home/admin/assets/nginx/www_public
 sudo chown admin:admin /home/admin/assets/nginx/www_public
 sudo rm -r /home/blitzapi/blitz_web/build/*

--- a/home.admin/config.scripts/blitz.fatpack.sh
+++ b/home.admin/config.scripts/blitz.fatpack.sh
@@ -9,6 +9,15 @@ if [ "$EUID" -ne 0 ]
   exit 1
 fi
 
+apt_install() {
+  apt install -y ${@}
+  if [ $? -eq 100 ]; then
+    echo "FAIL! apt failed to install needed packages!"
+    echo ${@}
+    exit 1
+  fi
+}
+
 echo "# getting default user/repo from build_sdcard.sh"
 sudo cp /home/admin/raspiblitz/build_sdcard.sh /home/admin/build_sdcard.sh
 sudo chmod +x /home/admin/build_sdcard.sh 2>/dev/null
@@ -24,7 +33,7 @@ echo "* Adding nodeJS Framework ..."
 /home/admin/config.scripts/bonus.nodejs.sh on || exit 1
 
 echo "* Optional Packages (may be needed for extended features)"
-sudo apt install -y qrencode secure-delete fbi msmtp unclutter xterm python3-pyqt5 xfonts-terminus apache2-utils nginx python3-jinja2 socat libatlas-base-dev hexyl autossh
+apt_install qrencode secure-delete fbi msmtp unclutter xterm python3-pyqt5 xfonts-terminus apache2-utils nginx python3-jinja2 socat libatlas-base-dev hexyl autossh
 
 echo "* Adding LND ..."
 /home/admin/config.scripts/lnd.install.sh install || exit 1

--- a/home.admin/config.scripts/cl-plugin.cln-grpc.sh
+++ b/home.admin/config.scripts/cl-plugin.cln-grpc.sh
@@ -45,6 +45,7 @@ function buildGRPCplugin() {
     echo "# delete old dir or binary"
     sudo rm -rf /home/bitcoin/cl-plugins-available/cln-grpc
     echo "# move to /home/bitcoin/cl-plugins-available/"
+    sudo mkdir -p /home/bitcoin/cl-plugins-available
     sudo -u bitcoin mv /home/bitcoin/cln-grpc-build/debug/cln-grpc /home/bitcoin/cl-plugins-available/
   else
     echo "# - cln-grpc plugin was already built/installed"


### PR DESCRIPTION
Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` brach - not the default release branch.

This PR is a port of #3770.

The following fixes were ommitted:
- cl.install.sh: Against the dev branch, there were no issues installing as I was encountering in v1.8
- protobuf-compiler: This dependency is already installed in the dev branch.

Included:
- `mkdir -p /home/admin/assets/nginx/www_public`: This is required as we delete the folder one step before and then try to copy files to a non-existent folder.

New:
- `apt_install` in fatpack file: This function is not defined.
- `sudo mkdir -p /home/bitcoin/cl-plugins-available`: This folder did not exist before we tried to copy our plugin to it.

I have not ran a final test with the latest changes, but will not be able to do so until after Tuesday. I'm still confident that it is an improvement as is.