### PR TITLE
bos telegram systemd service broken in v1.10.0 - rm working dir 

### DIFF
--- a/home.admin/config.scripts/bonus.bos.sh
+++ b/home.admin/config.scripts/bonus.bos.sh
@@ -130,7 +130,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/bos/balanceofsatoshis
+WorkingDirectory=/home/bos
 ExecStart=/home/bos/.npm-global/bin/bos telegram --connect $3 -v
 User=bos
 Group=bos

--- a/home.admin/config.scripts/bonus.bos.sh
+++ b/home.admin/config.scripts/bonus.bos.sh
@@ -130,7 +130,6 @@ After=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/home/bos
 ExecStart=/home/bos/.npm-global/bin/bos telegram --connect $3 -v
 User=bos
 Group=bos


### PR DESCRIPTION
Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.

bos telegram systemd service broken in v1.10.0 - rm working dir fixes issue. 
dir balanceofsatoshis no longer exists.