### PR TITLE
typo fixes in .md files with typos-cli

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -245,7 +245,7 @@ There was a small patch-update with raspiblitz-v1.7.1-2021-10-28.img.gz to fix a
 - New: Circuit Breaker (config-script) [details](https://github.com/rootzoll/raspiblitz/issues/1581)
 - New: PyBlock (Python Util & Fun Scripts) [details](https://github.com/curly60e/pyblock/blob/master/README.md)
 - New: Mempool Explorer [details](https://github.com/mempool/mempool)
-- New: dynu.com as alternative option for LetsEncrpyt FreeDNS provider
+- New: dynu.com as alternative option for LetsEncrypt FreeDNS provider
 - New: Experimental running RaspiBlitz as VM (vagrant & docker)
 
 For ALL small bug fixes & improvements see: https://github.com/rootzoll/raspiblitz/milestone/11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Not all enhancements needs to go through all levels, these are levels of difficu
 1. **Executable** --> Turn your experiment into a basic shell script.
 
 #### Advanced
-1. **Config script** --> Integrate your executable into the RaspiBlitz enviroment.
+1. **Config script** --> Integrate your executable into the RaspiBlitz environment.
 1. **SSH-GUI** --> Make it easier for others to use your config script.
 1. **WEB-GUI** --> Turn your feature into customer ready
 
@@ -70,7 +70,7 @@ NACKs without accompanying reasoning may be disregarded.
 After conceptual agreement on the change, code review can be provided. A review begins with the urgent necessity of the changes.
 Start from urgent to less important:
 1. Security risk.
-1. Code that breaks the enviroment.
+1. Code that breaks the environment.
 1. Enhancing current services functionality.
 1. Solving a common issue.
 1. Adding new applications.

--- a/FAQ.cl.md
+++ b/FAQ.cl.md
@@ -650,7 +650,7 @@ Will need to pay through a peer which supports the onion messages which means yo
 
 * Output if unsuccessful (the private key is not known):
     ```
-    Could not find any basepoint matching the provided witness programm.
+    Could not find any basepoint matching the provided witness programme.
     Are you sure that the channel used `option_static_remotekey` ?
     *** stack smashing detected ***: terminated
     Aborted
@@ -679,7 +679,7 @@ Will need to pay through a peer which supports the onion messages which means yo
     ```
 * Example output:
     ```
-    KwFvThe98E1t3mTNAr8pKx67eUzFJWdSNPqPSfxMEtrueW7PcQzL
+    KwFvTne98E1t3mTNAr8pKx67eUzFJWdSNPqPSfxMEtrueW7PcQzL
     ```
 * To import to the Electrum Wallet use the `p2wpkh:` prefix:
   <https://bitcoinelectrum.com/importing-your-private-keys-into-electrum/>
@@ -708,7 +708,7 @@ Will need to pay through a peer which supports the onion messages which means yo
 
 ### Experimental update to the latest master
 * this won't persist in case the SDcard is reflashed so will need to manually update again.
-* the command to use the built-in script to update to the lates commit in the default branch is:
+* the command to use the built-in script to update to the last commit in the default branch is:
     ```
     config.scripts/cl.install.sh update
     ```

--- a/FAQ.cl.md
+++ b/FAQ.cl.md
@@ -149,7 +149,7 @@ or with the alias: `cllog`
     ```
 * start with
     ```
-    lightnign-cli plugin start /home/bitcoin/cl-plugins-enabled/PLUGIN_NAME
+    lightning-cli plugin start /home/bitcoin/cl-plugins-enabled/PLUGIN_NAME
     ```
 * or to load it automatically on restart:
     ```
@@ -175,7 +175,7 @@ It does automatically:
 Overall it is a tool which makes users able to send and receive lightning payments with minimal interaction, basically setting up a routing node by itself.
 
 The transactions made by CLBOSS does cost money and running it requires a fair amount of trust in the (fully open-source - MIT) code.
-Neither the CLBOSS nor the RaspiBlitz developers can take resposibility for lost sats, use at your own discretion!
+Neither the CLBOSS nor the RaspiBlitz developers can take responsibility for lost sats, use at your own discretion!
 
 * Activate it in the menu - `SETTINGS` - `-CL CLBOSS`
 * Discussion: https://github.com/rootzoll/raspiblitz/issues/2490
@@ -317,7 +317,7 @@ the amounts can be specified in `sat` or `btc`
 list the utxo-s with `lightning-cli listfunds`, can list multiple
 the feerate is in `perkb` by default, e.g. use 1000 for 1 sat/byte
     ```
-    lightning-cli fundchannel feerate=PERKB_FEERATE utxos='["TRANSACTION_ID:INDDEX_NUMBER"]' -k id=NODE_ID amount=OWN_AMOUNTsat request_amt=PEER_CONTRIBUTION_AMOUNTsat compact_lease=COMPACT_LEASE
+    lightning-cli fundchannel feerate=PERKB_FEERATE utxos='["TRANSACTION_ID:INDEX_NUMBER"]' -k id=NODE_ID amount=OWN_AMOUNTsat request_amt=PEER_CONTRIBUTION_AMOUNTsat compact_lease=COMPACT_LEASE
     ```
 
 #### Multifundchannel syntax
@@ -679,9 +679,9 @@ Will need to pay through a peer which supports the onion messages which means yo
     ```
 * Example output:
     ```
-    KwFvTne98E1t3mTNAr8pKx67eUzFJWdSNPqPSfxMEtrueW7PcQzL
+    KwFvThe98E1t3mTNAr8pKx67eUzFJWdSNPqPSfxMEtrueW7PcQzL
     ```
-* To import to teh Electrum Wallet use the `p2wpkh:` prefix:
+* To import to the Electrum Wallet use the `p2wpkh:` prefix:
   <https://bitcoinelectrum.com/importing-your-private-keys-into-electrum/>
   ```
   p2wpkh:KxacygL6usxP8T9cFSM2SRW5QsEg66bUQUEn997UWwCZANEe7NLT
@@ -708,7 +708,7 @@ Will need to pay through a peer which supports the onion messages which means yo
 
 ### Experimental update to the latest master
 * this won't persist in case the SDcard is reflashed so will need to manually update again.
-* the commadn to use the built-in script to update to the lates commit in the default branch is:
+* the command to use the built-in script to update to the lates commit in the default branch is:
     ```
     config.scripts/cl.install.sh update
     ```
@@ -934,7 +934,7 @@ Will need to pay through a peer which supports the onion messages which means yo
 ## All possible config options
   *  can be shown by running:
   `lightningd --help`
-  * To persist the setings place the options in the config file without the `--` and restart lightningd
+  * To persist the settings place the options in the config file without the `--` and restart lightningd
     ```
     Usage: lightningd
     A bitcoin lightning daemon (default values shown for network: bitcoin).
@@ -970,7 +970,7 @@ Will need to pay through a peer which supports the onion messages which means yo
     --funding-confirms <arg>                          Confirmations required for funding transaction (default: 3)
     --cltv-delta <arg>                                Number of blocks for cltv_expiry_delta (default: 34)
     --cltv-final <arg>                                Number of blocks for final cltv_expiry (default: 18)
-    --commit-time=<millseconds>                       Time after changes before sending out COMMIT (default: 10)
+    --commit-time=<milliseconds>                       Time after changes before sending out COMMIT (default: 10)
     --fee-base <arg>                                  Millisatoshi minimum to charge for HTLC (default: 1000)
     --rescan <arg>                                    Number of blocks to rescan from the current head, or absolute blockheight if negative (default: 15)
     --fee-per-satoshi <arg>                           Microsatoshi fee for every satoshi in HTLC (default: 10)

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -129,7 +129,7 @@ The RaspiBlitz is your computer to experiment with. Feel free to add your own sc
 - When a release of a new main-update (see above) comes closer, a new release branch gets created from 'dev' with the first release candidate - the RCs and the final release sd card will be build from this branch.
 - All minor-releases will basically all work with the same 'build_sdcard.sh' script so that the code could be updated by just calling 'patch'. Emergency updates on lnd & bitcoin may break this guideline, but basic structure & packaging should stay mostly consistent over a main-update version.
 - Once a release is ready, that release branch will be set as the "default" branch on GitHub (so its shown as main page)
-- Hot fixes & new features for minor verisons will be created as single branches from the release branch, and once ready will be merged back into that release branch as a Pull Request using 'Squash-Merge' AND then, this 'Squash-Merge' (one single commit) will get cherry-picked into the  'dev' branch ('git cherry-pick COMMITHASH' - may call 'git fetch' & 'git pull' before to make a clean cherry-pick into dev).
+- Hot fixes & new features for minor versions will be created as single branches from the release branch, and once ready will be merged back into that release branch as a Pull Request using 'Squash-Merge' AND then, this 'Squash-Merge' (one single commit) will get cherry-picked into the  'dev' branch ('git cherry-pick COMMITHASH' - may call 'git fetch' & 'git pull' before to make a clean cherry-pick into dev).
 
 ### Can I run RaspiBlitz on other computers than RaspberryPi?
 
@@ -171,7 +171,7 @@ Once the branch is available and synced between the RaspiBlitz GitHub repo, your
 
 ### How can I sync a branch of my forked GitHub with my local RaspiBlitz?
 
-Since v1.5 of RaspiBlitz there has been an easy way thru the SSH menus: Under `MAIN MENU > UPDATE > PATCH` you have the option to change the GitHub repository and and branch to sync with. You change the GitHub Reposity by setting the GitHub username where you forked the Repo.
+Since v1.5 of RaspiBlitz there has been an easy way thru the SSH menus: Under `MAIN MENU > UPDATE > PATCH` you have the option to change the GitHub repository and and branch to sync with. You change the GitHub Repository by setting the GitHub username where you forked the Repo.
 
 So for example: If you forked the RaspiBlitz project (raspiblitz/raspiblitz) on GitHub and your GitHub project page is now called: https://github.com/raumi75/raspiblitz ... then just change the repo to sync/patch with to your username `raumi75`.
 
@@ -225,13 +225,13 @@ To change back to the code:
 
 ### How can I push changes to an existing Pull Request?
 
-See article: https://tech.sycamore.garden/add-commit-push-contributor-branch-git-github .. only works if your a contributer on raspiblitz repo.
+See article: https://tech.sycamore.garden/add-commit-push-contributor-branch-git-github .. only works if your a contributor on raspiblitz repo.
 
 ### How to cherry-pick with branch protections & CODEOWNERS file?
 
 Chery-picking patch PRs from dev to a release-branch like 'v1.8' (for example) is now a bit more complicated. Either an admin switches temorarly the branch protection "require a pull request before merging" setting off for the `git cherry-pick` OR we create a `p1.8` branch from `v1.8`, cherry-pick the squashed patch PR into that unprotected `p1.8` and then open a PR back to `v1.8`.
 
-But what we gain is that better branch protection and we can add more contributers to the project that are allowed to manage issues - like adding lables or closing.
+But what we gain is that better branch protection and we can add more contributors to the project that are allowed to manage issues - like adding labels or closing.
 
 ### How to run the automatic amd64 build on a VM on OSX?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -343,7 +343,7 @@ Once you finished all the transfers, the Raspiblitz will make a quick-check on t
 
 ### Bitcoind tells me to reindex - how can I do this?
 
- To find/access information fast in large data sets like the Bitcoin blockhain indexes are needed. Those indexes can get corrupted on your HDD/SSD and to repair them they need to be rebuild - re-indexed. Bitcoind has two different options to do this - a fast way called "reindex-chainstate" (which just rebuilds the UTXO set from the blocks as you have them) and the slow but complete way called just "reindex" that would even recheck all your block data - see for details here: https://bitcoin.stackexchange.com/questions/60709/when-should-i-use-reindex-chainstate-and-when-reindex 
+ To find/access information fast in large data sets like the Bitcoin blockchain indexes are needed. Those indexes can get corrupted on your HDD/SSD and to repair them they need to be rebuild - re-indexed. Bitcoind has two different options to do this - a fast way called "reindex-chainstate" (which just rebuilds the UTXO set from the blocks as you have them) and the slow but complete way called just "reindex" that would even recheck all your block data - see for details here: https://bitcoin.stackexchange.com/questions/60709/when-should-i-use-reindex-chainstate-and-when-reindex 
  
  So if you read in your debug logs of bitcoind that you should "reindex" you can try first just to do a fast "reindex-chainstate" and if that didnt worked a slow and full "reindex".
 
@@ -403,7 +403,7 @@ This script will offer you a way to transfer the lnd-rescue file from your lapto
 
 Remember those 24 words you were writing down during the setup? That's your "cipher seed" - These words are very important for recovering your wallet. If you don't have them anymore: go back to option "Recover LND data" (see above) and check all possible ways to recover data from the HDD. If you still have the word seed: good, but read the following carefully:
 
-With the word seed you can recover the on-chain funds that LND was managing for you - but it does not contain all the details about the channels you have open - it's mostly the key to your funding wallet. If you were able to close all channels or never opened any, then you should be safe: The best results to recover on-chain funds from wallet seeds have been reported from people installing the Lightning Labs App on laptop and then using the wallet seed (and same wallet passwords): https://github.com/lightninglabs/lightning-app/releases. Other people were succesful in this process using the Zap Desktop wallet (OSX, Win, Linux): https://zap.jackmallers.com/download
+With the word seed you can recover the on-chain funds that LND was managing for you - but it does not contain all the details about the channels you have open - it's mostly the key to your funding wallet. If you were able to close all channels or never opened any, then you should be safe: The best results to recover on-chain funds from wallet seeds have been reported from people installing the Lightning Labs App on laptop and then using the wallet seed (and same wallet passwords): https://github.com/lightninglabs/lightning-app/releases. Other people were successful in this process using the Zap Desktop wallet (OSX, Win, Linux): https://zap.jackmallers.com/download
 
 If you had open channels it would be best to check if you have also the `channel.backup` file (Static-Channel-Backup feature) that is available since LND 0.6 (RaspiBlitz v1.2) and use it in the process below ... for more details on the `channel.backup` file see [README.md on backups](README.md#backup-for-on-chain---channel-funds).
 
@@ -808,7 +808,7 @@ For the Raspiblitz this means that you can connect an additional 32GB USB3 Thumb
 
 #### Snapshotting the Blockchain
 
-BTRFS comes with a build in snapshot feature - that means that your RaspiBlitz can make every day a backup of the blockchain data and if a blockchain corruption occurs (exmaple thru a power outage) there is no need to sync the complete chain again. Just switch back to the last backup state and quickly sync up from there. On BTRFS such backups can be done as snapshots that dont need much more space on the drive and are quickly done - no need to buy a bigger SSD or wait for copying over 200GB.
+BTRFS comes with a build in snapshot feature - that means that your RaspiBlitz can make every day a backup of the blockchain data and if a blockchain corruption occurs (example thru a power outage) there is no need to sync the complete chain again. Just switch back to the last backup state and quickly sync up from there. On BTRFS such backups can be done as snapshots that dont need much more space on the drive and are quickly done - no need to buy a bigger SSD or wait for copying over 200GB.
 
 #### How do I use BTRFS on RaspiBlitz?
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ You now have the hardware ready for your RaspiBlitz - whats missing is the softw
 
 ## Downloading the Software
 
-In this section you find the lastest ready-to-use RaspiBlitz sd card images. Basically you just download, write/flash the image file to an sd card and start your RaspberryPi with it - its the same for first install or updating to a newer version. You can choose from two ready-made sd card images below:
+In this section you find the latest ready-to-use RaspiBlitz SDcard images. Basically you just download, write/flash the image file to an sd card and start your RaspberryPi with it - its the same for first install or updating to a newer version. You can choose from two ready-made sd card images below:
 
 ### FATPACK SD Card Image (Beginners - WebUI)
 
@@ -860,7 +860,7 @@ LNbits is a very simple server that sits on top of your Lightning Wallet.
 It can be used together with IP2Tor to provide:
 
 - Lightning Paper Vouchers (Plugin: LNURLw)
-- Merchant Onboarding (Plugin: TYPOS)
+- Merchant Onboarding (Plugin: TPOS)
 
 [![Video Tutorial](pictures/video-vouchers.png)](https://www.youtube.com/watch?v=0Bt3tHULAnw)
 

--- a/README.md
+++ b/README.md
@@ -860,7 +860,7 @@ LNbits is a very simple server that sits on top of your Lightning Wallet.
 It can be used together with IP2Tor to provide:
 
 - Lightning Paper Vouchers (Plugin: LNURLw)
-- Merchant Onboarding (Plugin: TPOS)
+- Merchant Onboarding (Plugin: TYPOS)
 
 [![Video Tutorial](pictures/video-vouchers.png)](https://www.youtube.com/watch?v=0Bt3tHULAnw)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,7 +44,7 @@ Ensure that you put quotes around fingerprints containing spaces if importing wi
 
 # Privacy Protection
 
-When you call `debug` on the command line you get basic system & services logs that can be used if you need to report details for support by other users. There is already a basic redaction of private data (nodeids, IPv4s, .onion-adresses, balances) for that debug report BUT always check the data you post in DMs or public before sending. If you find further private data that needs redaction, please report as an issue on the github repo.  
+When you call `debug` on the command line you get basic system & services logs that can be used if you need to report details for support by other users. There is already a basic redaction of private data (nodeids, IPv4s, .onion-addresses, balances) for that debug report BUT always check the data you post in DMs or public before sending. If you find further private data that needs redaction, please report as an issue on the github repo.  
 
 # Network Security
 
@@ -58,7 +58,7 @@ When you call `debug` on the command line you get basic system & services logs t
 
 * Downloaded binaries and source code is verified with the authors' PGP keys by either:
     * signed shasum files and checking the hash of each downloaded binary
-    * verfying the signature on the source code changes utilising the `git verify-commit` or `git verify-tag` commands
+    * verifying the signature on the source code changes utilising the `git verify-commit` or `git verify-tag` commands
 
 # Physical Security
 
@@ -85,7 +85,7 @@ Some apps (like Fully Noded or JoinMarket) activate the Bitcoin core wallet and 
 
 Please note that there is no perfect backup concept for the funds in your lightning channels yet. We strongly recommend using the `Static Channel Backup` provided by LND and consider off-line location backup of that file to have the best chances to recover Lightning funds in a case of recovering from a disaster.
 
-The C-ligthning lightning.sqlite3 is replicated on the SDcard from the disk in real time. See more details in the [Core Lightning FAQ](FAQ.cl.md#backups)
+The C-lightning lightning.sqlite3 is replicated on the SDcard from the disk in real time. See more details in the [Core Lightning FAQ](FAQ.cl.md#backups)
 
 
 For more practical information on this topic see: [Backup Channel Funds](README.md#backup-for-on-chain---channel-funds)

--- a/WORKSHOP.md
+++ b/WORKSHOP.md
@@ -57,7 +57,7 @@ Variation: If you don't have a big bugdet to prefinance the parts or people have
 
 _Estimated Duration: 4–6 Hours_
 
-This scenario is advised only for small groups, or you'll need to bring multiple blockchain copy stations - see details on "Prepare HDDs with Blockchain Data". Otherwise it needs the least prepartion time and prefinance and can be announced to participants about 5 days beforehand, so that they have time to order all the parts online.
+This scenario is advised only for small groups, or you'll need to bring multiple blockchain copy stations - see details on "Prepare HDDs with Blockchain Data". Otherwise it needs the least preparation time and prefinance and can be announced to participants about 5 days beforehand, so that they have time to order all the parts online.
 
 
 - [Instruct Participants to bring Hardware](WORKSHOP.md#instruct-participants-to-bring-hardware)
@@ -82,7 +82,7 @@ Make sure you have the following hardware and infrastructure ready for the works
 - Extra WLAN Router (if you are not sure if LAN & WLAN is not on the same network at location)
 - One or two USB SD card adapters
 - One or two USB-C to USB-A adapters
-- Some Tape, Markers & Pens always come in handy (also for participants to wirte down seeds & passwords)
+- Some Tape, Markers & Pens always come in handy (also for participants to write down seeds & passwords)
 - Potentially some bitcoin funds (if people dont have their own to start funding channels)
 
 Participants need to bring at least their laptops.
@@ -191,7 +191,7 @@ Once you have that "template" you can make an image from that and write that ima
 In the RaspiBlitz GitHub repo and also on every RaspiBlitz (since v1.3) you can find the script:
 `/home/admin/XXcopyStation.sh`
 
-This can be used to prepare and keep multiple HDDs in snyc with blockchain data in preparation of a workshop. You can start it directly on a RaspiBlitz and turn it into "Copy Station Mode" by executing on the command line:
+This can be used to prepare and keep multiple HDDs in sync with blockchain data in preparation of a workshop. You can start it directly on a RaspiBlitz and turn it into "Copy Station Mode" by executing on the command line:
 
 `sudo /home/admin/XXcopyStation.sh`
 

--- a/alternative.platforms/README.md
+++ b/alternative.platforms/README.md
@@ -87,7 +87,7 @@ These not need installation, password: `osboxes.org`
     sudo bash build_sdcard.sh -f true -b dev -d headless -t false -w off
     # Options:
     #   -h, --help                               this help info
-    #   -i, --interaction [0|1]                  interaction before proceeding with exection (default: 1)
+    #   -i, --interaction [0|1]                  interaction before proceeding with execution (default: 1)
     #   -f, --fatpack [0|1]                      fatpack mode (default: 1)
     #   -u, --github-user [rootzoll|other]       github user to be checked from the repo (default: rootzoll)
     #   -b, --branch [v1.7|v1.8]                 branch to be built on (default: v1.7)
@@ -274,7 +274,7 @@ Work notes partially based on: https://github.com/rootzoll/raspiblitz/blob/v1.7/
       * All files in one partition
       * Can remove the `Swap` partition - a swap file will be created on the Data disk later
 * At the `Software selection` choose:
-    * Debian dekstop environment
+    * Debian desktop environment
     * GNOME (could be other as preferred)
     * SSH server
     * standard system utilities
@@ -310,7 +310,7 @@ Work notes partially based on: https://github.com/rootzoll/raspiblitz/blob/v1.7/
 * Remove the `Installation medium` and the `Ubuntu Live` USB stick and the LAN cable
 #### Start Tails
 * Connect the `Tails USB Stick` (make it stay offline)
-* Boot Tails and set and Admin password in Additioanl Settings (will need it to work with the disk)
+* Boot Tails and set and Admin password in Additional Settings (will need it to work with the disk)
 * Set the screen to not switch off: Settings > Power -> Blank screen - Never
 #### Import the signing keys
 * Connect USB stick with GPG signing keys - decrypt drive if needed

--- a/home.admin/BlitzTUI/docs/README.md
+++ b/home.admin/BlitzTUI/docs/README.md
@@ -39,7 +39,7 @@ Have a look at the [Mini-Tutorial](tutorial.md)
 ## Release workflow
 
 * `make build-ui` - in case there were any changes to the *.ui or *.qrc files
-* make sure you have all changes added and commited (consider re-basing)
+* make sure you have all changes added and committed (consider re-basing)
 * update the version in `blitztui/version.py`
 * update the `CHANGELOG.md` file (reflect the new version!)
 * `git add CHANGELOG.md blitztui/version.py`

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,2 +1,2 @@
 Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
-- [ ] That its based against the `dev` brach - not the default release branch.
+- [ ] That its based against the `dev` branch - not the default release branch.

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,8 @@
+# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+# source "$HOME/.cargo/env"
+# cargo install typos-cli
+# typos -c typos.toml
+# typos -c typos.toml -w
+
+[files]
+extend-exclude = ["*.nodes","*.torrent","*.sh","*.py","*.proto","*.conf","*.json","*.service"]

--- a/typos.toml
+++ b/typos.toml
@@ -5,4 +5,11 @@
 # typos -c typos.toml -w
 
 [files]
+# skip these files
 extend-exclude = ["*.nodes","*.torrent","*.sh","*.py","*.proto","*.conf","*.json","*.service"]
+
+[default.extend-words]
+# don't correct these false positives
+tpos = "tpos"
+ba = "ba"
+tne = "tne"


### PR DESCRIPTION
Was trying the typos-cli on the repo skipping most file types other than .md-s  for now.

Could be a good github action as well as in: https://github.com/GaloyMoney/bria/blob/main/.github/workflows/spelling.yml

More info: https://github.com/crate-ci/typos/tree/master