### PR TITLE
lnd.conf and lnd.check.sh template adjustments

### DIFF
--- a/home.admin/BlitzTUI/blitztui/memo.py
+++ b/home.admin/BlitzTUI/blitztui/memo.py
@@ -682,7 +682,7 @@ adjectives = [
     "picky",
     "pied",
     "piggy",
-    "pilar",
+    "pillar",
     "pink",
     "plain",
     "plane",

--- a/home.admin/BlitzTUI/data/Wordlist-Adjectives-Common-Audited-Len-3-6.txt
+++ b/home.admin/BlitzTUI/data/Wordlist-Adjectives-Common-Audited-Len-3-6.txt
@@ -648,7 +648,7 @@ piano
 picky
 pied
 piggy
-pilar
+pillar
 pink
 plain
 plane

--- a/home.admin/config.scripts/lnd.check.sh
+++ b/home.admin/config.scripts/lnd.check.sh
@@ -69,7 +69,7 @@ if [ "$1" == "prestart" ]; then
 
   ##### APPLICATION OPTIONS SECTION #####
 
-  # remove sync-freelist=1 (use =true is you want to overrule raspiblitz)
+  # remove sync-freelist=1 (use =true if you want to overrule raspiblitz)
   # https://github.com/rootzoll/raspiblitz/issues/3251
   sed -i "/^# Avoid slow startup time/d" ${lndConfFile}
   sed -i "/^sync-freelist=1/d" ${lndConfFile}

--- a/home.admin/config.scripts/lnd.install.sh
+++ b/home.admin/config.scripts/lnd.install.sh
@@ -306,12 +306,19 @@ debuglevel=info
 gc-canceled-invoices-on-startup=true
 gc-canceled-invoices-on-the-fly=true
 ignore-historical-gossip-filters=1
-sync-freelist=true
 stagger-initial-reconnect=true
 tlsautorefresh=1
 tlsdisableautofill=1
 tlscertpath=/home/bitcoin/.lnd/tls.cert
 tlskeypath=/home/bitcoin/.lnd/tls.key
+
+# Set to false for nodes with larger amount of channels. This modification leads to increased 
+# latency during initialization, yet significantly boosts runtime performance of the daemon.
+sync-freelist=true
+
+# Specify the maximum number of logfiles retained in rotation and the threshold size for rotation initiation.
+maxlogfiles=7
+maxlogfilesize=500
 
 [Bitcoin]
 bitcoin.active=1

--- a/home.admin/config.scripts/lnd.install.sh
+++ b/home.admin/config.scripts/lnd.install.sh
@@ -317,8 +317,8 @@ tlskeypath=/home/bitcoin/.lnd/tls.key
 sync-freelist=true
 
 # Specify the maximum number of logfiles retained in rotation and the threshold size for rotation initiation.
-maxlogfiles=7
-maxlogfilesize=500
+maxlogfiles=5
+maxlogfilesize=400
 
 [Bitcoin]
 bitcoin.active=1


### PR DESCRIPTION
Second attempt to add

- a larger logrotation schedule. Even with loglevel=info, it'll only cost a few hundred MB but allows a larger lookbackwindow, helpful for force-close debugging
- more verbose comment on syncfreelist=false vs true