### PR TITLE
chore: update unnecessary packages in build_sdcard.sh

### DIFF
--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -285,7 +285,7 @@ echo "baseimage=${baseimage}"
 raspi_configfile="/boot/config.txt"
 raspi_commandfile="/boot/cmdline.txt"
 if [ -d /boot/firmware ];then
-  raspi_configfile="/boot/firmware/config.txt" 
+  raspi_configfile="/boot/firmware/config.txt"
   raspi_commandfile="/boot/firmware/cmdline.txt"
 fi
 echo "raspi_configfile=${raspi_configfile}"
@@ -343,7 +343,7 @@ if [ "${cpu}" = "aarch64" ] && { [ "${baseimage}" = "raspios_arm64" ] || [ "${ba
 fi
 
 echo "*** Remove unnecessary packages ***"
-unnecessary_packages=(libreoffice* oracle-java* chromium-browser nuscratch scratch sonic-pi plymouth python2 vlc* cups)
+unnecessary_packages=(libreoffice* oracle-java* chromium-browser nuscratch scratch sonic-pi plymouth python2 vlc* cups* libcups* libcamera* firefox* ffmpeg libpostproc* eom* evince*)
 for pkg in "${unnecessary_packages[@]}"; do
   if dpkg-query -W -f='${Status}' $pkg 2>/dev/null | grep -q "ok installed"; then
     echo "Removing $pkg..."


### PR DESCRIPTION
Saw on a `sudo apt upgrade` that some packages are unnecessary, so I added them to the array in `build_sdcard.sh`.


Saves about 550mb on a fresh 1.11.2 install for the packages itself + 510mb after `sudo apt autoremove`. So around ~1gb total

```
The following packages were automatically installed and are no longer required:
  accountsservice acl adwaita-icon-theme at-spi2-common avahi-utils bubblewrap colord colord-data
  edid-decode fio fonts-piboto geany-common gir1.2-atk-1.0 gir1.2-freedesktop gir1.2-gdkpixbuf-2.0
  gir1.2-gmenu-3.0 gir1.2-harfbuzz-0.0 gir1.2-notify-0.7 gir1.2-packagekitglib-1.0 gir1.2-pango-1.0
  gir1.2-polkit-1.0 gir1.2-secret-1 gnome-desktop3-data gnome-menus grim gsfonts gtk2-engines-pixbuf
  hunspell-en-us ibverbs-providers imagemagick-6-common inetutils-telnet ipp-usb libaccountsservice0 libaml0
  libappstream4 libaspell15 libass9 libatk-bridge2.0-0 libatk1.0-0 libatkmm-1.6-1v5 libatspi2.0-0
  libavformat59 libboost-iostreams1.74.0 libboost-log1.74.0 libboost-thread1.74.0 libbs2b0
  libcairomm-1.0-1v5 libchromaprint1 libcjson1 libcolord2 libcolorhug2 libdbus-glib-1-2 libdbusmenu-glib4
  libdbusmenu-gtk3-4 libdc1394-25 libdca0 libdirectfb-1.7-7 libdjvulibre-text libdjvulibre21 libdvdnav4
  libegl-dev libenchant-2-2 libevent-pthreads-2.1-7 libexempi8 libfaad2 libfftw3-double3 libflite1
  libfm-data libfm-extra4 libfm-gtk-data libfm4 libfreeaptx0 libgdk-pixbuf-xlib-2.0-0 libgdk-pixbuf2.0-0
  libgfapi0 libgfrpc0 libgfxdr0 libgl-dev libgl1-mesa-dev libgles-dev libglib2.0-bin libglibmm-2.4-1v5
  libglu1-mesa libglu1-mesa-dev libglusterfs0 libglut-dev libglut3.12 libglvnd-core-dev libglvnd-dev
  libglx-dev libgme0 libgnome-menu-3-0 libgs-common libgs10-common libgspell-1-common libgssdp-1.6-0
  libgstreamer-gl1.0-0 libgstreamer-plugins-bad1.0-0 libgtk-3-common libgtk2.0-common
  libgtksourceview-4-common libgupnp-1.6-0 libgupnp-igd-1.0-4 libgusb2 libgxps2 libharfbuzz-icu0
  libhunspell-1.7-0 libhyphen0 libibverbs1 libice-dev libid3tag0 libieee1284-3 libijs-0.35 libimath-3-1-29
  libinih1 libjavascriptcoregtk-4.1-0 libjbig2dec0 libjxr-tools libjxr0 libkate1 libkpathsea6 liblc3-0
  libldacbt-abr2 libldacbt-enc2 libliftoff-rpi liblightdm-gobject-1-0 liblilv-0-0 liblqr-1-0 liblrdf0
  libltc11 liblttng-ust-common1 liblttng-ust-ctl5 liblttng-ust1 liblua5.3-0 libmagickcore-6.q16-6
  libmagickcore-6.q16-6-extra libmagickwand-6.q16-6 libmanette-0.2-0 libmbedcrypto7 libmenu-cache-bin
  libmenu-cache3 libmjpegutils-2.1-0 libmpcdec6 libmpeg2encpp-2.1-0 libmplex2-2.1-0 libmysofa1 libnbd0
  libneon27 libnice10 libnma-common libnorm1 libnotify4 libobt2v5 libopenal-data libopenal1
  libopenexr-3-1-30 libopengl-dev libopengl0 libopenh264-7 libopenmpt0 libopenni2-0 libpackagekit-glib2-18
  libpangomm-1.4-1v5 libpangoxft-1.0-0 libpeas-common libpgm-5.3-0 libpipewire-0.3-0 libpipewire-0.3-common
  libpipewire-0.3-modules libpisp-common libpisp1 libplacebo208 libpmemblk1 libpocketsphinx3
  libpoppler-glib8 libpoppler126 libpthread-stubs0-dev libqt5designer5 libqt5help5 libqt5sql5
  libqt5sql5-sqlite libqt5test5 libqt5xml5 librabbitmq4 librados2 libraptor2-0 libraspberrypi0 librbd1
  librdmacm1 librist4 librubberband2 libsane-common libsane1 libsbc1 libseat1 libserd-0-0 libsigc++-2.0-0v5
  libsm-dev libsndio7.0 libsnmp-base libsnmp40 libsord-0-0 libsoundtouch1 libspa-0.2-bluetooth
  libspa-0.2-modules libspandsp2 libsphinxbase3 libsratom-0-0 libsrt1.5-gnutls libsrtp2-1 libssh-gcrypt-4
  libstartup-notification0 libstemmer0d libswscale6 libsynctex2 libturbojpeg0 libvidstab1.1 libvo-aacenc0
  libvo-amrwbenc0 libvte-2.91-common libwf-config1 libwf-utils0 libwildmidi2 libwireplumber-0.4-0
  libwlroots11 libwmflite-0.2-7 libwnck-3-common libwoff1 libwpe-1.0-1 libwpebackend-fdo-1.0-1 libx11-dev
  libxau-dev libxcb-composite0 libxcb-res0 libxcb1-dev libxdmcp-dev libxext-dev libxkbregistry0
  libxklavier16 libxmlb2 libxres1 libxt-dev libyajl2 libzbar0 libzimg2 libzmq5 libzxing2 lxde-common
  lxhotkey-core lxmenu-data lxpanel-data lxsession-data mate-desktop-common mate-polkit-common p11-kit
  p11-kit-modules packagekit pi-language-support pi-printer-support pipewire pipewire-bin pipewire-pulse
  pocketsphinx-en-us poppler-data poppler-utils python3-cairo python3-dbus python3-gi-cairo python3-kms++
  python3-libevdev python3-opengl python3-pidng python3-piexif python3-prctl python3-pyqt5.sip
  python3-pyudev python3-simplejpeg python3-smbc python3-v4l2 qt5ct rpd-wallpaper sane-airscan sane-utils
  update-inetd usb.ids wayfire webp-pixbuf-loader wireplumber wlr-randr x11proto-dev xdg-dbus-proxy
  xdg-desktop-portal xdg-desktop-portal-wlr xinput xorg-sgml-doctools xsettingsd xtrans-dev xwayland
  zenity-common
Use 'sudo apt autoremove' to remove them.
The following additional packages will be installed:
  libavcodec59 libavformat59 libavutil57 libfm4 libgs10-common libjavascriptcoregtk-4.1-0 libpipewire-0.3-0
  libpipewire-0.3-modules libspa-0.2-bluetooth libspa-0.2-modules libswscale6 pipewire pipewire-bin
  pipewire-pulse
Suggested packages:
  libcuda1 libnvcuvid1 libnvidia-encode1
Recommended packages:
  libfm-modules
The following packages will be REMOVED:
  agnostics alacarte arandr cups-common cups-pk-helper cups-ppdc eom eom-common evince evince-common ffmpeg
  firefox galculator gcr geany ghostscript gir1.2-eom-1.0 gir1.2-gtk-3.0 gir1.2-handy-1 gnome-keyring
  gstreamer1.0-libav gstreamer1.0-plugins-bad gtk2-engines-pixflat gui-pkinst libavdevice59 libavfilter8
  libayatana-ido3-0.4-0 libayatana-indicator3-7 libcamera-ipa libcamera-tools libcamera0.2 libcups2
  libcupsfilters1 libcupsimage2 libevdocument3-4 libevview3-3 libfm-gtk4 libfm-modules libgcr-ui-3-1
  libgnome-desktop-3-20 libgs10 libgspell-1-2 libgtk-3-0 libgtk-layer-shell0 libgtk2.0-0 libgtk2.0-bin
  libgtkmm-3.0-1v5 libgtksourceview-4-0 libhandy-1-0 libimlib2 libinput-tools libkeybinder-3.0-0
  libmate-desktop-2-17 libmousepad0 libneatvnc0 libnma0 libobrender32v5 libpeas-1.0-0 libpostproc56
  libqt5printsupport5 libspectre1 libvte-2.91-0 libwebkit2gtk-4.1-0 libwnck-3-0 lightdm lightdm-gtk-greeter
  lp-connection-editor lxappearance lxappearance-obconf lxde lxde-core lxhotkey-gtk lxinput lxpanel
  lxplug-bluetooth lxplug-cputemp lxplug-ejecter lxplug-magnifier lxplug-menu lxplug-netman lxplug-network
  lxplug-ptbatt lxplug-updater lxplug-volumepulse lxpolkit lxrandr lxsession lxsession-edit lxsession-logout
  lxtask lxterminal mate-polkit mate-polkit-bin mousepad obconf openbox openbox-lxde-session pcmanfm
  pi-greeter pi-package pi-package-data pi-package-session piclone pinentry-gnome3 pipanel
  pipewire-libcamera pishutdown pixflat-icons pixflat-theme printer-driver-escpr python3-av python3-cups
  python3-cupshelpers python3-libcamera python3-picamera2 python3-pyqt5 qt5-gtk-platformtheme
  qt5-gtk2-platformtheme qt5-style-plugins raspberrypi-ui-mods rc-gui rp-bookshelf rp-prefapps rpicam-apps
  scrot system-config-printer system-config-printer-common system-config-printer-udev telnet wayvnc
  wf-panel-pi xarchiver xdg-desktop-portal-gtk zenity
The following packages will be upgraded:
  libavcodec59 libavformat59 libavutil57 libfm4 libgs10-common libjavascriptcoregtk-4.1-0 libpipewire-0.3-0
  libpipewire-0.3-modules libspa-0.2-bluetooth libspa-0.2-modules libswscale6 pipewire pipewire-bin
  pipewire-pulse
14 upgraded, 0 newly installed, 134 to remove and 69 not upgraded.
Need to get 19.3 MB of archives.
After this operation, 548 MB disk space will be freed.
Do you want to continue? [Y/n] 
```