### PR TITLE
revert: build: remove externally-managed flag for python

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -391,6 +391,14 @@ else
   exit 1
 fi
 
+# don't protect system packages from pip install
+# tracking issue: https://github.com/raspiblitz/raspiblitz/issues/4170
+for PYTHONDIR in /usr/lib/python3.*; do
+  if [ -f "$PYTHONDIR/EXTERNALLY-MANAGED" ]; then
+    rm "$PYTHONDIR/EXTERNALLY-MANAGED"
+  fi
+done
+
 # make sure /usr/bin/pip exists (and calls pip3 in Debian Buster)
 update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 # 1. libs (for global python scripts)


### PR DESCRIPTION
Reverts raspiblitz/raspiblitz#4400
Discussed in #4170 