### PR TITLE
add shellcheck to scan bash scripts for errors

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: ShellCheck
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    paths:
+      - '**/*.sh'
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: '.'
+          severity: error


### PR DESCRIPTION
adds shellcheck from https://github.com/marketplace/actions/shellcheck to check the bash scripts.

Only fails on errors.

fixes #2702 