### PR TITLE
Fix Pyblock 2.2.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 - Update: LNbits 0.11.3 [details](https://github.com/lnbits/lnbits/releases/tag/0.11.3)
 - Update: Circuitbreaker v0.5.1 [details](https://github.com/lightningequipment/circuitbreaker/blob/master/README.md)
 - Experimental: LNDK (runs on top of LND to help forward onion messages (BOLT 12)) [details](https://github.com/lndk-org/lndk)
+- Fix: PyBlock 2.2.3 [details](https://github.com/curly60e/pyblock/blob/master/README.md) 
 - Refactor: Wifi config with file on sd card
 - Deprecated: Homer Dashboard (remove from SSH menus, config script will stay with possible future removal)
 - Deprecated: Bitcoinminds (remove from SSH menus, config script will stay with possible future removal)

--- a/home.admin/config.scripts/bonus.pyblock.sh
+++ b/home.admin/config.scripts/bonus.pyblock.sh
@@ -41,8 +41,15 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # install hexyl
   sudo apt-get install -y hexyl html2text
 
+  ## WORKAROUND: see https://github.com/raspiblitz/raspiblitz/issues/4383
   # install via pip
-  sudo -u pyblock pip3 install pybitblock 
+  # sudo -u pyblock pip3 install pybitblock 
+  # install from github
+  sudo -u pyblock git clone https://github.com/curly60e/pyblock.git
+  cd pyblock
+  sudo -u pyblock git checkout v2.2.3
+  sudo -u pyblock sed -i 's/jq = "1.2.2"/jq = "1.2.3"/' pyproject.toml
+  sudo -u pyblock pip install .
 
   # set PATH for the user
   sudo bash -c "echo 'PATH=\$PATH:/home/pyblock/.local/bin/' >> /home/pyblock/.profile"


### PR DESCRIPTION
Latest pyblock 2.4 needs python 3.12.0 while RaspiBlitz has now 3.12.0 ... so we fall back onto pyblock 2.2.3

But no installing the old 2.2.3 thru pypi package it was not working because jq==1.2.2 was no longer working with our updated python environment. So I created a workaround that installes 2.2.3 from github but chnages jq manually to 1.2.3 before running install. 