### PR TITLE
fix: pip config set global.break-system-packages true for non venv installs

### DIFF
--- a/home.admin/config.scripts/cl-plugin.feeadjuster.sh
+++ b/home.admin/config.scripts/cl-plugin.feeadjuster.sh
@@ -18,6 +18,7 @@ if [ "$1" = "on" ];then
   if [ ! -f "/home/bitcoin/cl-plugins-available/plugins/${plugin}/${plugin}.py" ]; then
     cd /home/bitcoin/cl-plugins-available || exit 1
     sudo -u bitcoin git clone https://github.com/lightningd/plugins.git
+    sudo -u bitcoin pip config set global.break-system-packages true
     sudo -u bitcoin pip install -r /home/bitcoin/cl-plugins-available/plugins/${plugin}/requirements.txt
   fi
   if [ ! -L /home/bitcoin/${netprefix}cl-plugins-enabled/${plugin}.py ];then

--- a/home.admin/config.scripts/cl-plugin.standard-python.sh
+++ b/home.admin/config.scripts/cl-plugin.standard-python.sh
@@ -45,6 +45,7 @@ if [ "$1" = "on" ]; then
   else
     if [ $($lightningcli_alias | grep -c "/${plugin}") -eq 0 ]; then
       echo "# Just start the ${plugin} plugin"
+      sudo -u bitcoin pip config set global.break-system-packages true
       sudo -u bitcoin pip install -r /home/bitcoin/cl-plugins-available/plugins/${plugin}/requirements.txt
       $lightningcli_alias plugin start /home/bitcoin/cl-plugins-available/plugins/${plugin}/${plugin}.py
     fi

--- a/home.admin/config.scripts/cl.hsmtool.sh
+++ b/home.admin/config.scripts/cl.hsmtool.sh
@@ -217,6 +217,7 @@ if [ "$1" = "new" ] || [ "$1" = "new-force" ] || [ "$1" = "seed" ] || [ "$1" = "
 
   # check for https://github.com/trezor/python-mnemonic
   if [ $(pip list | grep -c mnemonic) -eq 0 ];then
+    pip config set global.break-system-packages true
     pip install mnemonic==0.19 1>/dev/null
   fi
 

--- a/home.admin/config.scripts/lnd.install.sh
+++ b/home.admin/config.scripts/lnd.install.sh
@@ -490,6 +490,7 @@ alias ${netprefix}lndconf=\"sudo nano /home/bitcoin/.lnd/${netprefix}lnd.conf\"\
   fi
 
   # needed to make lnd.newwallet.py work
+  pip config set global.break-system-packages true
   pip install --upgrade google-api-python-client
 
   exit 0


### PR DESCRIPTION
Setting 
```
pip config set global.break-system-packages true
```
for the respective users where a venv is not used.

The main problem solved with this is that cannot get the CLN plugins to respect the venvs even if they are used.

fixing: #4690
Related: #4170