### PR TITLE
fix: remove sudo from lnd prestart

### DIFF
--- a/home.admin/config.scripts/lnd.check.sh
+++ b/home.admin/config.scripts/lnd.check.sh
@@ -333,8 +333,8 @@ if [ "$1" == "prestart" ]; then
   fi
 
   # remove erroneous entries
-  sudo sed -i '/^  \[rpcmiddleware\]/d' ${lndConfFile}
-  sudo sed -i '/^  \[\[Rr\]pcmiddleware\]/d' ${lndConfFile}
+  sed -i '/^  \[rpcmiddleware\]/d' ${lndConfFile}
+  sed -i '/^  \[\[Rr\]pcmiddleware\]/d' ${lndConfFile}
 
   # SET/UPDATE rpcmiddleware.enable
   setting ${lndConfFile} ${insertLine} "rpcmiddleware.enable" "true"


### PR DESCRIPTION
the sudo entry in prestart won't allow the script to finish when run with the user `bitcoin`
