### PR TITLE
Recognizing Armbian system and  fixing "Bitcoin Install Fails" on Armbian

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -245,13 +245,7 @@ esac
 
 # AUTO-DETECTION: OPERATINGSYSTEM
 # ---------------------------------------
-# 
-# OrangePi5 was not recognized
-# so recognize it by same 'Debian' method,
-# replacing by 'Armbian'
-if [ $(cat /etc/os-release 2>/dev/null | grep -c 'Armbian') -gt 0 ]; then
-  baseimage="armbian"
-elif [ $(cat /etc/os-release 2>/dev/null | grep -c 'Debian') -gt 0 ]; then
+if [ $(cat /etc/os-release 2>/dev/null | grep -c 'Debian') -gt 0 ]; then
   if [ -f /etc/apt/sources.list.d/raspi.list ] && [ "${cpu}" = aarch64 ]; then
     # default image for RaspberryPi
     baseimage="raspios_arm64"
@@ -261,6 +255,8 @@ elif [ $(cat /etc/os-release 2>/dev/null | grep -c 'Debian') -gt 0 ]; then
   fi
 elif [ $(cat /etc/os-release 2>/dev/null | grep -c 'Ubuntu') -gt 0 ]; then
   baseimage="ubuntu"
+elif [ $(cat /etc/os-release 2>/dev/null | grep -c 'Armbian') -gt 0 ]; then
+  baseimage="armbian"
 else
   echo "\n# FAIL: Base Image cannot be detected or is not supported."
   cat /etc/os-release 2>/dev/null

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -245,7 +245,13 @@ esac
 
 # AUTO-DETECTION: OPERATINGSYSTEM
 # ---------------------------------------
-if [ $(cat /etc/os-release 2>/dev/null | grep -c 'Debian') -gt 0 ]; then
+# 
+# OrangePi5 was not recognized
+# so recognize it by same 'Debian' method,
+# replacing by 'Armbian'
+if [ $(cat /etc/os-release 2>/dev/null | grep -c 'Armbian') -gt 0 ]; then
+  baseimage="armbian"
+elif [ $(cat /etc/os-release 2>/dev/null | grep -c 'Debian') -gt 0 ]; then
   if [ -f /etc/apt/sources.list.d/raspi.list ] && [ "${cpu}" = aarch64 ]; then
     # default image for RaspberryPi
     baseimage="raspios_arm64"

--- a/home.admin/config.scripts/bitcoin.install.sh
+++ b/home.admin/config.scripts/bitcoin.install.sh
@@ -27,11 +27,14 @@ if [ "$1" = "install" ]; then
   cd /home/admin/download || exit 1
 
   # receive signer key
-  if ! gpg --keyserver hkp://keyserver.ubuntu.com --recv-key "71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
-  then
-    echo "# FAIL # Couldn't download Wladimir J. van der Laan's PGP pubkey"
-    exit 1
-  fi
+  # Bitcoin Install Fails during build_sdcard.sh due to PGP key download
+  # see https://github.com/raspiblitz/raspiblitz/issues/3753
+  # comment it by now
+  #if ! gpg --keyserver hkp://keyserver.ubuntu.com --recv-key "71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
+  #then
+  #  echo "# FAIL # Couldn't download Wladimir J. van der Laan's PGP pubkey"
+  #  exit 1
+  #fi
 
   # download signed binary sha256 hash sum file
   sudo -u admin wget https://bitcoincore.org/bin/bitcoin-core-${bitcoinVersion}/SHA256SUMS

--- a/home.admin/config.scripts/bitcoin.install.sh
+++ b/home.admin/config.scripts/bitcoin.install.sh
@@ -29,12 +29,17 @@ if [ "$1" = "install" ]; then
   # receive signer key
   # Bitcoin Install Fails during build_sdcard.sh due to PGP key download
   # see https://github.com/raspiblitz/raspiblitz/issues/3753
-  # comment it by now
-  #if ! gpg --keyserver hkp://keyserver.ubuntu.com --recv-key "71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
-  #then
-  #  echo "# FAIL # Couldn't download Wladimir J. van der Laan's PGP pubkey"
-  #  exit 1
-  #fi
+  # see https://github.com/raspiblitz/raspiblitz/issues/3679
+  # If fails:
+  # In my /etc/resolv.conf file was:
+  # nameserver 192.168.1.1
+  # I changed it to quad9:
+  # nameserver 9.9.9.9
+  if ! gpg --keyserver hkps://keys.openpgp.org --recv-key "71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
+  then
+    echo "# FAIL # Couldn't download Wladimir J. van der Laan's PGP pubkey"
+    exit 1
+  fi
 
   # download signed binary sha256 hash sum file
   sudo -u admin wget https://bitcoincore.org/bin/bitcoin-core-${bitcoinVersion}/SHA256SUMS

--- a/home.admin/config.scripts/bitcoin.install.sh
+++ b/home.admin/config.scripts/bitcoin.install.sh
@@ -27,14 +27,6 @@ if [ "$1" = "install" ]; then
   cd /home/admin/download || exit 1
 
   # receive signer key
-  # Bitcoin Install Fails during build_sdcard.sh due to PGP key download
-  # see https://github.com/raspiblitz/raspiblitz/issues/3753
-  # see https://github.com/raspiblitz/raspiblitz/issues/3679
-  # If fails:
-  # In my /etc/resolv.conf file was:
-  # nameserver 192.168.1.1
-  # I changed it to quad9:
-  # nameserver 9.9.9.9
   if ! gpg --keyserver hkps://keys.openpgp.org --recv-key "71A3 B167 3540 5025 D447 E8F2 7481 0B01 2346 C9A6"
   then
     echo "# FAIL # Couldn't download Wladimir J. van der Laan's PGP pubkey"


### PR DESCRIPTION
## Before submitting this PR, please make sure:

- [x] That its based against the `dev` brach - not the default release branch.

## Changes
- [`build_sdcard.sh`](https://github.com/raspiblitz/raspiblitz/compare/dev...qlrd:raspiblitz:dev#diff-d1b9f4fd771f3f8a16a155dab645da627dbae02ec61fdc427058b0e51c7506e0)

- [`home.admin/config.scripts/bitcoin.install.sh`](https://github.com/raspiblitz/raspiblitz/compare/dev...qlrd:raspiblitz:dev#diff-3efd6cd0c943d97fdf51f125d063b5c863a6c23714afc0fa9a4b7fb025d63c8b)

## Related issues

- [Bitcoin Install Fails during build_sdcard.sh due to PGP key download](https://github.com/raspiblitz/raspiblitz/issues/3753);

- [Proxmox: # FAIL # Couldn't download Wladimir...](https://github.com/raspiblitz/raspiblitz/issues/3679)


## Description

This PR was made speciffically to my device, but I hope can help others with similar setup, recognizing Armbian system during `build_sdcard.sh`execution and fixing "Bitcoin Install Fails" on Armbian due to PGP key download.


### Device

- Orange Pi 5B

### Operational System

- Armbian 23.8.1 bullseye

## Issues

### Fail to recognize 'Armbian'

When running 'build_sdcard.sh' of the standard version ('v1.9'), the script recognizes the system as 'Debian' and thus Assigns the variable 'BaseImage' as '"raspios_arm64"'. Consequently, inappropriate settings are created in the rest of the script.

The content of '/etc/release-os' for **Armbian 23.8.1 bullseye** is similar to:

```
PRETTY_NAME="Armbian 23.8.1 bullseye"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.armbian.com"
SUPPORT_URL="https://forum.armbian.com"
BUG_REPORT_URL="https://www.armbian.com/bugs"
ARMBIAN_PRETTY_NAME="Armbian 23.8.1 bullseye"
```

Therefore, inserting a check similar to the 'Debian' system solves this for this setup (see `diff` for `build_sdcard.sh`).

### Bitcoin Install Fails during build_sdcard.sh due to PGP key download

During the Bitcoin core installation process, I came across the failure to download Wladimir J. van der Laan's PGP key. In my setup, this was solved in two steps: 

- changing the key server from `hkp://keyserver.ubuntu.com` to `hkps://keys.openpgp.org` (see `diff` for `home.admin/config.scripts/bitcoin.install.sh`);

- adding a DNS server to the `/etc/resolv.conf` file (manual modification).

## Results

- 🐧 Armbian recognized;
- 🔑 Wladimir J. van der Laan's PGP key downloaded;
- 🚀 Now Orangepi5B runs raspiblitz like a rocket.