### PR TITLE
ask before reboot in UPDATE menu

### DIFF
--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -269,7 +269,28 @@ Do you really want to update LND now?
       if [ ${#error} -gt 0 ]; then
         whiptail --title "ERROR" --msgbox "${error}" 8 30
       else
-        sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+        whiptail \
+         --title " LND update " \
+         --yes-button "Reboot" \
+         --no-button "Skip Reboot" \
+         --yesno \
+"OK LND update is done.
+
+By default a reboot is advised to sync macaroons and the TLS certificate.
+Consider rebooting later manually if encountering any problems.
+      " 12 50
+        if [ $? -eq 0 ]; then
+          clear
+          echo "# REBOOT .."
+          sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+          sleep 8
+          exit 1
+        else
+          echo "# SKIP REBOOT"
+          echo "# starting the bitcoind.service .."
+          sudo systemctl start lnd
+          exit 0
+        fi
         sleep 8
       fi
       ;;
@@ -293,7 +314,28 @@ Do you really want to update LND now?
       if [ ${#error} -gt 0 ]; then
         whiptail --title "ERROR" --msgbox "${error}" 8 30
       else
-        sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+        whiptail \
+         --title " LND update " \
+         --yes-button "Reboot" \
+         --no-button "Skip Reboot" \
+         --yesno \
+"OK LND update is done.
+
+By default a reboot is advised to sync macaroons and the TLS certificate.
+Consider rebooting later manually if encountering any problems.
+      " 12 50
+        if [ $? -eq 0 ]; then
+          clear
+          echo "# REBOOT .."
+          sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+          sleep 8
+          exit 1
+        else
+          echo "# SKIP REBOOT"
+          echo "# starting the bitcoind.service .."
+          sudo systemctl start lnd
+          exit 0
+        fi
         sleep 8
       fi
       ;;
@@ -418,7 +460,28 @@ Do you really want to update Bitcoin Core now?
       error=""
       warn=""
       sudo -u admin /home/admin/config.scripts/bitcoin.update.sh tested
-      sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+      whiptail \
+        --title " Bitcoin Core update " \
+        --yes-button "Reboot" \
+        --no-button "Skip Reboot" \
+        --yesno \
+"OK Bitcoin Core update is done.
+
+By default a reboot is advised.
+      " 9 40
+      if [ $? -eq 0 ]; then
+        clear
+        echo "# REBOOT .."
+        sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+        sleep 8
+        exit 1
+      else
+        echo "# SKIP REBOOT"
+        echo "# starting the bitcoind.service .."
+        sudo systemctl start bitcoind
+        exit 0
+      fi
+      sleep 8
       ;;
     RECKLESS)
       whiptail --title "UNTESTED Bitcoin Core update to ${bitcoinLatestVersion}" --yes-button "Cancel" \
@@ -439,11 +502,53 @@ Do you really want to update Bitcoin Core now?
       if [ ${#error} -gt 0 ]; then
         whiptail --title "ERROR" --msgbox "${error}" 8 30
       fi
-      sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+      whiptail \
+        --title " Bitcoin Core update " \
+        --yes-button "Reboot" \
+        --no-button "Skip Reboot" \
+        --yesno \
+"OK Bitcoin Core update is done.
+
+By default a reboot is advised.
+      " 9 40
+      if [ $? -eq 0 ]; then
+        clear
+        echo "REBOOT .."
+        sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+        sleep 8
+        exit 1
+      else
+        echo "# SKIP REBOOT"
+        echo "# starting the bitcoind.service .."
+        sudo systemctl start bitcoind
+        exit 0
+      fi
+      sleep 8
       ;;
     CUSTOM)
       sudo -u admin /home/admin/config.scripts/bitcoin.update.sh custom
-      sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+      whiptail \
+        --title " Bitcoin Core update " \
+        --yes-button "Reboot" \
+        --no-button "Skip Reboot" \
+        --yesno \
+"OK Bitcoin Core update is done.
+
+By default a reboot is advised.
+      " 9 40
+      if [ $? -eq 0 ]; then
+        clear
+        echo "# REBOOT .."
+        sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+        sleep 8
+        exit 1
+      else
+        echo "# SKIP REBOOT"
+        echo "# starting the bitcoind.service .."
+        sudo systemctl start bitcoind
+        exit 0
+      fi
+      sleep 8
       ;;
   esac
 }

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -287,7 +287,7 @@ Consider rebooting later manually if encountering any problems.
           exit 1
         else
           echo "# SKIP REBOOT"
-          echo "# starting the bitcoind.service .."
+          echo "# starting the lnd.service .."
           sudo systemctl start lnd
           exit 0
         fi
@@ -332,7 +332,7 @@ Consider rebooting later manually if encountering any problems.
           exit 1
         else
           echo "# SKIP REBOOT"
-          echo "# starting the bitcoind.service .."
+          echo "# starting the lnd.service .."
           sudo systemctl start lnd
           exit 0
         fi


### PR DESCRIPTION
I prefer not to reboot after updating core components
So far was using the cli to update, but introducing a question before rebooting the system would make it easier to use.

