### PR TITLE
cln update to v24.08.2

### DIFF
--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -2,7 +2,7 @@
 # https://lightning.readthedocs.io/
 
 # https://github.com/ElementsProject/lightning/releases
-CLVERSION="v24.08.1"
+CLVERSION="v24.08.2"
 
 # https://github.com/ElementsProject/lightning/tree/master/contrib/keys
 # rustyrussell D9200E6CD1ADB8F1


### PR DESCRIPTION
containes minor fixes
tested update on amd64

`CLN v24.08.2` does not show up as `-modded` version any more