### PR TITLE
clrest service to use BindsTo=lightningd.service

### DIFF
--- a/home.admin/config.scripts/cl.rest.sh
+++ b/home.admin/config.scripts/cl.rest.sh
@@ -196,6 +196,7 @@ if [ "$1" = on ]; then
 Description=c-lightning-REST daemon for ${CHAIN}
 Wants=${netprefix}lightningd.service
 After=${netprefix}lightningd.service
+BindsTo=${netprefix}lightningd.service
 
 [Service]
 ExecStart=/usr/bin/node /home/bitcoin/c-lightning-REST/${CLNETWORK}/cl-rest.js


### PR DESCRIPTION
How They Work Together
The service will start after lightningd.service due to After=.
When the service starts, it attempts to start lightningd.service due to Wants=.
The service's lifecycle will track lightningd.service due to BindsTo=, meaning if lightningd.service stops, the service will also stop, and vice versa for restarts.
In summary, this configuration ensures that:

The service starts after lightningd.service.
It wants lightningd.service to be running when it starts, but it's not critical for its own startup.
It is bound to the lifecycle of lightningd.service, meaning if lightningd.service stops or restarts, the dependent service will also stop or restart.