### PR TITLE
Bonus: several `elementsd` enhancements (Liquid)

### DIFF
--- a/home.admin/config.scripts/blitz.shutdown.sh
+++ b/home.admin/config.scripts/blitz.shutdown.sh
@@ -42,7 +42,7 @@ echo "-----------------------------------------------"
 sleep 3
 
 # general services to stop
-servicesToStop="electrs fulcrum"
+servicesToStop="electrs fulcrum elementsd"
 for service in ${servicesToStop}; do
   if systemctl is-active --quiet ${service}; then
     echo "stopping ${service} - please wait .."

--- a/home.admin/config.scripts/bonus.elements.sh
+++ b/home.admin/config.scripts/bonus.elements.sh
@@ -161,6 +161,7 @@ function installService() {
     echo "
 # Elementsd configuration
 datadir=/mnt/hdd/app-data/.elements
+walletdir=/mnt/hdd/app-data/.elements/liquidv1/wallets
 rpcuser=raspiblitz
 rpcpassword=$PASSWORD_B
 rpcbind=127.0.0.1


### PR DESCRIPTION
This PR does:

- Add elementsd to `blitz.shutdown.sh`  to ensure graceful shutdown and wallet release
- Sets the walletdir param in the bootstrapped `elements.conf` to the respective app-data dir. Otherwise it would default to `~/.elements/wallets` (which is likely wrong, for consistency reasons)