### PR TITLE
Fix pip error: This environment is externally managed on Debian 12

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -375,6 +375,11 @@ else
   exit 1
 fi
 
+# remove any debian python protection from pip installing modules
+if [ "${baseimage}" = "debian" ]; then
+  rm /usr/lib/python3.*/EXTERNALLY-MANAGED
+fi
+
 # make sure /usr/bin/pip exists (and calls pip3 in Debian Buster)
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 # 1. libs (for global python scripts)
@@ -549,6 +554,9 @@ if [ $(sudo cat /etc/group | grep -c "^admin") -lt 1 ]; then
 else
   echo -e "\nOK group admin exists"
 fi
+# make admin home directly readable by others, the bitcoin user needs access to it
+chmod 755 /home/admin
+
 
 echo -e "\n*** ADDING SERVICE USER bitcoin"
 # based on https://raspibolt.org/guide/raspberry-pi/system-configuration.html

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -376,7 +376,7 @@ else
 fi
 
 # remove any debian python protection from pip installing modules
-if [ "${baseimage}" = "debian" ]; then
+if [ -f rm /usr/lib/python3.*/EXTERNALLY-MANAGED ]; then
   rm /usr/lib/python3.*/EXTERNALLY-MANAGED
 fi
 
@@ -554,9 +554,6 @@ if [ $(sudo cat /etc/group | grep -c "^admin") -lt 1 ]; then
 else
   echo -e "\nOK group admin exists"
 fi
-# make admin home directly readable by others, the bitcoin user needs access to it
-chmod 755 /home/admin
-
 
 echo -e "\n*** ADDING SERVICE USER bitcoin"
 # based on https://raspibolt.org/guide/raspberry-pi/system-configuration.html


### PR DESCRIPTION
I'm currently working on installing raspiblitz on a debian12 linux notebook and ran into some issues, mostly around pip and home directories, this PR fixes them and I can install raspi on a fresh debian 12

- remove python lock which prevents pip from installing modules
- make admin home directory readable