### PR TITLE
(00raspiblitz.sh): fix typos; use -z for empty check; condensed some code

### DIFF
--- a/home.admin/00raspiblitz.sh
+++ b/home.admin/00raspiblitz.sh
@@ -15,7 +15,7 @@ infoFile="/home/admin/raspiblitz.info"
 source ${infoFile}
 
 # check that basic system phase/state information is available
-if [ "${setupPhase}" == "" ] || [ "${state}" == "" ]; then
+if [ -z "${setupPhase}" ] || [ -z "${state}" ]; then
   echo "setupPhase(${setupPhase}) state(${state})"
   echo "FAIL: ${infoFile} does not exist or missing state."
   echo "Check logs & bootstrap.service for errors and report to devs."
@@ -26,10 +26,8 @@ fi
 if [ "${state}" = "stop" ]; then
   echo "OK ready for manual provision - run 'release' at the end."
   exit
-fi
-
 # special state: copysource
-if [ "${state}" = "copysource" ]; then
+elif [ "${state}" = "copysource" ]; then
   echo "***********************************************************"
   echo "INFO: You lost connection during copying the blockchain"
   echo "You have the following options:"
@@ -42,7 +40,7 @@ fi
 # special state: copytarget
 source <(/home/admin/config.scripts/blitz.copychain.sh status)
 if [ "${copyInProgress}" = "1" ]; then
-  echo "Detected interrupted COPY blochain process ..."
+  echo "Detected interrupted COPY blockchain process ..."
   /home/admin/config.scripts/blitz.copychain.sh target
   exit
 fi
@@ -58,43 +56,30 @@ quit() {
   echo "SIGINT or SIGTERM received, exiting..."
   kill -9 $$
 }
-trap quit INT
-trap quit TERM
+trap quit INT TERM
 
 echo "# start ssh menu loop"
 # put some values on higher scan rate for 10 minute
-/home/admin/_cache.sh focus ln_default_ready 2 600 >/dev/null
-/home/admin/_cache.sh focus ln_default_locked 2 600 >/dev/null
-/home/admin/_cache.sh focus btc_default_synced 2 600 >/dev/null
+for key in ln_default_ready ln_default_locked btc_default_synced; do
+  /home/admin/_cache.sh focus $key 2 600 >/dev/null
+done
 
 echo "# starting ssh menu loop ... "
 exitMenuLoop=0
 doneIBD=0
-while [ ${exitMenuLoop} -eq 0 ]
-do
-
+while [ ${exitMenuLoop} -eq 0 ]; do
   #####################################
   # Access fresh system info on every loop
 
   # refresh system state information
   source <(/home/admin/_cache.sh get \
-    systemscan_runtime \
-    state \
-    setupPhase \
-    btc_default_synced \
-    ln_default_sync_chain \
-    ln_default_locked \
-    ln_default_ready \
-    ln_default_sync_initial_done \
-    message \
-    network \
-    chain \
-    lightning \
-    internet_localip
-  )
+    systemscan_runtime state setupPhase btc_default_synced \
+    ln_default_sync_chain ln_default_locked ln_default_ready \
+    ln_default_sync_initial_done message network chain \
+    lightning internet_localip)
 
   # background.scan is not ready yet
-  if [ "${systemscan_runtime}" == "" ]; then
+  if [ -z "${systemscan_runtime}" ]; then
     echo "# background.scan not ready yet ... (please wait)"
     sleep 4
     continue
@@ -108,18 +93,14 @@ do
   # Wallet Unlock
 
   if [ "${state}" == "ready" ] && [ "${setupPhase}" == "done" ] && [ "${ln_default_locked}" == "1" ]; then
-
     # unlock lnd
     if [ "${lightning}" == "lnd" ]; then
       /home/admin/config.scripts/lnd.unlock.sh
-    fi
-
     # unlock c-lightning
-    if [ "${lightning}" == "cl" ]; then
+    elif [ "${lightning}" == "cl" ]; then
       /home/admin/config.scripts/cl.hsmtool.sh unlock ${chain}net
       sleep 5
     fi
-
   fi
 
   #####################################
@@ -152,7 +133,7 @@ do
 
   # exit loop/script in case if system shutting down
   if [ "${state}" == "reboot" ] || [ "${state}" == "shutdown" ]; then
-    dialog --pause "  Prepare Reboot ..." 8 58 4
+    dialog --pause "  Prepare ${state} ..." 8 58 4
     clear
     echo "***********************************************************"
     echo "RaspiBlitz going to ${state}"
@@ -171,24 +152,10 @@ do
   # MAKE SURE BLOCKCHAIN/LN IS SYNC
   #####################################
   if [ "${setupPhase}" == "done" ] && [ "${state}" == "ready" ]; then
-    if [ "${lightning}" = "cl" ]; then
-      if [ "${btc_default_synced}" != "1" ] || [ "${ln_default_ready}" == "0" ] || [ "${ln_default_sync_chain}" == "0" ]; then
-        /home/admin/setup.scripts/eventBlockchainSync.sh ssh
-        sleep 3
-        continue
-      fi
-    elif [ "${lightning}" = "lnd" ]; then
-      if [ "${btc_default_synced}" != "1" ] || [ "${ln_default_ready}" == "0" ] || [ "${ln_default_sync_chain}" == "0" ] || [ "${ln_default_sync_initial_done}" == "0" ]; then
-        /home/admin/setup.scripts/eventBlockchainSync.sh ssh
-        sleep 3
-        continue
-      fi  
-    else
-      if [ "${btc_default_synced}" != "1" ]; then
-        /home/admin/setup.scripts/eventBlockchainSync.sh ssh
-        sleep 3
-        continue
-      fi
+    if [ "${btc_default_synced}" != "1" ] || [ "${ln_default_ready}" == "0" ] || [ "${ln_default_sync_chain}" == "0" ] || [ "${ln_default_sync_initial_done}" == "0" ]; then
+      /home/admin/setup.scripts/eventBlockchainSync.sh ssh
+      sleep 3
+      continue
     fi
   fi
 
@@ -202,25 +169,23 @@ do
     # check if there is a channel.backup to activate
     gotSCB=$(ls /home/admin/channel.backup 2>/dev/null | grep -c 'channel.backup')
     if [ "${gotSCB}" == "1" ]; then
-
       clear
       echo
       echo "*** channel.backup Recovery ***"
       echo "Running ... (please wait)"
       lncli --chain=${network} restorechanbackup --multi_file=/home/admin/channel.backup 2>/home/admin/.error.tmp
-      error=`cat /home/admin/.error.tmp`
+      error=$(cat /home/admin/.error.tmp)
       rm /home/admin/.error.tmp 2>/dev/null
 
       if [ ${#error} -gt 0 ]; then
-
         # output error message
         echo ""
         echo "# FAIL # SOMETHING WENT WRONG:"
         echo "${error}"
 
         # check if its possible to give background info on the error
-        notMachtingSeed=$(echo $error | grep -c 'unable to unpack chan backup')
-        if [ ${notMachtingSeed} -gt 0 ]; then
+        notMatchingSeed=$(echo $error | grep -c 'unable to unpack chan backup')
+        if [ ${notMatchingSeed} -gt 0 ]; then
           echo "--> ERROR BACKGROUND:"
           echo "The WORD SEED is not matching the channel.backup file."
           echo "Either there was an error in the word seed list or"
@@ -260,14 +225,15 @@ MAINMENU > REPAIR > REPAIR-LND > RETRYSCB
   if [ "${setupPhase}" == "done" ] && [ "${state}" == "ready" ]; then
     # MAIN MENU
     # remove higher scan rate on values
-    /home/admin/_cache.sh focus ln_default_locked -1
-    /home/admin/_cache.sh focus btc_default_synced -1
+    for key in ln_default_locked btc_default_synced; do
+      /home/admin/_cache.sh focus $key -1
+    done
     echo "# 00mainMenu.sh"
     /home/admin/00mainMenu.sh
     # use the exit code from main menu as signal if menu loop should exited
     # 0 = continue loop / everything else = break loop and exit to terminal
     exitMenuLoop=$?
-    if [ "${exitMenuLoop}" != "0" ]; then break; fi
+    [ "${exitMenuLoop}" != "0" ] && break
   fi
 
   #####################################
@@ -307,9 +273,7 @@ MAINMENU > REPAIR > REPAIR-LND > RETRYSCB
         # every other state just push as event to SSH frontend
         /home/admin/setup.scripts/eventInfoWait.sh "${state}" "${message}"
     fi
-
   fi
-
 done
 
 echo "# menu loop received exit code ${exitMenuLoop} --> exit to terminal"
@@ -350,12 +314,8 @@ echo "* Here be dragons .. have fun :)"
 echo "***********************************"
 if [ "${setupPhase}" == "done" ]; then
   echo "Bitcoin command line options: ${network}-cli help"
-  if [ "${lightning}" == "lnd" ]; then
-    echo "LND command line options: lncli -h"
-  fi
-  if [ "${lightning}" == "cl" ]; then
-    echo "Core Lightning command line options: lightning-cli help"
-  fi
+  [ "${lightning}" == "lnd" ] && echo "LND command line options: lncli -h"
+  [ "${lightning}" == "cl" ] && echo "Core Lightning command line options: lightning-cli help"
 else
   echo "Your setup is not finished."
   echo "For setup logs: cat raspiblitz.log"


### PR DESCRIPTION
tested by navigating the menu a bit

So first of all I fixed some typos, there won't be much to discuss there. :)

- for the equality checks I used `-z` instead, which should now also consider if the variable is unset
- used `elif` instead of many nested `if` statements and condensed some if checks, which condensed the `MAKE SURE BLOCKCHAIN/LN IS SYNC` check quite a bit
- used loops for multiple identical assignments, could be a style question there
- also used `&&` for single assignments, which is also a style question and thus should be discussed if wanted