### PR TITLE
fix: don't reinstall same CLN version + fmt

### DIFF
--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -2,7 +2,7 @@
 # https://lightning.readthedocs.io/
 
 # https://github.com/ElementsProject/lightning/releases
-CLVERSION=v23.02.2
+CLVERSION="v23.02.2"
 
 # install the latest master by using the last commit id
 # https://github.com/ElementsProject/lightning/commit/master

--- a/home.admin/config.scripts/cl.update.sh
+++ b/home.admin/config.scripts/cl.update.sh
@@ -19,7 +19,7 @@ fi
 mode="$1"
 
 # RECOMMENDED UPDATE BY RASPIBLITZ TEAM
-# comment will be shown as "BEWARE Info" when option is choosen (can be multiple lines) 
+# comment will be shown as "BEWARE Info" when option is choosen (can be multiple lines)
 clUpdateVersion="" # example: 0.12.1 .. keep empty if no newer version as sd card build is available
 clUpdateComment="Please keep in mind that downgrading afterwards is not tested. Also not all additional apps are fully tested with the this update - but it looked good on first tests."
 
@@ -65,7 +65,7 @@ if [ "${mode}" = "verified" ]; then
 
   # check for optional second parameter: forced update version
   # --> only does the verified update if its the given version
-  # this is needed for recovery/update. 
+  # this is needed for recovery/update.
   fixedUpdateVersion="$2"
   if [ ${#fixedUpdateVersion} -gt 0 ]; then
     echo "# checking for fixed version update: askedFor(${fixedUpdateVersion}) available(${clUpdateVersion})"
@@ -78,9 +78,8 @@ if [ "${mode}" = "verified" ]; then
       echo "# OK - update version is matching"
     fi
   fi
-  
 
-  if [ ${#clUpdateVersion} -gt 0 ];then
+  if [ ${#clUpdateVersion} -gt 0 ]; then
     /home/admin/config.scripts/cl.install.sh update v${clUpdateVersion}
   else
     /home/admin/config.scripts/cl.install.sh on
@@ -100,7 +99,7 @@ if [ "${mode}" = "reckless" ]; then
   echo "# cl.update.sh reckless"
 
   # only update if the latest release is different from the installed
-  if [ "v${clInstalledVersion}" = "${clLatestVersion}" ]; then
+  if [ "${clInstalledVersion}" = "${clLatestVersion}" ]; then
     # attention to leading 'v'
     echo "# clInstalledVersion = clLatestVersion (${clLatestVersion:1})"
     echo "# There is no need to update again."


### PR DESCRIPTION
fixes: #3789
to avoid the double install of CLN with 1.9.0 rc4 image

Fixing the extra v - required in previous versions, now
```
₿ sudo -u bitcoin lightning-cli --version
v23.02.2
₿ curl --header "X-GitHub-Api-Version:2022-11-28" -s https://api.github.com/repos/ElementsProject/lightning/releases | jq -r '.[].tag_name' | grep -v "rc" | head -n1
v23.02.2
```