### PR TITLE
build(arm64-rpi): make /dev/shm world writable for the build

### DIFF
--- a/ci/arm64-rpi/build.raspiblitz.sh
+++ b/ci/arm64-rpi/build.raspiblitz.sh
@@ -5,11 +5,12 @@ wget https://raw.githubusercontent.com/${github_user}/raspiblitz/${branch}/build
 
 if [ "${pack}" = "fatpack" ]; then
   fatpack="1"
-  # make /dev/shm world writable for qemu
-  sudo chmod 777 /dev/shm
 else
   fatpack="0"
 fi
+
+# make /dev/shm world writable for qemu
+sudo chmod 777 /dev/shm
 
 echo 'Build RaspiBlitz ...'
 bash build_sdcard.sh -f ${fatpack} -u ${github_user} -b ${branch} -t false -w off -i false


### PR DESCRIPTION
Fixing the display driver install errors in:
https://github.com/raspiblitz/raspiblitz/actions/runs/7371236475/job/20058409304