### PR TITLE
btcpay: add database backup and restore option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## What's new in Version 1.11.0 of RaspiBlitz?
 
 - New: Enabling NVMe PCIe Hats
+- New: BTCPay Server PostgreSQL database backup and restore options [details](https://github.com/raspiblitz/raspiblitz/pull/4409)
 - Update: RaspberryOS base image 2023-12-05 (Debian 12 Bookworm)
 - Update: Bitcoin Core v26.0 [details](https://bitcoincore.org/en/releases/26.0/)
 - Update: Electrum Server in Rust (electrs) v0.10.2 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0102-dec-31-2023)


### PR DESCRIPTION
added the pg backup and restore option similar to LNbits

- [x] test with a migrating BTCPayServer from arm64-RPi to amd64

![image](https://github.com/raspiblitz/raspiblitz/assets/43343391/f3f0369c-e68c-41c9-a5f6-7dbd57c66976)

![image](https://github.com/raspiblitz/raspiblitz/assets/43343391/9f03ff15-cb29-4d96-9328-8b18a4567f33)

![image](https://github.com/raspiblitz/raspiblitz/assets/43343391/5013a04d-fbb7-40b0-b893-733ff42331b8)