### PR TITLE
disable Specter update in menu

### DIFF
--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -496,9 +496,10 @@ if [ "${lndg}" == "on" ]; then
   OPTIONS+=(LNDG "Update LNDg")
 fi
 
-if [ "${specter}" == "on" ]; then
-  OPTIONS+=(SPECTER "Update Specter Desktop")
-fi
+## Disabled for now until the base image has Python 3.10
+#if [ "${specter}" == "on" ]; then
+#  OPTIONS+=(SPECTER "Update Specter Desktop")
+#fi
 
 if [ "${BTCPayServer}" == "on" ]; then
   OPTIONS+=(BTCPAY "Update BTCPayServer")

--- a/home.admin/config.scripts/bonus.specter.sh
+++ b/home.admin/config.scripts/bonus.specter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # https://github.com/cryptoadvance/specter-desktop
 
-pinnedVersion="1.14.5"
+pinnedVersion="1.8.1"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then

--- a/home.admin/config.scripts/bonus.specter.sh
+++ b/home.admin/config.scripts/bonus.specter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # https://github.com/cryptoadvance/specter-desktop
 
-pinnedVersion="1.8.1"
+pinnedVersion="1.14.5"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then


### PR DESCRIPTION
fixing #3803
Related: #3709

The latest Specter releases depend on Pyhton 3.10 which Debian doesn't have yet: https://github.com/rootzoll/raspiblitz/issues/3803