### PR TITLE
Fix electrs data dir user at update, update electrs to v0.10.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 - Update: LND v0.17.3-beta [details](https://github.com/lightningnetwork/lnd/releases/tag/v0.17.3-beta)
 - Update: Core Lightning v23.11.2 [details](https://github.com/ElementsProject/lightning/releases/tag/v23.11.2)
 - Update: C-lightningREST v0.10.7 [details](https://github.com/Ride-The-Lightning/c-lightning-REST/releases/tag/v0.10.7)
-- Update: Electrum Server in Rust (electrs) v0.10.2 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0102-dec-31-2023)
+- Update: Electrum Server in Rust (electrs) v0.10.4 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#0104-mar-15-2024)
 - Update: Fulcrum Electrum server v1.9.8 (CLI install script) [details](https://github.com/cculianu/Fulcrum/releases/tag/v1.9.8)
 - Update: BTC-RPC-Explorer v3.4.0 [details](https://github.com/janoside/btc-rpc-explorer/blob/master/CHANGELOG.md#v340)
 - Update: JoinMarket v0.9.11 [details](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.11)

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -270,6 +270,8 @@ if [ "$1" = "install" ]; then
 
   if id "electrs" &>/dev/null; then
       echo "# user electrs exists already (codebase is installed)"
+      # app-storage dir could have wrong userid fix just in case 
+      sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs
   else
     echo "# Installing codebase"
     

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -314,6 +314,16 @@ fi
 if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   echo "# ACTIVATING ELECTRS"
 
+  # check and create storage dir
+  if ! sudo ls /mnt/hdd/app-storage/electrs 2>/dev/null; then
+    sudo mkdir /mnt/hdd/app-storage/electrs
+    echo
+    echo "# The electrs database will be built in /mnt/hdd/app-storage/electrs/db. Takes ~18 hours and ~50Gb diskspace"
+    echo
+  fi
+  # always fix user id
+  sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs
+
   isInstalled=$(sudo ls /etc/systemd/system/electrs.service 2>/dev/null | grep -c 'electrs.service')
   if [ ${isInstalled} -eq 0 ]; then
 
@@ -331,16 +341,6 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
         exit 1
       fi
     fi
-
-    # check and create storage dir
-    if ! sudo ls /mnt/hdd/app-storage/electrs 2>/dev/null; then
-      sudo mkdir /mnt/hdd/app-storage/electrs
-      echo
-      echo "# The electrs database will be built in /mnt/hdd/app-storage/electrs/db. Takes ~18 hours and ~50Gb diskspace"
-      echo
-    fi
-    # always fix user id
-    sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs
 
     echo
     echo "# Getting RPC credentials from the bitcoin.conf"

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -5,13 +5,13 @@ ELECTRSVERSION="v0.10.2"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
- echo "config script to switch the Electrum Rust Server on or off"
- echo "bonus.electrs.sh status -> dont call in loops"
- echo "bonus.electrs.sh status-sync"
- echo "bonus.electrs.sh [on|off|menu|update]"
- echo "bonus.electrs.sh [install|uninstall]"
- echo "installs the version $ELECTRSVERSION"
- exit 1
+  echo "config script to switch the Electrum Rust Server on or off"
+  echo "bonus.electrs.sh status -> dont call in loops"
+  echo "bonus.electrs.sh status-sync"
+  echo "bonus.electrs.sh [on|off|menu|update]"
+  echo "bonus.electrs.sh [install|uninstall]"
+  echo "installs the version $ELECTRSVERSION"
+  exit 1
 fi
 
 PGPsigner="romanz"
@@ -55,7 +55,10 @@ if [ "$1" = "status" ]; then
     localPortRunning=$(sudo netstat -an | grep -c '0.0.0.0:50001')
     echo "localTCPPortActive=${localPortRunning}"
 
-    publicPortRunning=$(nc -z -w6 ${publicip} 50001 2>/dev/null; echo $?)
+    publicPortRunning=$(
+      nc -z -w6 ${publicip} 50001 2>/dev/null
+      echo $?
+    )
     if [ "${publicPortRunning}" == "0" ]; then
       # OK looks good - but just means that something is answering on that port
       echo "publicTCPPortAnswering=1"
@@ -66,7 +69,10 @@ if [ "$1" = "status" ]; then
     echo "portSSL='50002'"
     localPortRunning=$(sudo netstat -an | grep -c '0.0.0.0:50002')
     echo "localHTTPPortActive=${localPortRunning}"
-    publicPortRunning=$(nc -z -w6 ${publicip} 50002 2>/dev/null; echo $?)
+    publicPortRunning=$(
+      nc -z -w6 ${publicip} 50002 2>/dev/null
+      echo $?
+    )
     if [ "${publicPortRunning}" == "0" ]; then
       # OK looks good - but just means that something is answering on that port
       echo "publicHTTPPortAnswering=1"
@@ -177,7 +183,7 @@ This can take multiple hours.
   fi
 
   if [ ${nginxTest} -eq 0 ]; then
-     dialog --title "Testing nginx.conf has failed" --msgbox "
+    dialog --title "Testing nginx.conf has failed" --msgbox "
 Nginx is in a failed state. Will attempt to fix.
 Try connecting via port 50002 or Tor again once finished.
 Check 'sudo nginx -t' for a detailed error message.
@@ -194,17 +200,17 @@ Check 'sudo nginx -t' for a detailed error message.
   fi
 
   # Options (available without TOR)
-  OPTIONS=( \
-        CONNECT "How to Connect" \
-        REINDEX "Delete&Rebuild Index" \
-        STATUS "ElectRS Status Info"
-	)
+  OPTIONS=(
+    CONNECT "How to Connect"
+    REINDEX "Delete&Rebuild Index"
+    STATUS "ElectRS Status Info"
+  )
 
   CHOICE=$(whiptail --clear --title "Electrum Rust Server" --menu "menu" 10 50 4 "${OPTIONS[@]}" 2>&1 >/dev/tty)
   clear
 
   case $CHOICE in
-    CONNECT)
+  CONNECT)
     echo "######## How to Connect to Electrum Rust Server #######"
     echo
     echo "Install the Electrum Wallet App on your laptop from:"
@@ -235,13 +241,13 @@ Check 'sudo nginx -t' for a detailed error message.
     read key
     sudo /home/admin/config.scripts/blitz.display.sh hide
     ;;
-    STATUS)
+  STATUS)
     sudo /home/admin/config.scripts/bonus.electrs.sh status
     echo
     echo "Press ENTER to get back to main menu."
     read key
     ;;
-    REINDEX)
+  REINDEX)
     echo "######## Delete/Rebuild Index ########"
     echo "# stopping service"
     sudo systemctl stop electrs
@@ -269,10 +275,10 @@ if [ "$1" = "install" ]; then
   echo "# INSTALL ELECTRS"
 
   if id "electrs" &>/dev/null; then
-      echo "# user electrs exists already (codebase is installed)"
+    echo "# user electrs exists already (codebase is installed)"
   else
     echo "# Installing codebase"
-    
+
     echo
     echo "# Creating the electrs user"
     echo
@@ -284,7 +290,7 @@ if [ "$1" = "install" ]; then
     echo
     # https://github.com/romanz/electrs/blob/master/doc/usage.md#build-dependencies
     sudo -u electrs curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u electrs sh -s -- --default-toolchain none -y
-    sudo apt install -y clang cmake build-essential  # for building 'rust-rocksdb'
+    sudo apt install -y clang cmake build-essential # for building 'rust-rocksdb'
 
     echo
     echo "# Downloading and building electrs $ELECTRSVERSION. This will take ~40 minutes"
@@ -296,7 +302,7 @@ if [ "$1" = "install" ]; then
 
     # verify
     sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh \
-     "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
+      "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
 
     # build
     sudo -u electrs /home/electrs/.cargo/bin/cargo build --locked --release || exit 1
@@ -333,9 +339,9 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
       echo "# The electrs database will be built in /mnt/hdd/app-storage/electrs/db. Takes ~18 hours and ~50Gb diskspace"
       echo
     fi
-    # always fix user id 
-    sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs 
-    
+    # always fix user id
+    sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs
+
     echo
     echo "# Getting RPC credentials from the bitcoin.conf"
     # read PASSWORD_B
@@ -368,12 +374,11 @@ server_banner = \"Welcome to electrs $ELECTRSVERSION - the Electrum Rust Server 
     echo
     echo "# Checking for config.toml"
     echo
-    if [ ! -f "/home/electrs/.electrs/config.toml" ]
-        then
-            echo "Failed to create config.toml"
-            exit 1
-        else
-            echo "OK"
+    if [ ! -f "/home/electrs/.electrs/config.toml" ]; then
+      echo "Failed to create config.toml"
+      exit 1
+    else
+      echo "OK"
     fi
 
     echo
@@ -381,14 +386,14 @@ server_banner = \"Welcome to electrs $ELECTRSVERSION - the Electrum Rust Server 
     echo
     isElectrs=$(sudo cat /etc/nginx/nginx.conf 2>/dev/null | grep -c 'upstream electrs')
     if [ ${isElectrs} -gt 0 ]; then
-            echo "electrs is already configured with Nginx. To edit manually run \`sudo nano /etc/nginx/nginx.conf\`"
+      echo "electrs is already configured with Nginx. To edit manually run \`sudo nano /etc/nginx/nginx.conf\`"
 
     elif [ ${isElectrs} -eq 0 ]; then
 
-            isStream=$(sudo cat /etc/nginx/nginx.conf 2>/dev/null | grep -c 'stream {')
-            if [ ${isStream} -eq 0 ]; then
+      isStream=$(sudo cat /etc/nginx/nginx.conf 2>/dev/null | grep -c 'stream {')
+      if [ ${isStream} -eq 0 ]; then
 
-            echo "
+        echo "
 stream {
         upstream electrs {
                 server 127.0.0.1:50001;
@@ -405,9 +410,9 @@ stream {
         }
 }" | sudo tee -a /etc/nginx/nginx.conf
 
-            elif [ ${isStream} -eq 1 ]; then
-                    sudo truncate -s-2 /etc/nginx/nginx.conf
-                    echo "
+      elif [ ${isStream} -eq 1 ]; then
+        sudo truncate -s-2 /etc/nginx/nginx.conf
+        echo "
         upstream electrs {
                 server 127.0.0.1:50001;
         }
@@ -423,10 +428,10 @@ stream {
         }
 }" | sudo tee -a /etc/nginx/nginx.conf
 
-            elif [ ${isStream} -gt 1 ]; then
-                    echo " Too many \`stream\` commands in nginx.conf. Please edit manually: \`sudo nano /etc/nginx/nginx.conf\` and retry"
-                    exit 1
-            fi
+      elif [ ${isStream} -gt 1 ]; then
+        echo " Too many \`stream\` commands in nginx.conf. Please edit manually: \`sudo nano /etc/nginx/nginx.conf\` and retry"
+        exit 1
+      fi
     fi
 
     echo
@@ -480,7 +485,7 @@ WantedBy=multi-user.target
   fi
 
   # whitelist downloading to localhost from bitcoind
-  if ! sudo grep -Eq "^whitelist=download@127.0.0.1" /mnt/hdd/bitcoin/bitcoin.conf;then
+  if ! sudo grep -Eq "^whitelist=download@127.0.0.1" /mnt/hdd/bitcoin/bitcoin.conf; then
     echo "whitelist=download@127.0.0.1" | sudo tee -a /mnt/hdd/bitcoin/bitcoin.conf
     bitcoindRestart=yes
   fi
@@ -572,7 +577,7 @@ if [ "$1" = "update" ]; then
   sudo -u electrs git fetch
 
   localVersion=$(/home/electrs/electrs/target/release/electrs --version)
-  updateVersion=$(curl --header "X-GitHub-Api-Version:2022-11-28" -s https://api.github.com/repos/romanz/electrs/releases/latest|grep tag_name|head -1|cut -d '"' -f4)
+  updateVersion=$(curl --header "X-GitHub-Api-Version:2022-11-28" -s https://api.github.com/repos/romanz/electrs/releases/latest | grep tag_name | head -1 | cut -d '"' -f4)
 
   if [ $localVersion = $updateVersion ]; then
     echo "# Up-to-date on version $localVersion"
@@ -583,11 +588,11 @@ if [ "$1" = "update" ]; then
     sudo -u electrs git reset --hard $updateVersion
 
     sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh \
-     "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
+      "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
 
     echo "# Installing build dependencies"
     sudo -u electrs curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u electrs sh -s -- --default-toolchain none -y
-    sudo apt install -y clang cmake build-essential  # for building 'rust-rocksdb'
+    sudo apt install -y clang cmake build-essential # for building 'rust-rocksdb'
     echo
 
     echo "# Build Electrs ..."

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/romanz/electrs/releases
-ELECTRSVERSION="v0.10.2"
+ELECTRSVERSION="v0.10.4"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -264,14 +264,12 @@ fi
 echo "# Making sure services are not running"
 sudo systemctl stop electrs 2>/dev/null
 
-# uninstall
+# install
 if [ "$1" = "install" ]; then
   echo "# INSTALL ELECTRS"
 
   if id "electrs" &>/dev/null; then
       echo "# user electrs exists already (codebase is installed)"
-      # app-storage dir could have wrong userid fix just in case 
-      sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs
   else
     echo "# Installing codebase"
     
@@ -302,14 +300,7 @@ if [ "$1" = "install" ]; then
 
     # build
     sudo -u electrs /home/electrs/.cargo/bin/cargo build --locked --release || exit 1
-
-    echo
-    echo "# The electrs database will be built in /mnt/hdd/app-storage/electrs/db. Takes ~18 hours and ~50Gb diskspace"
-    echo
-    sudo mkdir /mnt/hdd/app-storage/electrs 2>/dev/null
-    sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs
   fi
-
   exit 0
 fi
 
@@ -335,6 +326,16 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
       fi
     fi
 
+    # check and create storage dir
+    if ! sudo ls /mnt/hdd/app-storage/electrs 2>/dev/null; then
+      sudo mkdir /mnt/hdd/app-storage/electrs
+      echo
+      echo "# The electrs database will be built in /mnt/hdd/app-storage/electrs/db. Takes ~18 hours and ~50Gb diskspace"
+      echo
+    fi
+    # always fix user id 
+    sudo chown -R electrs:electrs /mnt/hdd/app-storage/electrs 
+    
     echo
     echo "# Getting RPC credentials from the bitcoin.conf"
     # read PASSWORD_B


### PR DESCRIPTION
After RC upgrade I had this error.
```
Mar 16 12:43:43 raspberrypi electrs[93270]: Error: electrs failed
Mar 16 12:43:43 raspberrypi electrs[93270]: Caused by:
Mar 16 12:43:43 raspberrypi electrs[93270]:     0: failed to open DB: /mnt/hdd/app-storage/electrs/db/bitcoin
Mar 16 12:43:43 raspberrypi electrs[93270]:     1: IO error: While renaming a file to /mnt/hdd/app-storage/electrs/db/bitcoin/LOG.old.1710593023497237: /mnt/hdd/app-storage/electrs/db/bitcoin/LOG: Permission denied
```
All files have this rights:  ```-rw-r--r-- 1 joinmarket joinmarket    135154 Mar 16 11:55 LOG```
This was the fix:
```chown -R electrs:electrs /mnt/hdd/app-storage/electrs```

This PR will fix the rights of the external storage. Not sure if this is really needed or it was some sort of problem I self inflicted some how.
But this change should do no harm on any system.