### PR TITLE
(ci): update to github actions v4

### DIFF
--- a/.github/workflows/amd64-fatpack-image.yml
+++ b/.github/workflows/amd64-fatpack-image.yml
@@ -53,7 +53,7 @@ jobs:
   amd64-image-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set values
         id: set_values
@@ -96,7 +96,7 @@ jobs:
           sha256sum raspiblitz-amd64-debian-fatpack.qcow2.gz > raspiblitz-amd64-debian-fatpack.qcow2.gz.sha256
 
       - name: Upload the image and checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raspiblitz-amd64-image-${{env.BUILD_DATE}}-${{env.BUILD_VERSION}}
           path: |

--- a/.github/workflows/amd64-lean-image.yml
+++ b/.github/workflows/amd64-lean-image.yml
@@ -31,7 +31,7 @@ jobs:
   amd64-image-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set values
         id: set_values
@@ -74,7 +74,7 @@ jobs:
           sha256sum raspiblitz-amd64-debian-lean.qcow2.gz > raspiblitz-amd64-debian-lean.qcow2.gz.sha256
 
       - name: Upload the image and checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raspiblitz-amd64-image-${{env.BUILD_DATE}}-${{env.BUILD_VERSION}}
           path: |

--- a/.github/workflows/amd64-lean-legacyboot-image.yml
+++ b/.github/workflows/amd64-lean-legacyboot-image.yml
@@ -31,7 +31,7 @@ jobs:
   amd64-image-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set values
         id: set_values
@@ -74,7 +74,7 @@ jobs:
           sha256sum raspiblitz-amd64-debian-lean.qcow2.gz > raspiblitz-amd64-debian-lean.qcow2.gz.sha256
 
       - name: Upload the image and checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raspiblitz-amd64-image-${{env.BUILD_DATE}}-${{env.BUILD_VERSION}}
           path: |

--- a/.github/workflows/arm64-rpi-fatpack-image.yml
+++ b/.github/workflows/arm64-rpi-fatpack-image.yml
@@ -53,7 +53,7 @@ jobs:
   arm64-rpi-image-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set values
         id: set_values
@@ -96,7 +96,7 @@ jobs:
           sha256sum raspiblitz-arm64-rpi-fatpack.img.gz > raspiblitz-arm64-rpi-fatpack.img.gz.sha256
 
       - name: Upload the image and checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raspiblitz-arm64-fatpack-rpi-image-${{ env.BUILD_DATE }}-${{ env.BUILD_VERSION }}
           path: |

--- a/.github/workflows/arm64-rpi-lean-image.yml
+++ b/.github/workflows/arm64-rpi-lean-image.yml
@@ -31,7 +31,7 @@ jobs:
   arm64-rpi-image-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set values
         id: set_values
@@ -74,7 +74,7 @@ jobs:
           sha256sum raspiblitz-arm64-rpi-lean.img.gz > raspiblitz-arm64-rpi-lean.img.gz.sha256
 
       - name: Upload the image and checksums
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: raspiblitz-arm64-rpi-image-${{ env.BUILD_DATE }}-${{ env.BUILD_VERSION }}
           path: |

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -3,9 +3,9 @@ name: Spelling
 on:
   workflow_dispatch:
   push:
-    branches: ["dev", "v1.10", "v1.11"]
+    branches: ['dev', 'v1.10', 'v1.11']
   pull_request:
-      branches: ["dev", "v1.10", "v1.11"]
+    branches: ['dev', 'v1.10', 'v1.11']
 
 jobs:
   spelling:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Spell Check Repo
         uses: crate-ci/typos@master
         with:


### PR DESCRIPTION
Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.

See https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/

Should enable faster artifact upload and fixes deprecation notice.