### PR TITLE
debug: do not change termbin link

### DIFF
--- a/home.admin/_commands.sh
+++ b/home.admin/_commands.sh
@@ -172,7 +172,7 @@ function debug() {
   if [ "$1" = "-l" ]||[ "$1" = "--link" ]; then
     proxy="-X 5 -x localhost:9050"
     if [ "$2" = "-n" ]||[ "$2" = "--no-tor" ]; then proxy=""; fi
-    cat /var/cache/raspiblitz/debug.log | nc ${proxy} termbin.com 9999 | sed "s/termbin.com/l.termbin.com/"
+    cat /var/cache/raspiblitz/debug.log | nc ${proxy} termbin.com 9999
   else
     cat /var/cache/raspiblitz/debug.log
   fi


### PR DESCRIPTION
see the differene on the link:

https://l.termbin.com/lbvu

vs without the `l.` added:
https://termbin.com/lbvu

Probably the original function of the l subdomain doesn't work any more: https://github.com/raspiblitz/raspiblitz/pull/2815