### PR TITLE
Update LIT to 0.13.4-alpha .. with Taproot Assets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,6 @@
 - Update: LNDK 0.2.0 (Pay BOLT12 offers with LND) [details](https://github.com/lndk-org/lndk/releases/tag/v0.2.0)
 - Update: Helipad (Podcasting 2.0 Boostagram reader) v0.2.0 [details](https://github.com/Podcastindex-org/helipad/releases/tag/v0.2.0)
 - Update: Mempool 3.0.0 [details](https://github.com/mempool/mempool/releases/tag/v3.0.0)
-- Update: Lightning Terminal v0.13.3-alpha [details](https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.13.3-alpha)
 
 ## What's new in Version 1.11.2 of RaspiBlitz?
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - Update: LNDK 0.2.0 (Pay BOLT12 offers with LND) [details](https://github.com/lndk-org/lndk/releases/tag/v0.2.0)
 - Update: Helipad (Podcasting 2.0 Boostagram reader) v0.2.0 [details](https://github.com/Podcastindex-org/helipad/releases/tag/v0.2.0)
 - Update: Mempool 3.0.0 [details](https://github.com/mempool/mempool/releases/tag/v3.0.0)
+- Update: Lightning Terminal v0.13.3-alpha [details](https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.13.3-alpha)
 
 ## What's new in Version 1.11.2 of RaspiBlitz?
 

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -12,7 +12,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
 fi
 
 # check who signed the release in https://github.com/lightninglabs/lightning-terminal/releases
-PGPsigner="ViktorTigerstrom"
+PGPsigner="ellemouton"
 
 if [ $PGPsigner = ellemouton ]; then
   pgpPubKey="D7D916376026F177"

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/lightninglabs/lightning-terminal/releases
-LITVERSION="0.13.3-alpha"
+LITVERSION="0.13.4-alpha"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -12,7 +12,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
 fi
 
 # check who signed the release in https://github.com/lightninglabs/lightning-terminal/releases
-PGPsigner="ellemouton"
+PGPsigner="ViktorTigerstrom"
 
 if [ $PGPsigner = ellemouton ]; then
   pgpPubKey="D7D916376026F177"

--- a/home.admin/config.scripts/bonus.lit.sh
+++ b/home.admin/config.scripts/bonus.lit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/lightninglabs/lightning-terminal/releases
-LITVERSION="0.12.5-alpha"
+LITVERSION="0.13.3-alpha"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then


### PR DESCRIPTION
This is not just a simple update because `tapd` was added and there could be risk of losing assets & BTC funds.

See Release Notes: https://github.com/lightninglabs/lightning-terminal/releases/tag/v0.13.4-alpha

So before rushing this - pushing it to v1.12.x Milestone