### PR TITLE
README: Change webui link to organization; fix markdown issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <!-- omit in toc -->
-# ![RaspiBlitz](pictures/raspilogo_tile_400px.png) 
+
+# ![RaspiBlitz](pictures/raspilogo_tile_400px.png)
 
 _Build your own Lightning & Bitcoin Fullnode on a RaspberryPi with an optional Display._
 
-`Version 1.10.0rc2 with bitcoin 25.0.0, lnd 0.16.4 & Core Lightning 23.05.2` ([api](https://github.com/fusion44/blitz_api)|[web](https://github.com/cstenglein/raspiblitz-web))
+`Version 1.10.0rc2 with bitcoin 25.0.0, lnd 0.16.4 & Core Lightning 23.05.2` ([api](https://github.com/fusion44/blitz_api)|[web](https://github.com/raspiblitz/raspiblitz-web))
 
 ![RaspiBlitz](pictures/raspiblitz.jpg)
 
@@ -14,25 +15,27 @@ Discover & develop the growing ecosystem of the Lightning Network by becoming a 
 Build it as part of a [workshop](WORKSHOP.md) or as a weekend project yourself.
 
 ---
+
 <!-- omit in toc -->
+
 ## Table of Contents
 
-  - [Feature Overview](#feature-overview)
-  - [Time Estimate to Set Up a RaspiBlitz](#time-estimate-to-set-up-a-raspiblitz)
-  - [Hardware Needed](#hardware-needed)
-  - [Assemble your RaspiBlitz](#assemble-your-raspiblitz)
-  - [Downloading the Software](#downloading-the-software)
-  - [Write the SD-Card image to your SD Card](#write-the-sd-card-image-to-your-sd-card)
-  - [Boot your RaspiBlitz](#boot-your-raspiblitz)
-  - [Support](#support)
-  - [Setup Process (Detailed Documentation)](#setup-process-detailed-documentation)
-  - [Import a Migration File](#import-a-migration-file)
-  - [Make a RaspiBlitz out of your Umbrel, Citadel or MyNode](#make-a-raspiblitz-out-of-your-umbrel-citadel-or-mynode)
-  - [Interface / APIs](#interface--apis)
-  - [Updating RaspiBlitz to new Version](#updating-raspiblitz-to-new-version)
-  - [Build the SD Card Image](#build-the-sd-card-image)
-  - [FAQ](#faq)
-  - [Community Development](#community-development)
+- [Feature Overview](#feature-overview)
+- [Time Estimate to Set Up a RaspiBlitz](#time-estimate-to-set-up-a-raspiblitz)
+- [Hardware Needed](#hardware-needed)
+- [Assemble your RaspiBlitz](#assemble-your-raspiblitz)
+- [Downloading the Software](#downloading-the-software)
+- [Write the SD-Card image to your SD Card](#write-the-sd-card-image-to-your-sd-card)
+- [Boot your RaspiBlitz](#boot-your-raspiblitz)
+- [Support](#support)
+- [Setup Process (Detailed Documentation)](#setup-process-detailed-documentation)
+- [Import a Migration File](#import-a-migration-file)
+- [Make a RaspiBlitz out of your Umbrel, Citadel or MyNode](#make-a-raspiblitz-out-of-your-umbrel-citadel-or-mynode)
+- [Interface / APIs](#interface--apis)
+- [Updating RaspiBlitz to new Version](#updating-raspiblitz-to-new-version)
+- [Build the SD Card Image](#build-the-sd-card-image)
+- [FAQ](#faq)
+- [Community Development](#community-development)
 
 ---
 
@@ -132,7 +135,7 @@ _If the above mentioned LCD screen is sold out you can also use these different 
 
 - Quimat 3,5'' Zoll Inch Touch
 - ELEGOO Display 3.5" Zoll TFT LCD
-- kuman 3.5 Inch Touch Screen TFT Monitor 
+- kuman 3.5 Inch Touch Screen TFT Monitor
 - Waveshare 3.5inch Display for Raspberry Pi
 
 With all LCD screen models dont use the ones that have an HDMI port/connector - what you need is a 3.5 inch LCD screen model (resolution of 480×320) that connects only thru the GPIO ports (SPI) and has an XPT2046 touch controller.
@@ -164,10 +167,10 @@ In this section you find the latest ready-to-use RaspiBlitz SDcard images. Basic
 
 This is the sd card image you should choose if your at the beginning of your RaspiBlitz journey or you are a casual node runner wanna download the next update/upgrade - with WebUI & fast installing bonus apps.
 
-*WARNING: THIS IS STILL A RELEASE CANDIDATE VERSION</br>
-JUST USE FOR TESTING, HIGHER RISK OF LOSING FUNDS!*
+_WARNING: THIS IS STILL A RELEASE CANDIDATE VERSION</br>
+JUST USE FOR TESTING, HIGHER RISK OF LOSING FUNDS!_
 
-- __FATPACK SD CARD IMAGE ⮕ [raspiblitz-fat-v1.10.0rc2-2023-08-02.img.gz](https://raspiblitz.fulmo.org/images/raspiblitz-fat-v1.10.0rc2-2023-08-02.img.gz)__
+- **FATPACK SD CARD IMAGE ⮕ [raspiblitz-fat-v1.10.0rc2-2023-08-02.img.gz](https://raspiblitz.fulmo.org/images/raspiblitz-fat-v1.10.0rc2-2023-08-02.img.gz)**
 - SHA-256: a1a187a655a7b9b9ba6b3b1609d555a801f6be754d6fd209dfede9ff9e7379b8
 <!--- GPG 64-bit (main): 1C73 060C 7C17 6461 & (sub): AA9D D1B5 CC56 47DA
 - Signature-File: [raspiblitz-fat-v1.9.0-2023-05-22.img.gz.sig](https://raspiblitz.fulmo.org/images/raspiblitz-fat-v1.9.0-2023-05-22.img.gz.sig)
@@ -178,10 +181,10 @@ JUST USE FOR TESTING, HIGHER RISK OF LOSING FUNDS!*
 
 This is the sd card image for RaspiBlitz users that are already more experienced and want to use just a limited set of features of the RaspiBlitz. This image has just the bare minimum of features pre-installed - LCD & HDMI output is off by default. Setup, Update or Recovery needs to be done thru SSH login - API & WebUI are later available but are not preinstalled/activated by default. The RaspiBlitz will download & compile just the tools that are in your ´raspiblitz.conf´ - this will take longer but as a trade-off this RaspiBlitz then just runs with a reduced set of dependencies and so a minimalized attack vector and better performance. Its for the serious & experienced node runners.
 
-*WARNING: THIS IS STILL A RELEASE CANDIDATE VERSION</br>
-JUST USE FOR TESTING, HIGHER RISK OF LOSING FUNDS!*
+_WARNING: THIS IS STILL A RELEASE CANDIDATE VERSION</br>
+JUST USE FOR TESTING, HIGHER RISK OF LOSING FUNDS!_
 
-- __MINIMAL SD CARD IMAGE ⮕ [raspiblitz-min-v1.10.0rc2-2023-08-02.img.gz](https://raspiblitz.fulmo.org/images/raspiblitz-min-v1.10.0rc2-2023-08-02.img.gz)__
+- **MINIMAL SD CARD IMAGE ⮕ [raspiblitz-min-v1.10.0rc2-2023-08-02.img.gz](https://raspiblitz.fulmo.org/images/raspiblitz-min-v1.10.0rc2-2023-08-02.img.gz)**
 - SHA-256: d2775524f5e51770294d873a9418b445041d98b97606c4510c3e322a180f9806
 <!-- - GPG 64-bit (main): 1C73 060C 7C17 6461 & (sub): AA9D D1B5 CC56 47DA
 - Signature-File: [raspiblitz-min-v1.9.0-2023-05-22.img.gz.sig](https://raspiblitz.fulmo.org/images/raspiblitz-min-v1.9.0-2023-05-22.img.gz.sig)
@@ -1296,7 +1299,7 @@ Run the command below to generate root SSH keys:
 `sudo /home/admin/config.scripts/blitz.ssh.sh root-get`
 The public key is found in the `sshPubKey=` section of the above output. For manual setup, use the value after the = without the single quotes.
 
-Copy the generated keys from above to the remote server (note, if your remote server doesn't allow password authentication, you will have to copy it manually). 
+Copy the generated keys from above to the remote server (note, if your remote server doesn't allow password authentication, you will have to copy it manually).
 `sudo /home/admin/config.scripts/blitz.ssh.sh root-transfer myuser@myserver`
 
 Note: If you do not copy the public key to your remote server, these backups will not work.


### PR DESCRIPTION
Use the new `raspiblitz` org link for the webui instead of `cstenglein` in the README.

Also fixed some trailing spaces / markdown issues (via Markdownlint).