### PR TITLE
(ci): build fatpack based on lean image

### DIFF
--- a/.github/workflows/arm64-rpi-lean-image.yml
+++ b/.github/workflows/arm64-rpi-lean-image.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 40000
-          temp-reserve-mb: 40000
+          root-reserve-mb: 31000
+          temp-reserve-mb: 31000
           remove-dotnet: 'true'
           remove-android: 'true'
           remove-haskell: 'true'

--- a/.github/workflows/arm64-rpi-lean-image.yml
+++ b/.github/workflows/arm64-rpi-lean-image.yml
@@ -1,4 +1,4 @@
-name: arm64-rpi-lean-image-build
+name: arm64-rpi-image-build
 
 concurrency:
   group: arm64-rpi-lean-image-build-${{ github.head_ref }}
@@ -28,7 +28,7 @@ on:
       - 'ci/arm64-rpi/**'
 
 jobs:
-  arm64-rpi-image-build:
+  arm64-rpi-lean-image-build:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -57,27 +57,75 @@ jobs:
           echo "Using the variables: --pack lean --github_user ${{steps.set_values.outputs.GITHUB_USER}} --branch ${{env.BRANCH_NAME}}"
           cd ci/arm64-rpi
           bash packer.build.arm64-rpi.sh --pack lean --github_user ${{steps.set_values.outputs.GITHUB_USER}} --branch ${{env.BRANCH_NAME}}
-
-      - name: Compute checksum of the raw image
+      - name: Calculate checksum
         run: |
           cd ci/arm64-rpi
           sha256sum raspiblitz-arm64-rpi-lean.img > raspiblitz-arm64-rpi-lean.img.sha256
-
-      - name: Compress image
-        run: |
-          cd ci/arm64-rpi
-          gzip -v9 raspiblitz-arm64-rpi-lean.img
-
-      - name: Compute checksum of the compressed image
-        run: |
-          cd ci/arm64-rpi
-          sha256sum raspiblitz-arm64-rpi-lean.img.gz > raspiblitz-arm64-rpi-lean.img.gz.sha256
-
-      - name: Upload the image and checksums
+      - name: Upload the image
         uses: actions/upload-artifact@v4
         with:
-          name: raspiblitz-arm64-rpi-image-${{ env.BUILD_DATE }}-${{ env.BUILD_VERSION }}
+          name: raspiblitz-arm64-rpi-lean
           path: |
-            ${{ github.workspace }}/ci/arm64-rpi/raspiblitz-arm64-rpi-lean.img.sha256
-            ${{ github.workspace }}/ci/arm64-rpi/raspiblitz-arm64-rpi-lean.img.gz
-            ${{ github.workspace }}/ci/arm64-rpi/raspiblitz-arm64-rpi-lean.img.gz.sha256
+            ci/arm64-rpi/raspiblitz-arm64-rpi-lean.img
+            ci/arm64-rpi/raspiblitz-arm64-rpi-lean.img.sha256
+  arm64-rpi-fat-image-build:
+    needs: arm64-rpi-lean-image-build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 40000
+          temp-reserve-mb: 40000
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+      - name: Display free space
+        run: |
+          df -h
+          du -hd1
+      - name: Set values
+        id: set_values
+        run: |
+          echo "BUILD_DATE=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
+          echo "BUILD_VERSION=$(git describe --always --tags)" >> $GITHUB_ENV
+          if [ -z "$GITHUB_HEAD_REF" ]; then
+            echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          fi
+          if [[ "${{github.event_name}}" == "pull_request" ]]; then
+            echo "GITHUB_USER=${{github.event.pull_request.head.repo.owner.login}}" >> $GITHUB_OUTPUT
+          else
+            echo "GITHUB_USER=$(echo ${{github.repository}} | cut -d'/' -f1)" >> $GITHUB_OUTPUT
+          fi
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: Download lean image
+        uses: actions/download-artifact@v4
+        with:
+          name: raspiblitz-arm64-rpi-lean
+          path: ci/arm64-rpi
+      - name: set "image_checksum" variable
+        run: |
+          echo "IMAGE_CHECKSUM=$(cat ci/arm64-rpi/raspiblitz-arm64-rpi-lean.img.sha256 | cut -d' ' -f1)" >> $GITHUB_ENV
+      - name: Run the fatpack build
+        run: |
+          echo "Using the variables: --github_user ${{steps.set_values.outputs.GITHUB_USER}} --branch ${{env.BRANCH_NAME}}"
+          cd ci/arm64-rpi
+          docker run --rm --privileged \
+            -v /dev:/dev \
+            -v .:/build \
+            mkaczanowski/packer-builder-arm:1.0.9 build \
+            -var "github_user=${{steps.set_values.outputs.GITHUB_USER}}" \
+            -var "branch=${{env.BRANCH_NAME}}" \
+            -var "artifact=file:/build/raspiblitz-arm64-rpi-lean.img" \
+            -var "image_checksum=${{env.IMAGE_CHECKSUM}}" \
+            build.arm64-rpi-fat.pkr.hcl
+      - name: Upload fatpack
+        uses: actions/upload-artifact@v4
+        with:
+          name: raspiblitz-fat
+          path: ci/arm64-rpi/raspiblitz-arm64-rpi-fat.img

--- a/ci/arm64-rpi/build.arm64-rpi-fat.pkr.hcl
+++ b/ci/arm64-rpi/build.arm64-rpi-fat.pkr.hcl
@@ -1,0 +1,47 @@
+variable "github_user" { default = "raspiblitz" }
+variable "branch" { default = "dev" }
+variable "artifact" { default = "file:/build/raspiblitz-arm64-rpi-lean.img" }
+variable "image_checksum" { default = "not_available" }
+
+source "arm" "raspiblitz-arm64-rpi-lean" {
+  file_urls = [var.artifact]
+  file_checksum_type = "sha256"
+  file_checksum         = var.image_checksum
+  file_target_extension = "img"
+
+  image_build_method    = "reuse"
+  image_chroot_env      = ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"]
+  image_partitions {
+    filesystem   = "vfat"
+    mountpoint   = "/boot"
+    name         = "boot"
+    size         = "256M"
+    start_sector = "8192"
+    type         = "c"
+  }
+  image_partitions {
+    filesystem   = "ext4"
+    mountpoint   = "/"
+    name         = "root"
+    size         = "0"
+    start_sector = "532480"
+    type         = "83"
+  }
+  image_path                   = "raspiblitz-arm64-rpi-fat.img"
+  image_size                   = "28G"
+  image_type                   = "dos"
+  qemu_binary_destination_path = "/usr/bin/qemu-arm-static"
+  qemu_binary_source_path      = "/usr/bin/qemu-arm-static"
+}
+
+build {
+  sources = ["source.arm.raspiblitz-arm64-rpi-lean"]
+
+  provisioner "shell" {
+    environment_vars = [
+      "github_user=${var.github_user}",
+      "branch=${var.branch}",
+    ]
+    script = "./build.raspiblitz-fat.sh"
+  }
+}

--- a/ci/arm64-rpi/build.arm64-rpi-fat.pkr.hcl
+++ b/ci/arm64-rpi/build.arm64-rpi-fat.pkr.hcl
@@ -28,7 +28,7 @@ source "arm" "raspiblitz-arm64-rpi-lean" {
     type         = "83"
   }
   image_path                   = "raspiblitz-arm64-rpi-fat.img"
-  image_size                   = "28G"
+  image_size                   = "20G"
   image_type                   = "dos"
   qemu_binary_destination_path = "/usr/bin/qemu-arm-static"
   qemu_binary_source_path      = "/usr/bin/qemu-arm-static"

--- a/ci/arm64-rpi/build.arm64-rpi.pkr.hcl
+++ b/ci/arm64-rpi/build.arm64-rpi.pkr.hcl
@@ -29,7 +29,7 @@ source "arm" "raspiblitz-arm64-rpi" {
     type         = "83"
   }
   image_path                   = "raspiblitz-arm64-rpi-${var.pack}.img"
-  image_size                   = "28G"
+  image_size                   = "20G"
   image_type                   = "dos"
   qemu_binary_destination_path = "/usr/bin/qemu-arm-static"
   qemu_binary_source_path      = "/usr/bin/qemu-arm-static"

--- a/ci/arm64-rpi/build.raspiblitz-fat.sh
+++ b/ci/arm64-rpi/build.raspiblitz-fat.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -eux
+
+echo 'Download the blitz.fatpack.sh script ...'
+wget https://raw.githubusercontent.com/${github_user}/raspiblitz/${branch}/home.admin/config.scripts/blitz.fatpack.sh
+
+# make /dev/shm world writable for qemu
+sudo chmod 777 /dev/shm
+
+echo 'Build Fatpack ...'
+bash blitz.fatpack.sh


### PR DESCRIPTION
This is a quick draft I came up with, don't think it will work yet, but trying to get out the idea.

This is the idea described in #4441 

The only difference between the lean and the fat image is the `blitz.fatpack.sh` script. So we could build a lean image and then a fatpack on top of it. 

This should shorten build times for the fatpack and make it (hopefully) possible to build the fatpack in github actions.