### PR TITLE
Rename Electrs INDEX option to REINDEX

### DIFF
--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -193,7 +193,7 @@ Check 'sudo nginx -t' for a detailed error message.
   # Options (available without TOR)
   OPTIONS=( \
         CONNECT "How to Connect" \
-        INDEX "Delete&Rebuild Index" \
+        REINDEX "Delete&Rebuild Index" \
         STATUS "ElectRS Status Info"
 	)
 
@@ -238,7 +238,7 @@ Check 'sudo nginx -t' for a detailed error message.
     echo "Press ENTER to get back to main menu."
     read key
     ;;
-    INDEX)
+    REINDEX)
     echo "######## Delete/Rebuild Index ########"
     echo "# stopping service"
     sudo systemctl stop electrs


### PR DESCRIPTION
Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.

I suggest renaming the **INDEX** option in the Electrs configuration menu to **REINDEX** to better reflects its meaning. 

Although the option description says _"Delete&Rebuild Index"_, the name "INDEX" suggests that you get into some index settings where you can delete and rebuild the index or do something else. Instead, hitting this option, which is located among the harmless ones, just instantly deletes the index that took 2 days to build, without any confirmation.