### PR TITLE
CLN: less reckless update, consistent leading v

### DIFF
--- a/home.admin/_provision_.sh
+++ b/home.admin/_provision_.sh
@@ -243,9 +243,14 @@ fi
 if [ ${#clInterimsUpdate} -gt 0 ]; then
   /home/admin/_cache.sh set message "Provisioning CL update"
   if [ "${clInterimsUpdate}" == "reckless" ]; then
-    # determine the database version
-    clDbVersion=$(sudo -u bitcoin sqlite3 /home/bitcoin/.lightning/bitcoin/lightningd.sqlite3 "SELECT version FROM version;")
-    # Examples: 216 is CLN v23.02.2 # 219 is CLN v23.05
+    # determine the database version # Examples: 216 is CLN v23.02.2 # 219 is CLN v23.05
+    clDbVersion=$(sqlite3 /mnt/hdd/app-data/.lightning/bitcoin/lightningd.sqlite3 "SELECT version FROM version;")
+    if [ ${#clDbVersion} -eq 0 ]; then
+      echo "Could not determine the CLN database version - using 0" >> ${logFile}
+      clDbVersion=0
+    else
+      echo "The CLN database version is ${clDbVersion}" >> ${logFile}
+    fi
     if [ ${clDbVersion} -lt 217 ]; then
       # even if reckless is set - update to the recommended release
       echo "Provisioning CL verified interims update" >> ${logFile}

--- a/home.admin/_provision_.sh
+++ b/home.admin/_provision_.sh
@@ -243,13 +243,22 @@ fi
 if [ ${#clInterimsUpdate} -gt 0 ]; then
   /home/admin/_cache.sh set message "Provisioning CL update"
   if [ "${clInterimsUpdate}" == "reckless" ]; then
-    # recklessly update CL to latest release on GitHub (just for test & dev nodes)
-    echo "Provisioning CL reckless interims update" >> ${logFile}
-    /home/admin/config.scripts/cl.update.sh reckless >> ${logFile}
+    # determine the database version
+    clDbVersion=$(sudo -u bitcoin sqlite3 /home/bitcoin/.lightning/bitcoin/lightningd.sqlite3 "SELECT version FROM version;")
+    # Examples: 216 is CLN v23.02.2 # 219 is CLN v23.05
+    if [ ${clDbVersion} -lt 217 ]; then
+      # even if reckless is set - update to the recommended release
+      echo "Provisioning CL verified interims update" >> ${logFile}
+      /home/admin/config.scripts/cl.update.sh verified >> ${logFile}
+    else # 217 or higher
+      # recklessly update CL to latest release on GitHub (just for test & dev nodes)
+      echo "Provisioning CL reckless interims update" >> ${logFile}
+      /home/admin/config.scripts/cl.update.sh reckless >> ${logFile}
+    fi
   else
     # when installing the same sd image - this will re-trigger the secure interims update
-    # if this a update with a newer RaspiBlitz version .. interims update will be ignored
-    # because standard CL version is most more up to date
+    # if this is an update with a newer RaspiBlitz version .. interims update will be ignored
+    # because the standard CL version is up to date
     echo "Provisioning CL verified interims update" >> ${logFile}
     /home/admin/config.scripts/cl.update.sh verified ${clInterimsUpdate} >> ${logFile}
   fi

--- a/home.admin/config.scripts/cl.update.sh
+++ b/home.admin/config.scripts/cl.update.sh
@@ -80,7 +80,13 @@ if [ "${mode}" = "verified" ]; then
   fi
 
   if [ ${#clUpdateVersion} -gt 0 ]; then
-    /home/admin/config.scripts/cl.install.sh update ${clUpdateVersion}
+    # only update if the clUpdateVersion is different from the installed
+    if [ "${clInstalledVersion}" = "${clUpdateVersion}" ]; then
+      echo "# clInstalledVersion = clUpdateVersion (${clUpdateVersion})"
+      echo "# There is no need to update again."
+    else
+      /home/admin/config.scripts/cl.install.sh update ${clUpdateVersion}
+    fi
   else
     /home/admin/config.scripts/cl.install.sh on
   fi

--- a/home.admin/config.scripts/cl.update.sh
+++ b/home.admin/config.scripts/cl.update.sh
@@ -9,7 +9,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "verified -> only do recommended updates by RaspiBlitz team"
   echo "  binary will be checked by signature and checksum"
   echo "reckless -> if you just want to update to the latest release"
-  echo "  published on Core Lightning GitHub releases (RC or final) without any"
+  echo "  published on Core Lightning GitHub releases without any"
   echo "  testing or security checks."
   echo
   exit 1
@@ -20,13 +20,13 @@ mode="$1"
 
 # RECOMMENDED UPDATE BY RASPIBLITZ TEAM
 # comment will be shown as "BEWARE Info" when option is choosen (can be multiple lines)
-clUpdateVersion="" # example: 0.12.1 .. keep empty if no newer version as sd card build is available
+clUpdateVersion="v23.02.2" # example: v23.02.2 # keep empty if no newer version as sd card build is available
 clUpdateComment="Please keep in mind that downgrading afterwards is not tested. Also not all additional apps are fully tested with the this update - but it looked good on first tests."
 
 # GATHER DATA
 
 # installed Core Lightning version
-clInstalledVersion=$(sudo -u bitcoin lightning-cli --version)
+clInstalledVersion=$(sudo -u bitcoin lightningd --version) # example output: v23.02.2
 clInstalledVersionMajor=$(echo "${clInstalledVersion}" | cut -d "-" -f1 | cut -d "." -f1)
 clInstalledVersionMain=$(echo "${clInstalledVersion}" | cut -d "-" -f1 | cut -d "." -f2)
 clInstalledVersionMinor=$(echo "${clInstalledVersion}" | cut -d "-" -f1 | cut -d "." -f3)
@@ -36,7 +36,7 @@ clUpdateInstalled=$(echo "${clInstalledVersion}" | grep -c "${clUpdateVersion}")
 
 # get latest release from Core Lightning GitHub releases without release candidates
 clLatestVersion=$(curl --header "X-GitHub-Api-Version:2022-11-28" -s https://api.github.com/repos/ElementsProject/lightning/releases | jq -r '.[].tag_name' | grep -v "rc" | head -n1)
-# example: v0.12.1
+# example output: v23.05
 
 # INFO
 if [ "${mode}" = "info" ]; then
@@ -80,7 +80,7 @@ if [ "${mode}" = "verified" ]; then
   fi
 
   if [ ${#clUpdateVersion} -gt 0 ]; then
-    /home/admin/config.scripts/cl.install.sh update v${clUpdateVersion}
+    /home/admin/config.scripts/cl.install.sh update ${clUpdateVersion}
   else
     /home/admin/config.scripts/cl.install.sh on
   fi
@@ -100,10 +100,9 @@ if [ "${mode}" = "reckless" ]; then
 
   # only update if the latest release is different from the installed
   if [ "${clInstalledVersion}" = "${clLatestVersion}" ]; then
-    # attention to leading 'v'
-    echo "# clInstalledVersion = clLatestVersion (${clLatestVersion:1})"
+    echo "# clInstalledVersion = clLatestVersion (${clLatestVersion})"
     echo "# There is no need to update again."
-    clInterimsUpdateNew="${clLatestVersion:1}"
+    clInterimsUpdateNew="${clLatestVersion}"
   else
     /home/admin/config.scripts/cl.install.sh update ${clLatestVersion}
     clInterimsUpdateNew="reckless"


### PR DESCRIPTION
If 23.02.2 or lower was the CLN version run before update, update only to the recommended version.
Fixes previous workarounds for the inconsistency in the leading v in version numbers.

Context: CLN v23.05 breaks RTL: 
> We have to update cl-rest and RTL's code to accommodate cln's msat purge. You can follow these issues here https://github.com/Ride-The-Lightning/c-lightning-REST/issues/168 & https://github.com/Ride-The-Lightning/RTL/issues/1231

Needs testing.