### PR TITLE
do not install postgres for cln to not create a cluster outside of the pg install script

### DIFF
--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -42,7 +42,7 @@ function installDependencies() {
     autoconf automake build-essential git libtool libsqlite3-dev \
     net-tools zlib1g-dev libsodium-dev gettext
   # additional requirements
-  sudo apt-get install -y postgresql libpq-dev
+  sudo apt-get install -y libpq-dev
   # for clnrest (since v23.11)
   sudo apt-get install -y python3-json5 python3-flask python3-gunicorn
   # upgrade pip


### PR DESCRIPTION
related to https://github.com/raspiblitz/raspiblitz/issues/4496

if CLN fails without the postgres dependency the postgres install script would need to be called from the cl.install.sh