### PR TITLE
Broken builds on amd64 for blitz api and core lightning (debian 12)

### DIFF
--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -17,7 +17,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ "$1" = "-help" ];
   echo "blitz.web.api.sh on DEFAULT"
   echo "blitz.web.api.sh update-config"
   echo "blitz.web.api.sh update-code [?BRANCH]"
-  echo "blitz.web.api.sh off"
+  echo "blitz.web.api.sh off"f
   exit 1
 fi
 
@@ -286,13 +286,9 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # install
   echo "# running install"
   sudo -u blitzapi python3 -m venv venv
-  # see https://github.com/raspiblitz/raspiblitz/issues/4169 - requires both Cython upgrade and use-pep517 for now
+  # see https://github.com/raspiblitz/raspiblitz/issues/4169 - requires a Cython upgrade.
   if ! sudo -u blitzapi ./venv/bin/pip install --upgrade Cython; then
     echo "error='pip install upgrade Cython'"
-    exit 1
-  fi
-  if ! sudo -u blitzapi ./venv/bin/pip install install cchardet --use-pep517; then
-    echo "error='pip install cchardet failed'"
     exit 1
   fi
   if ! sudo -u blitzapi ./venv/bin/pip install -r requirements.txt --no-deps; then

--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -287,7 +287,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   echo "# running install"
   sudo -u blitzapi python3 -m venv venv
   # see https://github.com/raspiblitz/raspiblitz/issues/4169 - requires both Cython upgrade and use-pep517 for now
-  if ! sudo -u blitzapi ./venv/bin/pip install --upgrade Cython then
+  if ! sudo -u blitzapi ./venv/bin/pip install --upgrade Cython; then
     echo "error='pip install upgrade Cython'"
     exit 1
   fi

--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -286,7 +286,11 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # install
   echo "# running install"
   sudo -u blitzapi python3 -m venv venv
-  # see https://github.com/raspiblitz/raspiblitz/issues/4169
+  # see https://github.com/raspiblitz/raspiblitz/issues/4169 - requires both Cython upgrade and use-pep517 for now
+  if ! sudo -u blitzapi ./venv/bin/pip install --upgrade Cython then
+    echo "error='pip install upgrade Cython'"
+    exit 1
+  fi
   if ! sudo -u blitzapi ./venv/bin/pip install install cchardet --use-pep517; then
     echo "error='pip install cchardet failed'"
     exit 1

--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -17,7 +17,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] || [ "$1" = "-help" ];
   echo "blitz.web.api.sh on DEFAULT"
   echo "blitz.web.api.sh update-config"
   echo "blitz.web.api.sh update-code [?BRANCH]"
-  echo "blitz.web.api.sh off"f
+  echo "blitz.web.api.sh off"
   exit 1
 fi
 

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -42,7 +42,7 @@ function installDependencies() {
     libsqlite3-dev python3 net-tools zlib1g-dev libsodium-dev \
     gettext
   # additional requirements
-  sudo apt-get install -y postgresql libpq-dev psutil
+  sudo apt-get install -y postgresql libpq-dev
   # upgrade pip
   sudo pip3 install --upgrade pip
   sudo -u bitcoin pip install mako

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -42,7 +42,7 @@ function installDependencies() {
     libsqlite3-dev python3 net-tools zlib1g-dev libsodium-dev \
     gettext
   # additional requirements
-  sudo apt-get install -y postgresql libpq-dev
+  sudo apt-get install -y postgresql libpq-dev psutil
   # upgrade pip
   sudo pip3 install --upgrade pip
   sudo -u bitcoin pip install mako


### PR DESCRIPTION
There was a missing dependency for psutil for core lightning.
The --use-pip didn't work correctly on debian 12, and the fix was to upgrade Cython.