### PR TITLE
Remove Bitcoin recommended Update for v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 _Build your own Lightning & Bitcoin Fullnode on a RaspberryPi with an optional Display._
 
-`Version 1.9.0 with bitcoin 24.0.1, lnd 0.16.2 & Core Lightning 23.02.2` ([api](https://github.com/fusion44/blitz_api)|[web](https://github.com/cstenglein/raspiblitz-web))
+`Version 1.10.0rc1 with bitcoin 24.0.1, lnd 0.16.2 & Core Lightning 23.02.2` ([api](https://github.com/fusion44/blitz_api)|[web](https://github.com/cstenglein/raspiblitz-web))
 
 ![RaspiBlitz](pictures/raspiblitz.jpg)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 _Build your own Lightning & Bitcoin Fullnode on a RaspberryPi with an optional Display._
 
-`Version 1.10.0rc1 with bitcoin 24.0.1, lnd 0.16.2 & Core Lightning 23.02.2` ([api](https://github.com/fusion44/blitz_api)|[web](https://github.com/cstenglein/raspiblitz-web))
+`Version 1.10.0rc1 with bitcoin 25.0.0, lnd 0.16.4 & Core Lightning 23.05.2` ([api](https://github.com/fusion44/blitz_api)|[web](https://github.com/cstenglein/raspiblitz-web))
 
 ![RaspiBlitz](pictures/raspiblitz.jpg)
 

--- a/home.admin/config.scripts/bitcoin.update.sh
+++ b/home.admin/config.scripts/bitcoin.update.sh
@@ -18,7 +18,7 @@ mode="$1"
 
 # RECOMMENDED UPDATE BY RASPIBLITZ TEAM (just possible once per sd card update)
 # comment will be shown as "BEWARE Info" when option is choosen (can be multiple lines)
-bitcoinVersion="24.1" # example: 22.0 .. keep empty if no newer version as sd card build is available
+bitcoinVersion="" # example: 22.0 .. keep empty if no newer version as sd card build is available
 
 # needed to check code signing
 # https://github.com/emzy.gpg


### PR DESCRIPTION
There is no newer recommended update version for bitcoind v25.0 for now - so remove the old one.
