### PR TITLE
revert "ci: use environment files in actions"

### DIFF
--- a/.github/workflows/amd64-fatpack-image.yml
+++ b/.github/workflows/amd64-fatpack-image.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set values
+        id: set_values
         run: |
           echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
           echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
@@ -65,18 +66,19 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           fi
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            echo "github_user=${{github.event.pull_request.head.repo.owner.login}}" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::${{github.event.pull_request.head.repo.owner.login}}"
           else
-            echo "github_user=$(echo ${{github.repository}} | cut -d'/' -f1)" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::$(echo ${{github.repository}} | cut -d'/' -f1)"
+          fi
 
       - name: Display the build name
         run: echo "Building the raspiblitz-amd64-debian-image-${{env.BUILD_DATE}}-${{env.BUILD_VERSION}}"
 
       - name: Run the build script
         run: |
-          echo "Using the variables: --pack fatpack --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop none"
+          echo "Using the variables: --pack fatpack --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop none"
           cd ci/amd64
-          bash packer.build.amd64-debian.sh --pack fatpack --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop none
+          bash packer.build.amd64-debian.sh --pack fatpack --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop none
 
       - name: Compute checksum of the raw image
         run: |

--- a/.github/workflows/amd64-lean-image.yml
+++ b/.github/workflows/amd64-lean-image.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: ["dev", "v1.10", "v1.11"]
+    branches: ["dev", "v1.10"]
     paths:
       - "build_sdcard.sh"
       - "home.admin/bitcoin.install.sh"
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set values
+        id: set_values
         run: |
           echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
           echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
@@ -43,18 +44,19 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           fi
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            echo "github_user=${{github.event.pull_request.head.repo.owner.login}}" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::${{github.event.pull_request.head.repo.owner.login}}"
           else
-            echo "github_user=$(echo ${{github.repository}} | cut -d'/' -f1)" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::$(echo ${{github.repository}} | cut -d'/' -f1)"
+          fi
 
       - name: Display the build name
         run: echo "Building the raspiblitz-amd64-debian-image-${{env.BUILD_DATE}}-${{env.BUILD_VERSION}}"
 
       - name: Run the build script
         run: |
-          echo "Using the variables: --pack lean --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop gnome"
+          echo "Using the variables: --pack lean --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop gnome"
           cd ci/amd64
-          bash packer.build.amd64-debian.sh --pack lean --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop gnome
+          bash packer.build.amd64-debian.sh	--pack lean --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot uefi --desktop gnome
 
       - name: Compute checksum of the raw image
         run: |
@@ -78,4 +80,4 @@ jobs:
           path: |
             ${{github.workspace}}/ci/amd64/builds/raspiblitz-amd64-debian-lean-qemu/raspiblitz-amd64-debian-lean.qcow2.sha256
             ${{github.workspace}}/ci/amd64/builds/raspiblitz-amd64-debian-lean-qemu/raspiblitz-amd64-debian-lean.qcow2.gz
-            ${{github.workspace}}/
+            ${{github.workspace}}/ci/amd64/builds/raspiblitz-amd64-debian-lean-qemu/raspiblitz-amd64-debian-lean.qcow2.gz.sha256

--- a/.github/workflows/amd64-lean-legacyboot-image.yml
+++ b/.github/workflows/amd64-lean-legacyboot-image.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: ["dev", "v1.10", "v1.11"]
+    branches: ["dev", "v1.10"]
     paths:
       - "build_sdcard.sh"
       - "home.admin/bitcoin.install.sh"
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set values
+        id: set_values
         run: |
           echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
           echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
@@ -43,18 +44,19 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           fi
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            echo "github_user=${{github.event.pull_request.head.repo.owner.login}}" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::${{github.event.pull_request.head.repo.owner.login}}"
           else
-            echo "github_user=$(echo ${{github.repository}} | cut -d'/' -f1)" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::$(echo ${{github.repository}} | cut -d'/' -f1)"
+          fi
 
       - name: Display the build name
         run: echo "Building the raspiblitz-amd64-debian-image-${{env.BUILD_DATE}}-${{env.BUILD_VERSION}}"
 
       - name: Run the build script
         run: |
-          echo "Using the variables: --pack lean --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot bios --desktop none"
+          echo "Using the variables: --pack lean --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot bios --desktop none"
           cd ci/amd64
-          bash packer.build.amd64-debian.sh --pack lean --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot bios --desktop none
+          bash packer.build.amd64-debian.sh	--pack lean --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}} --preseed_file preseed.cfg --boot bios --desktop none
 
       - name: Compute checksum of the raw image
         run: |
@@ -78,4 +80,4 @@ jobs:
           path: |
             ${{github.workspace}}/ci/amd64/builds/raspiblitz-amd64-debian-lean-qemu/raspiblitz-amd64-debian-lean.qcow2.sha256
             ${{github.workspace}}/ci/amd64/builds/raspiblitz-amd64-debian-lean-qemu/raspiblitz-amd64-debian-lean.qcow2.gz
-            ${{github.workspace}}/ci/amd64/builds/raspiblitz-amd
+            ${{github.workspace}}/ci/amd64/builds/raspiblitz-amd64-debian-lean-qemu/raspiblitz-amd64-debian-lean.qcow2.gz.sha256

--- a/.github/workflows/arm64-rpi-fatpack-image.yml
+++ b/.github/workflows/arm64-rpi-fatpack-image.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set values
+        id: set_values
         run: |
           echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
           echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
@@ -65,18 +66,19 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           fi
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            echo "github_user=${{github.event.pull_request.head.repo.owner.login}}" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::${{github.event.pull_request.head.repo.owner.login}}"
           else
-            echo "github_user=$(echo ${{github.repository}} | cut -d'/' -f1)" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::$(echo ${{github.repository}} | cut -d'/' -f1)"
+          fi
 
       - name: Display the build name
         run: echo "Building the raspiblitz-arm64-rpi-fatpack-image-${{env.BUILD_DATE}}-${{env.BUILD_VERSION}}"
 
       - name: Run the build script
         run: |
-          echo "Using the variables: --pack fatpack --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}}"
+          echo "Using the variables: --pack fatpack --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}}"
           cd ci/arm64-rpi
-          bash packer.build.arm64-rpi.sh --pack fatpack --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}}
+          bash packer.build.arm64-rpi.sh --pack fatpack --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}}
 
       - name: Compute checksum of the raw image
         run: |

--- a/.github/workflows/arm64-rpi-lean-image.yml
+++ b/.github/workflows/arm64-rpi-lean-image.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   push:
-    branches: ["dev", "v1.10", "v1.11"]
+    branches: ["dev", "v1.10"]
     paths:
       - "build_sdcard.sh"
       - "home.admin/bitcoin.install.sh"
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set values
+        id: set_values
         run: |
           echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
           echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
@@ -43,18 +44,19 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           fi
           if [[ "${{github.event_name}}" == "pull_request" ]]; then
-            echo "github_user=${{github.event.pull_request.head.repo.owner.login}}" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::${{github.event.pull_request.head.repo.owner.login}}"
           else
-            echo "github_user=$(echo ${{github.repository}} | cut -d'/' -f1)" >> $GITHUB_OUTPUT
+            echo "::set-output name=github_user::$(echo ${{github.repository}} | cut -d'/' -f1)"
+          fi
 
       - name: Display the build name
         run: echo "Building the raspiblitz-arm64-rpi-lean-image-${{ env.BUILD_DATE }}-${{ env.BUILD_VERSION }}"
 
       - name: Run the build script
         run: |
-          echo "Using the variables: --pack lean --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}}"
+          echo "Using the variables: --pack lean --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}}"
           cd ci/arm64-rpi
-          bash packer.build.arm64-rpi.sh --pack lean --github_user $(cat $GITHUB_OUTPUT) --branch ${{env.BRANCH_NAME}}
+          bash packer.build.arm64-rpi.sh --pack lean --github_user ${{steps.set_values.outputs.github_user}} --branch ${{env.BRANCH_NAME}}
 
       - name: Compute checksum of the raw image
         run: |


### PR DESCRIPTION
Reverts raspiblitz/raspiblitz#4338

workflows fail with syntax error
needs testing with the manual run triggers from Actions