### PR TITLE
fix: use absolute path for cln backup-cli

### DIFF
--- a/home.admin/config.scripts/cl-plugin.backup.sh
+++ b/home.admin/config.scripts/cl-plugin.backup.sh
@@ -89,7 +89,7 @@ if [ "$1" = on ]; then
   # https://github.com/lightningd/plugins/tree/master/backup#setup
   echo "# Initialize the backup plugin"
   cd ${plugindir}/backup/ || exit 1
-  sudo -u bitcoin poetry run ./backup-cli init --lightning-dir /home/bitcoin/.lightning/${CLNETWORK} \
+  sudo -u bitcoin poetry run /home/bitcoin/cl-plugins-available/plugins/backup/backup-cli init --lightning-dir /home/bitcoin/.lightning/${CLNETWORK} \
     file:///home/bitcoin/${netprefix}lightningd.sqlite3.backup
 
   if [ $(crontab -u admin -l | grep -c "backup-compact $CHAIN") -eq 0 ]; then
@@ -134,7 +134,7 @@ then
     sudo systemctl stop ${netprefix}lightningd
 
     # https://github.com/lightningd/plugins/tree/master/backup#restoring-a-backup
-    # poetry run ./backup-cli restore file:///mnt/external/location ~/.lightning/bitcoin/lightningd.sqlite3
+    # poetry run /home/bitcoin/cl-plugins-available/plugins/backup/backup-cli restore file:///mnt/external/location ~/.lightning/bitcoin/lightningd.sqlite3
 
     # make sure to not overwrite old database
     if sudo ls /home/bitcoin/.lightning/${CLNETWORK}/lightningd.sqlite3; then
@@ -149,7 +149,7 @@ then
 
     # restore
     cd ${plugindir}/backup/ || exit 1
-    sudo -u bitcoin poetry run ./backup-cli restore \
+    sudo -u bitcoin poetry run /home/bitcoin/cl-plugins-available/plugins/backup/backup-cli restore \
       file:///home/bitcoin/${netprefix}lightningd.sqlite3.backup \
       /home/bitcoin/.lightning/${CLNETWORK}/lightningd.sqlite3
 


### PR DESCRIPTION
fix: #3856 
running:
```
./config.scripts/cl-plugin.backup.sh on
```
works now and fixes CLN.
Will run a test with a new install.