### PR TITLE
use the nginx-full package for stream support on amd64

### DIFF
--- a/home.admin/config.scripts/blitz.web.sh
+++ b/home.admin/config.scripts/blitz.web.sh
@@ -37,7 +37,7 @@ elif [ "$1" = "http-on" ]; then
 
   # install
   sudo apt-get update
-  sudo apt-get install -y nginx apache2-utils
+  sudo apt-get install -y nginx-full apache2-utils
   if [ $? -ne 0 ]; then
     echo "error='nginx install failed'"
     exit 1


### PR DESCRIPTION
To fix the error got on fulcrum install using amd64 Debian 12 :

```
₿ sudo nginx -t                                                                             
2023/08/17 10:38:31 [emerg] 1355295#1355295: unknown directive "stream" in /etc/nginx/nginx.conf:86               
nginx: configuration file /etc/nginx/nginx.conf test failed    
```

Fixed after adding `nginx-full` containing the `libnginx-mod-stream` package

```
₿ sudo apt install nginx-full                                                               
Reading package lists... Done                                                                                     
Building dependency tree... Done                                                                                  
Reading state information... Done                                                                                 
The following additional packages will be installed:                                                              
  libnginx-mod-http-auth-pam libnginx-mod-http-dav-ext libnginx-mod-http-echo libnginx-mod-http-geoip2            
  libnginx-mod-http-subs-filter libnginx-mod-http-upstream-fair libnginx-mod-stream libnginx-mod-stream-geoip2    
The following NEW packages will be installed:                                                                     
  libnginx-mod-http-auth-pam libnginx-mod-http-dav-ext libnginx-mod-http-echo libnginx-mod-http-geoip2            
  libnginx-mod-http-subs-filter libnginx-mod-http-upstream-fair libnginx-mod-stream libnginx-mod-stream-geoip2    
  nginx-full                                                                                                      
0 upgraded, 9 newly installed, 0 to remove and 1 not upgraded.                                                    
Need to get 303 kB of archives.    
```