### PR TITLE
handle nvme drives when using ext4

### DIFF
--- a/home.admin/config.scripts/blitz.datadrive.sh
+++ b/home.admin/config.scripts/blitz.datadrive.sh
@@ -717,6 +717,11 @@ if [ "$1" = "format" ]; then
 
   # formatting old: EXT4
   if [ "$2" = "ext4" ]; then
+     if [ $(echo "${hdd}" | grep -c "nvme")  = 0 ]; then
+       nvp=""
+     else
+       nvp="p"
+     fi
      # prepare temp mount point
      mkdir -p /tmp/ext4 1>/dev/null
      if [ $ext4IsPartition -eq 0 ]; then
@@ -733,7 +738,7 @@ if [ "$1" = "format" ]; then
           >&2 echo "# waiting until the partition gets available"
           sleep 2
           sync
-          loopdone=$(lsblk -o NAME | grep -c ${hdd}1)
+          loopdone=$(lsblk -o NAME | grep -c ${hdd}${nvp}1)
           loopcount=$(($loopcount +1))
           if [ ${loopcount} -gt 10 ]; then
             >&2 echo "# partition failed"
@@ -754,7 +759,7 @@ if [ "$1" = "format" ]; then
      fi
      >&2 echo "# Formatting"
      if [ $ext4IsPartition -eq 0 ]; then
-        mkfs.ext4 -F -L BLOCKCHAIN /dev/${hdd}1 1>/dev/null
+        mkfs.ext4 -F -L BLOCKCHAIN /dev/${hdd}${nvp}1 1>/dev/null
      else
         mkfs.ext4 -F -L BLOCKCHAIN /dev/${hdd} 1>/dev/null
      fi


### PR DESCRIPTION
I ran into an issue that when using NVME drives with ext4 they cannot be partitioned and formatted as the nvme drives are creatd in the format `nvme0n1p1` while the code right now looks for `nvme0n11` (see missing `p`). The attached code fixes this with existing code used for btrfs.
