### PR TITLE
fix cln watchtower client plugin

### DIFF
--- a/home.admin/config.scripts/cl-plugin.watchtower-client.sh
+++ b/home.admin/config.scripts/cl-plugin.watchtower-client.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # command info
-if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ];then
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo
   echo "Install the rust-teos watchtower-client plugin for CLN"
   echo "Usage:"
@@ -15,16 +15,15 @@ fi
 echo "# cl-plugin.watchtower-client.sh $*"
 
 source <(/home/admin/config.scripts/network.aliases.sh getvars cl $2)
-source /mnt/hdd/raspiblitz.conf  #to get runBehindTor
+source /mnt/hdd/raspiblitz.conf #to get runBehindTor
 plugin="watchtower-client"
 pkg_dependencies="libssl-dev"
 
-
 if [ "$1" = info ]; then
-	whiptail --title "The Eye of Satoshi CLN Watchtower" \
+  whiptail --title "The Eye of Satoshi CLN Watchtower" \
     --msgbox "
 This is a watchtower client plugin to interact with an Eye of Satoshi tower, and
-eventually with any BOLT13 compliant watchtower. 
+eventually with any BOLT13 compliant watchtower.
 
 The plugin manages all the client-side logic to send appointment to a number of
 registered towers every time a new commitment transaction is generated.
@@ -48,12 +47,11 @@ https://github.com/talaia-labs/rust-teos/tree/master/watchtower-plugin
   exit 0
 fi
 
-
-if [ "$1" = "on" ];then
+if [ "$1" = "on" ]; then
 
   # rust for rust-teos, includes rustfmt
-  sudo -u bitcoin curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-  sudo -u bitcoin sh -s -- -y
+  sudo -u bitcoin curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    sudo -u bitcoin sh -s -- -y
 
   #Cleanup existing
   if [ -d "/home/bitcoin/cl-plugins-available/plugins/${plugin}/" ]; then
@@ -67,22 +65,22 @@ if [ "$1" = "on" ];then
   #Clone source repository
   cd /home/bitcoin/cl-plugins-available || exit 1
   sudo -u bitcoin git clone https://github.com/talaia-labs/rust-teos.git
-  
+
   #Install additional dependencies
-  sudo apt-get install -y ${pkg_dependencies} > /dev/null
+  sudo apt-get install -y ${pkg_dependencies} >/dev/null
 
   #Compile
   cd /home/bitcoin/cl-plugins-available/rust-teos || exit 1
   sudo -u bitcoin /home/bitcoin/.cargo/bin/cargo install --path watchtower-plugin \
-      --target-dir /home/bitcoin/cl-plugins-available/${plugin}
+    --target-dir /home/bitcoin/cl-plugins-available/${plugin} || exit 1
 
   #Symlink to enable
-  if [ ! -L  /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin} ]; then
+  if [ ! -L /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin} ]; then
     echo "Running: sudo -u bitcoin ln -s /home/bitcoin/cl-plugins-available/${plugin}/release/${plugin} /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin}"
     sudo -u bitcoin ln -s /home/bitcoin/cl-plugins-available/${plugin}/release/${plugin} /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin}
   fi
 
-  #check if toronly node, then add watchtower-proxy config to CL 
+  #check if toronly node, then add watchtower-proxy config to CL
   if [ "$runBehindTor" = on ]; then
     echo "watchtower-proxy=127.0.0.1:9050" | sudo tee -a ${CLCONF}
   fi
@@ -98,8 +96,7 @@ if [ "$1" = "on" ];then
 
 fi
 
-
-if [ "$1" = off ];then
+if [ "$1" = off ]; then
   # delete symlink
   sudo rm -rf /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin}
 
@@ -110,16 +107,14 @@ if [ "$1" = off ];then
   sudo systemctl restart ${netprefix}lightningd
 
   # purge
-  if [ "$(echo "$@" | grep -c purge)" -gt 0 ];then
+  if [ "$(echo "$@" | grep -c purge)" -gt 0 ]; then
     echo "# Delete plugin and source code"
     sudo rm -rf /home/bitcoin/cl-plugins-available/rust-teos*
     sudo rm -rf /home/bitcoin/cl-plugins-available/${plugin}
   fi
-
 
   # setting value in raspi blitz config
   /home/admin/config.scripts/blitz.conf.sh set ${netprefix}clWatchtowerClient "off"
   echo "# watchtower-client was uninstalled for ${CHAIN}"
 
 fi
-


### PR DESCRIPTION
attempt to fix: https://github.com/raspiblitz/raspiblitz/issues/4457

Currently getting a  compile error:
```
Receiving objects: 100% (2379/2379), 820.54 KiB | 708.00 KiB/s, done.
remote: Total 2379 (delta 768), reused 763 (delta 742), pack-reused 1532
Resolving deltas: 100% (1492/1492), done.
  Installing watchtower-plugin v0.2.0 (/home/bitcoin/cl-plugins-available/rust-teos/watchtower-plugin)
    Updating crates.io index
   Compiling teos-common v0.2.0 (/home/bitcoin/cl-plugins-available/rust-teos/teos-common)
   Compiling watchtower-plugin v0.2.0 (/home/bitcoin/cl-plugins-available/rust-teos/watchtower-plugin)
error[E0308]: mismatched types
   --> watchtower-plugin/src/main.rs:79:37
    |
79  |         u16::try_from(plugin.option(constants::WT_PORT).unwrap().as_i64().unwrap())
    |                              ------ ^^^^^^^^^^^^^^^^^^ expected `&ConfigOption<'_, _>`, found `&str`
    |                              |
    |                              arguments to this method are incorrect
    |
    = note: expected reference `&ConfigOption<'_, _>`
               found reference `&'static str`
note: method defined here
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/lib.rs:517:12
    |
517 |     pub fn option<'a, OV: OptionType<'a>>(
    |            ^^^^^^

error[E0599]: no function or associated item named `new` found for struct `ConfigOption` in the current scope
   --> watchtower-plugin/src/main.rs:537:31
    |
537 |         .option(ConfigOption::new(
    |                               ^^^ function or associated item not found in `ConfigOption<'_, _>`
    |
note: if you're trying to build a new `ConfigOption<'_, _>` consider using one of the following associated functions:
      ConfigOption::<'a, DefaultString>::new_str_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::String>::new_str_no_default
      ConfigOption::<'a, DefaultInteger>::new_i64_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::Integer>::new_i64_no_default
      and 3 others
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/options.rs:438:5
    |
438 | /     pub const fn new_str_with_default(
439 | |         name: &'a str,
440 | |         default: &'a str,
441 | |         description: &'a str,
442 | |     ) -> Self {
    | |_____________^
...
453 |       pub const fn new_str_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
464 |       pub const fn new_i64_with_default(name: &'a str, default: i64, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
475 |       pub const fn new_i64_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no function or associated item named `new` found for struct `ConfigOption` in the current scope
   --> watchtower-plugin/src/main.rs:542:31
    |
542 |         .option(ConfigOption::new(
    |                               ^^^ function or associated item not found in `ConfigOption<'_, _>`
    |
note: if you're trying to build a new `ConfigOption<'_, _>` consider using one of the following associated functions:
      ConfigOption::<'a, DefaultString>::new_str_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::String>::new_str_no_default
      ConfigOption::<'a, DefaultInteger>::new_i64_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::Integer>::new_i64_no_default
      and 3 others
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/options.rs:438:5
    |
438 | /     pub const fn new_str_with_default(
439 | |         name: &'a str,
440 | |         default: &'a str,
441 | |         description: &'a str,
442 | |     ) -> Self {
    | |_____________^
...
453 |       pub const fn new_str_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
464 |       pub const fn new_i64_with_default(name: &'a str, default: i64, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
475 |       pub const fn new_i64_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no function or associated item named `new` found for struct `ConfigOption` in the current scope
   --> watchtower-plugin/src/main.rs:547:31
    |
547 |         .option(ConfigOption::new(
    |                               ^^^ function or associated item not found in `ConfigOption<'_, _>`
    |
note: if you're trying to build a new `ConfigOption<'_, _>` consider using one of the following associated functions:
      ConfigOption::<'a, DefaultString>::new_str_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::String>::new_str_no_default
      ConfigOption::<'a, DefaultInteger>::new_i64_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::Integer>::new_i64_no_default
      and 3 others
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/options.rs:438:5
    |
438 | /     pub const fn new_str_with_default(
439 | |         name: &'a str,
440 | |         default: &'a str,
441 | |         description: &'a str,
442 | |     ) -> Self {
    | |_____________^
...
453 |       pub const fn new_str_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
464 |       pub const fn new_i64_with_default(name: &'a str, default: i64, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
475 |       pub const fn new_i64_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0599]: no function or associated item named `new` found for struct `ConfigOption` in the current scope
   --> watchtower-plugin/src/main.rs:552:31
    |
552 |         .option(ConfigOption::new(
    |                               ^^^ function or associated item not found in `ConfigOption<'_, _>`
    |
note: if you're trying to build a new `ConfigOption<'_, _>` consider using one of the following associated functions:
      ConfigOption::<'a, DefaultString>::new_str_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::String>::new_str_no_default
      ConfigOption::<'a, DefaultInteger>::new_i64_with_default
      ConfigOption::<'a, cln_plugin::options::config_type::Integer>::new_i64_no_default
      and 3 others
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/options.rs:438:5
    |
438 | /     pub const fn new_str_with_default(
439 | |         name: &'a str,
440 | |         default: &'a str,
441 | |         description: &'a str,
442 | |     ) -> Self {
    | |_____________^
...
453 |       pub const fn new_str_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
464 |       pub const fn new_i64_with_default(name: &'a str, default: i64, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
475 |       pub const fn new_i64_no_default(name: &'a str, description: &'a str) -> Self {
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> watchtower-plugin/src/main.rs:634:21
    |
634 |             .option(constants::WT_MAX_RETRY_TIME)
    |              ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&ConfigOption<'_, _>`, found `&str`
    |              |
    |              arguments to this method are incorrect
    |
    = note: expected reference `&ConfigOption<'_, _>`
               found reference `&'static str`
note: method defined here
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/lib.rs:614:12
    |
614 |     pub fn option<'a, OV: OptionType<'a>>(
    |            ^^^^^^

error[E0308]: mismatched types
   --> watchtower-plugin/src/main.rs:646:21
    |
646 |             .option(constants::WT_AUTO_RETRY_DELAY)
    |              ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&ConfigOption<'_, _>`, found `&str`
    |              |
    |              arguments to this method are incorrect
    |
    = note: expected reference `&ConfigOption<'_, _>`
               found reference `&'static str`
note: method defined here
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/lib.rs:614:12
    |
614 |     pub fn option<'a, OV: OptionType<'a>>(
    |            ^^^^^^

error[E0308]: mismatched types
   --> watchtower-plugin/src/main.rs:658:21
    |
658 |             .option(constants::DEV_WT_MAX_RETRY_INTERVAL)
    |              ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&ConfigOption<'_, _>`, found `&str`
    |              |
    |              arguments to this method are incorrect
    |
    = note: expected reference `&ConfigOption<'_, _>`
               found reference `&'static str`
note: method defined here
   --> /home/bitcoin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cln-plugin-0.1.8/src/lib.rs:614:12
    |
614 |     pub fn option<'a, OV: OptionType<'a>>(
    |            ^^^^^^

Some errors have detailed explanations: E0308, E0599.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `watchtower-plugin` (bin "watchtower-client") due to 8 previous errors
error: failed to compile `watchtower-plugin v0.2.0 (/home/bitcoin/cl-plugins-available/rust-teos/watchtower-plugin)`, intermediate artifacts can be found at `/home/bitcoin/cl-plugins-available/watchtower-client`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

Fixed with adding `--locked`