### PR TITLE
Fixed typo "additial" in dev branch

### DIFF
--- a/home.admin/setup.scripts/dialogPasswords.sh
+++ b/home.admin/setup.scripts/dialogPasswords.sh
@@ -92,7 +92,7 @@ if [ "${setPasswordB}" == "1" ]; then
   fi
   sudo sed -i '/^passwordB=/d' $SETUPFILE
   echo "passwordB='${password}'" >> $SETUPFILE
-  dialog --backtitle "RaspiBlitz - Setup" --msgbox "\nThanks - Password B accepted.\n\nUse this password as login for\nadditial Apps & API access." 10 34
+  dialog --backtitle "RaspiBlitz - Setup" --msgbox "\nThanks - Password B accepted.\n\nUse this password as login for\nadditional Apps & API access." 10 34
 fi
 
 # PASSWORD C


### PR DESCRIPTION
I noticed a small typo during the install process:

![raspiBlitz_TYPO](https://github.com/rootzoll/raspiblitz/assets/54002590/b066aaa9-e1c6-465a-8273-8e85ab66f5e4)

Please let me know if I made any mistake in this PR or if this issue was already submitted.

Cheers / thanks
nformant