### PR TITLE
Activate i2p more reliably

### DIFF
--- a/home.admin/_provision_.sh
+++ b/home.admin/_provision_.sh
@@ -210,11 +210,6 @@ else
   echo "Provisioning Bitcoin Core interims update - keep default" >> ${logFile}
 fi
 
-# I2P
-echo "Start i2pd" >> ${logFile}
-/home/admin/_cache.sh set message "i2pd setup"
-/home/admin/config.scripts/blitz.i2pd.sh on >> ${logFile}
-
 # LND INTERIMS UPDATE
 if [ ${#lndInterimsUpdate} -gt 0 ]; then
   /home/admin/_cache.sh set message "Provisioning LND update"
@@ -810,6 +805,11 @@ if [ ${confExists} -eq 0 ]; then
   cp /home/admin/assets/bitcoin.conf /mnt/hdd/bitcoin/bitcoin.conf
   chown bitcoin:bitcoin /mnt/hdd/bitcoin/bitcoin.conf
 fi
+
+# I2P
+echo "Start i2pd" >> ${logFile}
+/home/admin/_cache.sh set message "i2pd setup"
+/home/admin/config.scripts/blitz.i2pd.sh on >> ${logFile}
 
 # signal setup done
 /home/admin/_cache.sh set message "Setup Done"

--- a/home.admin/config.scripts/blitz.i2pd.sh
+++ b/home.admin/config.scripts/blitz.i2pd.sh
@@ -92,7 +92,7 @@ function bitcoinI2Pstatus {
   echo "# Follow live with the command:"
   echo "sudo tail -n 1000 -f /mnt/hdd/bitcoin/debug.log | grep i2p"
   echo
-  sudo cat  /mnt/hdd/bitcoin/debug.log | grep i2p
+  sudo cat /mnt/hdd/bitcoin/debug.log | grep i2p
   echo
   echo "# Running the command:"
   echo "bitcoin-cli -netinfo 4"
@@ -106,7 +106,6 @@ function bitcoinI2Pstatus {
   echo "# Password: your passwordB"
   echo
 }
-
 
 echo "# Running: 'blitz.i2pd.sh $*'"
 source /mnt/hdd/raspiblitz.conf
@@ -145,11 +144,10 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   if systemctl is-active --quiet i2pd.service; then
     echo "# i2pd.service is already active."
-    exit 0
+  else
+    echo "# sudo systemctl enable i2pd"
+    sudo systemctl enable i2pd
   fi
-
-  echo "# sudo systemctl enable i2pd"
-  sudo systemctl enable i2pd
 
   echo "# i2pd config"
   /home/admin/config.scripts/blitz.conf.sh set debug tor /mnt/hdd/bitcoin/bitcoin.conf noquotes
@@ -159,7 +157,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   /home/admin/config.scripts/blitz.conf.sh set onlynet tor /mnt/hdd/bitcoin/bitcoin.conf noquotes
   confAdd onlynet i2p /mnt/hdd/bitcoin/bitcoin.conf
   PASSWORD_B=$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcpassword | cut -c 13-)
-  cat << EOF | sudo tee /etc/i2pd/i2pd.conf
+  cat <<EOF | sudo tee /etc/i2pd/i2pd.conf
 # i2pd settings for the RaspiBlitz
 # for the defaults see:
 # https://github.com/PurpleI2P/i2pd/blob/openssl/contrib/i2pd.conf
@@ -212,6 +210,7 @@ EOF
   # setting value in raspiblitz.conf
   /home/admin/config.scripts/blitz.conf.sh set i2pd "on"
 
+  localip=$(hostname -I | awk '{print $1}')
   echo "# Config: /etc/i2pd/i2pd.conf"
   echo "# i2pd web console: ${localip}:7070"
   echo "# Monitor i2p in bitcoind:"


### PR DESCRIPTION
Found on a recover that i2p is not working for bitcoind, aiming to make the activation more reliable here.