### PR TITLE
electrs: control the log level in the conf only

### DIFF
--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -319,7 +319,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     # https://github.com/romanz/electrs/blob/master/doc/usage.md#configuration-files-and-environment-variables
     sudo -u electrs mkdir /home/electrs/.electrs 2>/dev/null
     echo "\
-log_filters = \"INFO\"
+log_filters = \"WARN\"
 timestamp = true
 jsonrpc_import = true
 index-batch-size = 10
@@ -422,7 +422,6 @@ Type=simple
 TimeoutSec=60
 Restart=always
 RestartSec=60
-LogLevelMax=5
 
 # Hardening measures
 PrivateTmp=true


### PR DESCRIPTION
It is a returning question to enable electrs logs and the systemd setting is unexpected so better to remove. See: https://t.me/raspiblitz/134975

Reducing the level in the electrs config to WARN.

Other options:
https://docs.rs/env_logger/latest/env_logger/#enabling-logging
```
error
warn
info
debug
trace
```