### PR TITLE
Local release image build with Packer 

### DIFF
--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -9,8 +9,12 @@
 * Make sure the packer script is in root of the 128GB-USBDrive
   * If it is not there download: `curl -O -L https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
 * Security read/check script and then start build with (replace parameters):
-* `sudo bash ./packer.sh [BRANCH] [arm|x86] [min|fat]`
-
+* `sudo bash ./packer.sh [BRANCH] [arm|x86] [min|fat] [?LASTCOMMITHASH]`
+  * BRANCH = the branch of which the image should be build
+  * `[arm|x86]` = The architecture the image is targeting
+  * `[min|fat]` = lean or fatpack
+  * LASTCOMMITHASH (optional) = security check & copy the latest commit hash of the branch you want to build
+ 
 ### What is the process of creating a new RaspberryPi SD card image release manually?
 
 Checklist before making a SD card image release:

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -7,7 +7,8 @@
   * Connect a additional 128GB USB with NFTS formatted 
 * Using Filemanager open the 128GB-USBDrive and right-click "Open in Terminal"
 * Make sure the packer script is in root of the 128GB-USBDrive
-  * If it is not there download: `curl -O -L https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
+  * If it is not there download: 
+  * `curl -O -L https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
 * Security read/check script and then start build with (replace parameters):
 * `sudo bash ./packer.sh [BRANCH] [arm|x86] [min|fat] [?LASTCOMMITHASH]`
   * `BRANCH` = the branch name on this repo of which the image should be build

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -10,9 +10,9 @@
   * If it is not there download: `curl -O -L https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
 * Security read/check script and then start build with (replace parameters):
 * `sudo bash ./packer.sh [BRANCH] [arm|x86] [min|fat] [?LASTCOMMITHASH]`
-  * `BRANCH` = the branch of which the image should be build
-  * `[arm|x86]` = The architecture the image is targeting
-  * `[min|fat]` = lean or fatpack
+  * `BRANCH` = the branch name on this repo of which the image should be build
+  * `[arm|x86]` = The architecture the image is targeting (RaspberryPi = `arm`)
+  * `[min|fat]` = lean or fatpack (fatpack prepackages lots of apps already with the image)
   * `LASTCOMMITHASH` (optional) = security check & copy the latest commit hash of the branch you want to build
  
 ### What is the process of creating a new RaspberryPi SD card image release manually?

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -1,6 +1,17 @@
 ## FAQ Development
 
-### What is the process of creating a new SD card image release?
+### Steps to create RaspberryPi images with Packer?
+
+* Start [`Debian LIVE`](https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid/debian-live-12.4.0-amd64-cinnamon.iso) from USB stick
+  * On USB boot be sure to start the "LIVE_SYSTEM" image
+  * Connect a additional 128GB USB with NFTS formatted 
+* Using Filemanager open the 128GB-USBDrive and right-click "Open in Terminal"
+* Make sure the packer script is in root of the 128GB-USBDrive
+  * If it is not there download: `wget --no-cache https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
+* Security read/check script and then start build with (replace parameters):
+* `sudo bash ./packer.sh [BRANCH] [lean|fat|x86]`
+
+### What is the process of creating a new RaspberryPi SD card image release manually?
 
 Checklist before making a SD card image release:
 

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -7,7 +7,7 @@
   * Connect a additional 128GB USB with NFTS formatted 
 * Using Filemanager open the 128GB-USBDrive and right-click "Open in Terminal"
 * Make sure the packer script is in root of the 128GB-USBDrive
-  * If it is not there download: `curl -O -L --no-cache https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
+  * If it is not there download: `curl -O -L https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
 * Security read/check script and then start build with (replace parameters):
 * `sudo bash ./packer.sh [BRANCH] [lean|fat|x86]`
 

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -9,7 +9,7 @@
 * Make sure the packer script is in root of the 128GB-USBDrive
   * If it is not there download: `curl -O -L https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
 * Security read/check script and then start build with (replace parameters):
-* `sudo bash ./packer.sh [BRANCH] [lean|fat|x86]`
+* `sudo bash ./packer.sh [BRANCH] [arm|x86] [min|fat]`
 
 ### What is the process of creating a new RaspberryPi SD card image release manually?
 

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -7,7 +7,7 @@
   * Connect a additional 128GB USB with NFTS formatted 
 * Using Filemanager open the 128GB-USBDrive and right-click "Open in Terminal"
 * Make sure the packer script is in root of the 128GB-USBDrive
-  * If it is not there download: `wget --no-cache https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
+  * If it is not there download: `curl -O -L --no-cache https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
 * Security read/check script and then start build with (replace parameters):
 * `sudo bash ./packer.sh [BRANCH] [lean|fat|x86]`
 

--- a/FAQ.dev.md
+++ b/FAQ.dev.md
@@ -10,10 +10,10 @@
   * If it is not there download: `curl -O -L https://raw.githubusercontent.com/raspiblitz/raspiblitz/dev/ci/packer.sh`
 * Security read/check script and then start build with (replace parameters):
 * `sudo bash ./packer.sh [BRANCH] [arm|x86] [min|fat] [?LASTCOMMITHASH]`
-  * BRANCH = the branch of which the image should be build
+  * `BRANCH` = the branch of which the image should be build
   * `[arm|x86]` = The architecture the image is targeting
   * `[min|fat]` = lean or fatpack
-  * LASTCOMMITHASH (optional) = security check & copy the latest commit hash of the branch you want to build
+  * `LASTCOMMITHASH` (optional) = security check & copy the latest commit hash of the branch you want to build
  
 ### What is the process of creating a new RaspberryPi SD card image release manually?
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GITHUB_HEAD_REF = $(shell git rev-parse --abbrev-ref HEAD)
 amd64-lean-desktop-uefi-image:
 	# Run the build script
 	cd ci/amd64 && \
-	bash packer.build.amd64-debian.sh \
+	sudo bash packer.build.amd64-debian.sh \
 	  --pack lean \
 	  --github_user $(GITHUB_ACTOR) \
 	  --branch $(GITHUB_HEAD_REF) \
@@ -31,7 +31,7 @@ amd64-lean-desktop-uefi-image:
 amd64-lean-server-legacyboot-image:
 	# Run the build script
 	cd ci/amd64 && \
-	bash packer.build.amd64-debian.sh \
+	sudo bash packer.build.amd64-debian.sh \
 	  --pack lean \
 	  --github_user $(GITHUB_ACTOR) \
 	  --branch $(GITHUB_HEAD_REF) \
@@ -57,7 +57,7 @@ amd64-lean-server-legacyboot-image:
 amd64-fatpack-desktop-uefi-image:
 	# Run the build script
 	cd ci/amd64 && \
-	bash packer.build.amd64-debian.sh \
+	sudo bash packer.build.amd64-debian.sh \
 	--pack fatpack \
 	--github_user $(GITHUB_ACTOR) \
 	--branch $(GITHUB_HEAD_REF) \
@@ -83,7 +83,7 @@ amd64-fatpack-desktop-uefi-image:
 arm64-rpi-lean-image:
 	# Run the build script
 	cd ci/arm64-rpi && \
-	bash packer.build.arm64-rpi.local.sh \
+	sudo bash packer.build.arm64-rpi.local.sh \
 	--pack lean \
 	--github_user $(GITHUB_ACTOR) \
 	--branch $(GITHUB_HEAD_REF)

--- a/ci/arm64-rpi/packer.build.arm64-rpi.local.sh
+++ b/ci/arm64-rpi/packer.build.arm64-rpi.local.sh
@@ -59,7 +59,8 @@ go build || exit 1
 
 # set vars
 echo "# Setting the variables: $*"
-source ../set_variables.sh
+# running from the ci/arm64-rpi/packer-builder-arm directory
+source ../../set_variables.sh
 set_variables "$@"
 
 cp ../build.arm64-rpi.pkr.hcl ./

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -60,6 +60,7 @@ git checkout $BRANCH
 
 # get code version
 source <(./home.admin/_version.info)
+codeVersion=$(cat ./home_admin/_version.info | grep 'codeVersion="' | cut -d'"' -f2)
 echo "# RaspiBlitz Version: ${codeVersion}"
 
 # get date as string fromatted like YEAR-MONTH-DAY

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -95,7 +95,7 @@ if [ ${#codeVersion} -eq 0 ]; then
 fi
 echo "# RaspiBlitz Version: ${codeVersion}"
 
-# get date as string fromatted like YEAR-MONTH-DAY
+# get date as string formatted like YEAR-MONTH-DAY
 dateString=$(date +%Y-%m-%d)
 echo "# Date: ${dateString}"
 
@@ -127,7 +127,7 @@ if [ -f "./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz" ]; then
   exit 1
 fi
 
-# prevet monitor to go to sleep during long non-inetractive build
+# prevent monitor to go to sleep during long non-interactive build
 xset s off
 gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
 
@@ -141,7 +141,7 @@ if [ $? -gt 0 ]; then
   exit 1
 fi
 
-echo "# BUILDING SUCESS ###########################################"
+echo "# BUILDING SUCCESS ###########################################"
 
 echo "# moving build to timestamped folder ./${BUILDFOLDER}"
 cd ..

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -48,21 +48,11 @@ else
   exit 1
 fi
 
-# check if build was successful
-if [ $? -gt 0 ]; then
-  echo "# BUILDING FAILED ###########################################"
-  echo "# Check the output above for errors."
-  exit 1
-fi
-
 # check if started with sudo
 if [ "$EUID" -ne 0 ]; then
   echo "error='run as root / may use sudo'"
   exit 1
 fi
-
-# switch to root
-sudo su
 
 # install git and make
 apt update && apt install -y git make
@@ -76,6 +66,9 @@ cd raspiblitz
 
 # checkout the desired branch
 git checkout $BRANCH
+
+# prevet monitor to go to sleep during long non-inetractive build
+xset s off
 
 echo "# BUILDING '${PACKERTARGET}' ###########################################"
 make $PACKERTARGET

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -53,8 +53,6 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
-git log -1 --format=%H | grep -c
-
 # install git and make
 apt update && apt install -y git make
 
@@ -73,7 +71,6 @@ cd raspiblitz
 
 # checkout the desired branch
 git checkout $BRANCH
-
 
 # check commit hash if set
 if [ ${#COMMITHASH} -gt 0 ]; then

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -53,14 +53,23 @@ rm -rf raspiblitz 2>/dev/null
 
 # download the repo
 git clone $REPO
+if [ $? -gt 0 ]; then
+  echo "# REPO: ${REPO}"
+  echo "error='git clone failed'"
+  exit 1
+fi
+
 cd raspiblitz
 
 # checkout the desired branch
 git checkout $BRANCH
 
 # get code version
-source <(./home.admin/_version.info)
 codeVersion=$(cat ./home_admin/_version.info | grep 'codeVersion="' | cut -d'"' -f2)
+if [ ${#codeVersion} -eq 0 ]; then
+  echo "error='codeVersion not found'"
+  exit 1
+fi
 echo "# RaspiBlitz Version: ${codeVersion}"
 
 # get date as string fromatted like YEAR-MONTH-DAY

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -146,7 +146,7 @@ echo "# Keep this terminal open and the 128GB stick connected."
 echo "# Additionalley connect and unlock the USB device with the signer keys."
 echo "# Open in Filemanager and use right-click 'Open in Termonal' and run:"
 echo "# gpg --import ./sub.key"
-echi "# Close that second terminal and remove USB device with signer keys."
+echo "# Close that second terminal and remove USB device with signer keys."
 echo 
 echo "# Press RETURN to continue..."
 read -r -p "" key

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+#########################################################################
+# script to trigger packer image build on a debian LIVE system
+# see FAQ.dev.md for instructions
+##########################################################################
+
+# YOUR REPO (REPLACE WITH YOUR OWN FORK IF NEEDED)
+REPO = "https://github.com/raspiblitz/raspiblitz"
+
+echo "Build RaspiBlitz install images on a Debian LIVE system"
+echo "From repo (change in script is needed):"
+echo $REPO
+
+# give info if not started with parameters
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+  echo "Start this script in the root of an writable 128GB NTFS formatted USB drive:"
+  echo "packer.sh [BRANCH] [lean|fat|x86]"
+  exit 1
+fi
+
+BRANCH = $1
+OUTPUT = $2
+
+# check if branch is set
+if [ "$BRANCH" == "[BRANCH]" ]; then
+  echo "error='branch not set'"
+  exit 1
+fi
+
+# check if output is set
+if [ -z "$OUTPUT" ]; then
+  echo "error='output not set'"
+  exit 1
+fi
+
+if [ "${OUTPUT}" == "lean" ]; then
+  PACKERTARGET = "arm64-rpi-lean-image"
+  PACKERBUILDPATH = "./raspiblitz/ci/arm64-rpi/packer-builder-arm/raspiblitz-arm64-rpi-lean"
+elif [ "${OUTPUT}" == "fat" ]; then
+  PACKERTARGET = "arm64-rpi-fatpack-image" 
+  PACKERBUILDPATH = "./raspiblitz/ci/arm64-rpi/packer-builder-arm/TODO" #TODO
+elif [ "${OUTPUT}" == "x86" ]; then
+  PACKERTARGET = "amd64-lean-server-legacyboot-image" 
+  PACKERBUILDPATH = "./raspiblitz/ci/amd64/TODO" #TODO
+else
+  echo "error='output $OUTPUT not supported'"
+  exit 1
+fi
+
+# check if build was successful
+if [ $? -gt 0 ]; then
+  echo "# BUILDING FAILED ###########################################"
+  echo "# Check the output above for errors."
+  exit 1
+fi
+
+# check if started with sudo
+if [ "$EUID" -ne 0 ]; then
+  echo "error='run as root / may use sudo'"
+  exit 1
+fi
+
+# switch to root
+sudo su
+
+# install git and make
+apt update && apt install -y git make
+
+# clean old repo
+rm -rf raspiblitz 2>/dev/null
+
+# download the repo
+git clone $REPO
+cd raspiblitz
+
+# checkout the desired branch
+git checkout $BRANCH
+
+echo "# BUILDING '${PACKERTARGET}' ###########################################"
+make $PACKERTARGET
+
+# check if build was successful
+if [ $? -gt 0 ]; then
+  echo "# BUILDING FAILED ###########################################"
+  echo "# Check the output above for errors."
+  exit 1
+fi
+
+echo "# BUILDING SUCESS ###########################################"
+
+echo "# moving build to timestamped folder"
+TIMESTAMP = $(date +%s)
+mkdir $TIMESTAMP
+mv $PACKERBUILDPATH.img.gz ./$TIMESTAMP
+mv $PACKERBUILDPATH.img.gz.sha256 ./$TIMESTAMP
+mv $PACKERBUILDPATH.img.sha256 ./$TIMESTAMP
+
+echo "# TODO: CLEAN UP OLD BUILDS"
+echo "# TODO: CUT INTERNET & SIGN IMAGE"
+
+
+
+
+
+
+
+

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -65,7 +65,7 @@ cd raspiblitz
 git checkout $BRANCH
 
 # get code version
-codeVersion=$(cat ./home_admin/_version.info | grep 'codeVersion="' | cut -d'"' -f2)
+codeVersion=$(cat ./home.admin/_version.info | grep 'codeVersion="' | cut -d'"' -f2)
 if [ ${#codeVersion} -eq 0 ]; then
   echo "error='codeVersion not found'"
   exit 1

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -72,6 +72,7 @@ git checkout $BRANCH
 
 # prevet monitor to go to sleep during long non-inetractive build
 xset s off
+gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
 
 echo "# BUILDING '${PACKERTARGET}' ###########################################"
 make $PACKERTARGET
@@ -87,6 +88,7 @@ echo "# BUILDING SUCESS ###########################################"
 
 TIMESTAMP=$(date +%s)
 echo "# moving build to timestamped folder ./${TIMESTAMP}"
+cd ..
 mkdir "${TIMESTAMP}"
 if [ $? -gt 0 ]; then
   echo "# FAILED CREATING FOLDER: ${TIMESTAMP}"

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -8,9 +8,14 @@
 # YOUR REPO (REPLACE WITH YOUR OWN FORK IF NEEDED)
 REPO="https://github.com/raspiblitz/raspiblitz"
 
+# folders to store the build results
+BUILDFOLDER="images"
+
 echo "Build RaspiBlitz install images on a Debian LIVE system"
 echo "From repo (change in script is needed):"
 echo $REPO
+echo "Results will be stored in:"
+echo $BUILDFOLDER
 
 # give info if not started with parameters
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -34,23 +39,6 @@ if [ -z "$OUTPUT" ]; then
   exit 1
 fi
 
-if [ "${OUTPUT}" == "lean" ]; then
-  PACKERTARGET="arm64-rpi-lean-image"
-  PACKERBUILDPATH="./raspiblitz/ci/arm64-rpi/packer-builder-arm/"
-  PACKERBUILDFILE="raspiblitz-arm64-rpi-lean"
-elif [ "${OUTPUT}" == "fat" ]; then
-  PACKERTARGET="arm64-rpi-fatpack-image" 
-  PACKERBUILDPATH="./raspiblitz/ci/arm64-rpi/packer-builder-arm/TODO" #TODO
-  PACKERBUILDFILE="TODO" #TODO
-elif [ "${OUTPUT}" == "x86" ]; then
-  PACKERTARGET="amd64-lean-server-legacyboot-image" 
-  PACKERBUILDPATH="./raspiblitz/ci/amd64/TODO" #TODO
-  PACKERBUILDFILE="TODO" #TODO
-else
-  echo "error='output $OUTPUT not supported'"
-  exit 1
-fi
-
 # check if started with sudo
 if [ "$EUID" -ne 0 ]; then
   echo "error='run as root / may use sudo'"
@@ -70,6 +58,35 @@ cd raspiblitz
 # checkout the desired branch
 git checkout $BRANCH
 
+# get code version
+source <(./home.admin/_version.info)
+echo "# RaspiBlitz Version: ${codeVersion}"
+
+# get date as string fromatted like YEAR-MONTH-DAY
+dateString=$(date +%Y-%m-%d)
+echo "# Date: ${dateString}"
+
+if [ "${OUTPUT}" == "lean" ]; then
+  PACKERTARGET="arm64-rpi-lean-image"
+  PACKERBUILDPATH="./raspiblitz/ci/arm64-rpi/packer-builder-arm/raspiblitz-arm64-rpi-lean"
+  PACKERFINALFILE="raspiblitz-min-${codeVersion}-${dateString}"
+elif [ "${OUTPUT}" == "fat" ]; then
+  PACKERTARGET="arm64-rpi-fatpack-image" 
+  PACKERBUILDPATH="./raspiblitz/ci/arm64-rpi/packer-builder-arm/TODO" #TODO
+  PACKERFINALFILE="raspiblitz-fat-${codeVersion}-${dateString}"
+elif [ "${OUTPUT}" == "x86" ]; then
+  PACKERTARGET="amd64-lean-server-legacyboot-image" 
+  PACKERBUILDPATH="./raspiblitz/ci/amd64/TODO" #TODO
+  PACKERFINALFILE="raspiblitz-amd64-${codeVersion}-${dateString}"
+else
+  echo "error='output $OUTPUT not supported'"
+  exit 1
+fi
+
+echo "# PACKER TARGET: ${PACKERTARGET}"
+echo "# PACKER BUILD PATH: ${PACKERBUILDPATH}"
+echo "# PACKER FINAL FILE: ${PACKERFINALFILE}"
+
 # prevet monitor to go to sleep during long non-inetractive build
 xset s off
 gsettings set org.gnome.desktop.screensaver idle-activation-enabled false
@@ -86,25 +103,24 @@ fi
 
 echo "# BUILDING SUCESS ###########################################"
 
-TIMESTAMP=$(date +%s)
-echo "# moving build to timestamped folder ./${TIMESTAMP}"
+echo "# moving build to timestamped folder ./${BUILDFOLDER}"
 cd ..
-mkdir "${TIMESTAMP}"
+mkdir "${BUILDFOLDER}"
 if [ $? -gt 0 ]; then
-  echo "# FAILED CREATING FOLDER: ${TIMESTAMP}"
+  echo "# FAILED CREATING FOLDER: ${BUILDFOLDER}"
   exit 1
 fi
-mv "${PACKERBUILDPATH}${PACKERBUILDFILE}.img.gz" "./${TIMESTAMP}/${PACKERBUILDFILE}.img.gz"
+mv "${PACKERBUILDPATH}.img.gz" "./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz"
 if [ $? -gt 0 ]; then
   echo "# FAILED MOVING .img.gz"
   exit 1
 fi
-mv "${PACKERBUILDPATH}${PACKERBUILDFILE}.img.gz.sha256" "./${TIMESTAMP}/${PACKERBUILDFILE}.img.gz.sha256"
+mv "${PACKERBUILDPATH}.img.gz.sha256" "./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz.sha256"
 if [ $? -gt 0 ]; then
   echo "# FAILED MOVING .img.gz.sha256"
   exit 1
 fi
-mv "${PACKERBUILDPATH}${PACKERBUILDFILE}.img.sha256" "./${TIMESTAMP}/${PACKERBUILDFILE}.img.sha256"
+mv "${PACKERBUILDPATH}.img.sha256" "./${BUILDFOLDER}/${PACKERFINALFILE}.img.sha256"
 if [ $? -gt 0 ]; then
   echo "# FAILED MOVING .img.sha256"
   exit 1
@@ -135,7 +151,7 @@ echo
 echo "# MANUAL ACTION NEEDED:"
 echo "# Note down the SHA256 checksum of the image:"
 echo
-cat ./${TIMESTAMP}/${PACKERBUILDFILE}.img.gz.sha256
+cat ./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz.sha256
 echo 
 echo "# Press RETURN to continue..."
 read -r -p "" key
@@ -145,7 +161,7 @@ echo "# MANUAL ACTION NEEDED:"
 echo "# Keep this terminal open and the 128GB stick connected."
 echo "# Additionalley connect and unlock the USB device with the signer keys."
 echo "# Open in Filemanager and use right-click 'Open in Termonal' and run:"
-echo "# gpg --import ./sub.key"
+echo "# sudo gpg --import ./sub.key"
 echo "# Close that second terminal and remove USB device with signer keys."
 echo 
 echo "# Press RETURN to continue..."
@@ -155,11 +171,11 @@ read -r -p "" key
 echo "# MANUAL ACTION NEEDED:"
 echo "# Please wait infront of the screen until the signing process is asks you for the password."
 echo
-cd "${TIMESTAMP}"
-gpg --output ${PACKERBUILDFILE}.img.gz.sig --detach-sign ${PACKERBUILDFILE}.img.gz
+cd "${BUILDFOLDER}"
+gpg --output ${PACKERFINALFILE}.img.gz.sig --detach-sign ${PACKERFINALFILE}.img.gz
 if [ $? -gt 0 ]; then
   echo "# !!!!!!! SIGNING FAILED - redo manual before closing this terminbal !!!!!!!"
-  echo "gpg --output ${PACKERBUILDFILE}.img.gz.sig --detach-sign ${PACKERBUILDFILE}.img.gz"
+  echo "gpg --output ${PACKERFINALFILE}.img.gz.sig --detach-sign ${PACKERFINALFILE}.img.gz"
 else
   echo "# OK Signing successful."
 fi
@@ -168,4 +184,4 @@ fi
 echo
 echo "Close this terminal and eject your 128GB usb device."
 echo "Have fun with your build image on it under:"
-echo "${TIMESTAMP}/${PACKERBUILDFILE}.img.gz"
+echo "${BUILDFOLDER}/${PACKERBUILDFILE}.img.gz"

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -259,4 +259,4 @@ fi
 echo
 echo "Close this terminal and eject your 128GB usb device."
 echo "Have fun with your build image on it under:"
-echo "${BUILDFOLDER}/${PACKERBUILDFILE}.gz"
+echo "${BUILDFOLDER}/${PACKERFINALFILE}.gz"

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -97,6 +97,13 @@ echo "# PACKER TARGET: ${PACKERTARGET}"
 echo "# PACKER BUILD PATH: ${PACKERBUILDPATH}"
 echo "# PACKER FINAL FILE: ${PACKERFINALFILE}"
 
+# check if file already exists
+if [ -f "./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz" ]; then
+  echo "error='image already exists'"
+  echo "# delete ./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz (and all .sha256 & .sig) before trying again"
+  exit 1
+fi
+
 # prevet monitor to go to sleep during long non-inetractive build
 xset s off
 gsettings set org.gnome.desktop.screensaver idle-activation-enabled false

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -6,7 +6,7 @@
 ##########################################################################
 
 # YOUR REPO (REPLACE WITH YOUR OWN FORK IF NEEDED)
-REPO = "https://github.com/raspiblitz/raspiblitz"
+REPO="https://github.com/raspiblitz/raspiblitz"
 
 echo "Build RaspiBlitz install images on a Debian LIVE system"
 echo "From repo (change in script is needed):"
@@ -19,8 +19,8 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   exit 1
 fi
 
-BRANCH = $1
-OUTPUT = $2
+BRANCH=$1
+OUTPUT=$2
 
 # check if branch is set
 if [ "$BRANCH" == "[BRANCH]" ]; then
@@ -35,14 +35,14 @@ if [ -z "$OUTPUT" ]; then
 fi
 
 if [ "${OUTPUT}" == "lean" ]; then
-  PACKERTARGET = "arm64-rpi-lean-image"
-  PACKERBUILDPATH = "./raspiblitz/ci/arm64-rpi/packer-builder-arm/raspiblitz-arm64-rpi-lean"
+  PACKERTARGET="arm64-rpi-lean-image"
+  PACKERBUILDPATH="./raspiblitz/ci/arm64-rpi/packer-builder-arm/raspiblitz-arm64-rpi-lean"
 elif [ "${OUTPUT}" == "fat" ]; then
-  PACKERTARGET = "arm64-rpi-fatpack-image" 
-  PACKERBUILDPATH = "./raspiblitz/ci/arm64-rpi/packer-builder-arm/TODO" #TODO
+  PACKERTARGET="arm64-rpi-fatpack-image" 
+  PACKERBUILDPATH="./raspiblitz/ci/arm64-rpi/packer-builder-arm/TODO" #TODO
 elif [ "${OUTPUT}" == "x86" ]; then
-  PACKERTARGET = "amd64-lean-server-legacyboot-image" 
-  PACKERBUILDPATH = "./raspiblitz/ci/amd64/TODO" #TODO
+  PACKERTARGET="amd64-lean-server-legacyboot-image" 
+  PACKERBUILDPATH="./raspiblitz/ci/amd64/TODO" #TODO
 else
   echo "error='output $OUTPUT not supported'"
   exit 1
@@ -90,7 +90,7 @@ fi
 echo "# BUILDING SUCESS ###########################################"
 
 echo "# moving build to timestamped folder"
-TIMESTAMP = $(date +%s)
+TIMESTAMP=$(date +%s)
 mkdir $TIMESTAMP
 mv $PACKERBUILDPATH.img.gz ./$TIMESTAMP
 mv $PACKERBUILDPATH.img.gz.sha256 ./$TIMESTAMP
@@ -98,11 +98,3 @@ mv $PACKERBUILDPATH.img.sha256 ./$TIMESTAMP
 
 echo "# TODO: CLEAN UP OLD BUILDS"
 echo "# TODO: CUT INTERNET & SIGN IMAGE"
-
-
-
-
-
-
-
-

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -164,7 +164,7 @@ if [ $? -gt 0 ]; then
 fi
 
 # move gz.sha256 file to build folder
-mv "${PACKERBUILDPATH}.gz.sha256" "./${BUILDFOLDER}/${PACKERFINALFILE}gz.sha256"
+mv "${PACKERBUILDPATH}.gz.sha256" "./${BUILDFOLDER}/${PACKERFINALFILE}.gz.sha256"
 if [ $? -gt 0 ]; then
   echo "# FAILED MOVING .gz.sha256"
   exit 1

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -122,27 +122,34 @@ echo "# BUILDING SUCESS ###########################################"
 
 echo "# moving build to timestamped folder ./${BUILDFOLDER}"
 cd ..
-mkdir "${BUILDFOLDER}"
-if [ $? -gt 0 ]; then
-  echo "# FAILED CREATING FOLDER: ${BUILDFOLDER}"
+mkdir "${BUILDFOLDER}" 2>/dev/null
+
+#check that Build folder exists
+if [ ! -d "./${BUILDFOLDER}" ]; then
+  echo "# FAILED CREATING BUILD FOLDER: ./${BUILDFOLDER}"
   exit 1
 fi
+
+# move img.gz file to build folder
 mv "${PACKERBUILDPATH}.img.gz" "./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz"
 if [ $? -gt 0 ]; then
   echo "# FAILED MOVING .img.gz"
   exit 1
 fi
+
+# move img.gz.sha256 file to build folder
 mv "${PACKERBUILDPATH}.img.gz.sha256" "./${BUILDFOLDER}/${PACKERFINALFILE}.img.gz.sha256"
 if [ $? -gt 0 ]; then
   echo "# FAILED MOVING .img.gz.sha256"
   exit 1
 fi
+
+# move img.sha256 file to build folder
 mv "${PACKERBUILDPATH}.img.sha256" "./${BUILDFOLDER}/${PACKERFINALFILE}.img.sha256"
 if [ $? -gt 0 ]; then
   echo "# FAILED MOVING .img.sha256"
   exit 1
 fi
-
 
 echo "# clean up"
 rm -rf raspiblitz 2>/dev/null

--- a/ci/packer.sh
+++ b/ci/packer.sh
@@ -85,14 +85,26 @@ fi
 
 echo "# BUILDING SUCESS ###########################################"
 
-echo "# moving build to timestamped folder"
 TIMESTAMP=$(date +%s)
+echo "# moving build to timestamped folder ./${TIMESTAMP}"
 mkdir "${TIMESTAMP}"
+if [ $? -gt 0 ]; then
+  echo "# FAILED CREATING FOLDER: ${TIMESTAMP}"
+  exit 1
+fi
 mv "${PACKERBUILDPATH}${PACKERBUILDFILE}.img.gz" "./${TIMESTAMP}/${PACKERBUILDFILE}.img.gz"
+if [ $? -gt 0 ]; then
+  echo "# FAILED MOVING .img.gz"
+  exit 1
+fi
 mv "${PACKERBUILDPATH}${PACKERBUILDFILE}.img.gz.sha256" "./${TIMESTAMP}/${PACKERBUILDFILE}.img.gz.sha256"
+if [ $? -gt 0 ]; then
+  echo "# FAILED MOVING .img.gz.sha256"
+  exit 1
+fi
 mv "${PACKERBUILDPATH}${PACKERBUILDFILE}.img.sha256" "./${TIMESTAMP}/${PACKERBUILDFILE}.img.sha256"
 if [ $? -gt 0 ]; then
-  echo "# FAILED MOVING FILES"
+  echo "# FAILED MOVING .img.sha256"
   exit 1
 fi
 
@@ -120,7 +132,8 @@ echo
 # Note down the SHA256 checksum of the image
 echo "# MANUAL ACTION NEEDED:"
 echo "# Note down the SHA256 checksum of the image:"
-echo "TODO: cat checksum file" #TODO
+echo
+cat ./${TIMESTAMP}/${PACKERBUILDFILE}.img.gz.sha256
 echo 
 echo "# Press RETURN to continue..."
 read -r -p "" key


### PR DESCRIPTION
OK I streamlied the packer image build on my decidated Laptop running a Debian LIVE image.

Most things work, but some details to discuss with @openoms 

A) arm64-fatpack does not run thru 

Not with the script I was building - but just by calling the make command the build of the arm64-fatpack fails with:

```
==> arm.raspiblitz-arm64-rpi: https://downloads.raspberrypi.org/raspios_arm64/images/raspios_arm64-2023-12-06/2023-12-05-raspios-bookworm-arm64.img.xz?archive=false&checksum=sha256%3A5c54f0572d61e443a32dfa80aa8d918049814bfc70ab977f2d545eef45f1658e => /home/user/.cache/packer/6754bd243accdb4ae9941ce7d93be7d8d7963068.xz
    arm.raspiblitz-arm64-rpi: unpacking /home/user/.cache/packer/6754bd243accdb4ae9941ce7d93be7d8d7963068.xz to raspiblitz-arm64-rpi-lean.img
    arm.raspiblitz-arm64-rpi: unpacking with custom command: [xz --decompress /tmp/image971241824/6754bd243accdb4ae9941ce7d93be7d8d7963068.xz]
    arm.raspiblitz-arm64-rpi: resizing the image file raspiblitz-arm64-rpi-lean.img to 28G
    arm.raspiblitz-arm64-rpi: expanding partition no. 2 on the image raspiblitz-arm64-rpi-lean.img
==> arm.raspiblitz-arm64-rpi: error while expanding partition exec: "parted": executable file not found in $PATH:
Build 'arm.raspiblitz-arm64-rpi' errored after 6 minutes 27 seconds: build was halted 
```

B) sudo debian user warings

When running the the build for arm64-lean I get a lot of those warinigs .. is that sane? Can it be prevented?

`sudo: unable to resolve host debian: Name or service not known`


C) amd64-lean: qcow2 zipping?

When build an image for x86 .. why not as part of the packer process convert the qcow2 to img? I build a part in my packer.sh script where I take the qcow2.gz - unzip it, convert it to img and zip it again. It works, but feels that this would make more sense of having it as part of the packer make process - or is there a speiacl reason to keep it with qcow2? 
