### PR TITLE
ci:  amd64 base image update to debian 12.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - New: Enabling NVMe PCIe Hats
 - Update: RaspberryOS base image 2023-12-05 (Debian 12 Bookworm)
+- Update: amd64 base image: debian-12.5.0-amd64-netinst.iso
 - Update: Bitcoin Core v26.0 [details](https://bitcoincore.org/en/releases/26.0/)
 - Update: Electrum Server in Rust (electrs) v0.10.2 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0102-dec-31-2023)
 - Update: Fulcrum Electrum server v1.9.7 (CLI install script) [details](https://github.com/cculianu/Fulcrum/releases/tag/v1.9.7)

--- a/ci/amd64/debian/build.amd64-debian.pkr.hcl
+++ b/ci/amd64/debian/build.amd64-debian.pkr.hcl
@@ -1,5 +1,5 @@
-variable "iso_name" { default = "debian-12.4.0-amd64-netinst.iso" }
-variable "iso_checksum" { default = "64d727dd5785ae5fcfd3ae8ffbede5f40cca96f1580aaa2820e8b99dae989d94" }
+variable "iso_name" { default = "debian-12.5.0-amd64-netinst.iso" }
+variable "iso_checksum" { default = "013f5b44670d81280b5b1bc02455842b250df2f0c6763398feb69af1a805a14f" }
 
 variable "pack" { default = "lean" }
 variable "github_user" { default = "raspiblitz" }


### PR DESCRIPTION
https://www.debian.org/News/2024/20240210