### PR TITLE
prevent caching of index.html, add cache-control header for other req…

### DIFF
--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -32,6 +32,13 @@ server {
 		root /var/www/letsencrypt;
 	}
 
+	location = /index.html {
+		# internal means that it can't be called from outside
+		internal;
+		# add no-store to prevent caching of index.html
+		add_header Cache-Control 'no-store';
+	}
+
 	location / {
 		# make sure to have https link to exact same host that was called
 		sub_filter '<a href="https://HOST_SET_BY_NGINX/' '<a href="https://$host/';
@@ -39,7 +46,7 @@ server {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ /index.html =404;
-
+		add_header Cache-Control "no-cache, must-revalidate";
 	}
 
 }

--- a/home.admin/assets/nginx/sites-available/public.httponly.conf
+++ b/home.admin/assets/nginx/sites-available/public.httponly.conf
@@ -23,6 +23,13 @@ server {
 		root /var/www/letsencrypt;
 	}
 
+	location = /index.html {
+		# internal means that it can't be called from outside
+		internal;
+		# add no-store to prevent caching of index.html
+		add_header Cache-Control 'no-store';
+	}
+
 	location / {
 		# make sure to have https link to exact same host that was called
 		sub_filter '<a href="https://HOST_SET_BY_NGINX/' '<a href="https://$host/';
@@ -30,7 +37,7 @@ server {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ /index.html =404;
-
+		add_header Cache-Control "no-cache, must-revalidate";
 	}
 
 }


### PR DESCRIPTION
When upgrading the RaspiBlitz, some users get an error with the webUI since the cached index.html in the browser tries to load resources which don't exist anymore, see e.g. https://github.com/cstenglein/raspiblitz-web/issues/633

The JS & CSS filenames have the hash attached to them, so they are no problem, but the index.html always has the same filename, thus the browser wants to use the cached version.

This PR adds `Cache-Control` header to prevent any caching of the index.html (`no-store`) and tells the browser for other resources, that it should revalidate them (`no-cache, must-revalidate`). Don't be confused with `no-cache` - it does caching, it's a misnomer, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control