### PR TITLE
fulcrum: improve config to prevent data corruption and sync large wallets

### DIFF
--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -385,29 +385,38 @@ if [ "$1" = on ]; then
   echo "# Get the RPC credentials from the bitcoin.conf"
   RPC_USER=$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcuser | cut -c 9-)
   PASSWORD_B=$(sudo cat /mnt/hdd/bitcoin/bitcoin.conf | grep rpcpassword | cut -c 13-)
-  echo "\
+  echo "## Fulcrum Config File
+## for full explanations see:
+## https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf
 datadir = /home/fulcrum/.fulcrum/db
 bitcoind = 127.0.0.1:8332
 rpcuser = ${RPC_USER}
 rpcpassword = ${PASSWORD_B}
-# RPi optimizations
-# avoid 'bitcoind request timed out'
-bitcoind_timeout = 600
-# reduce load (4 cores only)
-bitcoind_clients = 1
-worker_threads = 1
-db_mem=1024
-# for 4GB RAM
-db_max_open_files=200
-fast-sync = 1024
-# server connections
-# disable peer discovery and public server options
+
+## Server Connections
+## disable peer discovery and public server options
 peering = false
 announce = false
 tcp = 0.0.0.0:${portTCP}
 admin = ${portAdmin}
-# ssl via nginx
-" | sudo -u fulcrum tee /home/fulcrum/.fulcrum/fulcrum.conf
+## ssl is handled via nginx
+
+## RPi Optimizations
+## avoid 'bitcoind request timed out'
+bitcoind_timeout = 600
+## reduce load
+bitcoind_clients = 1
+worker_threads = 1
+## optimize for 4-8 GB RAM
+db_mem=1024
+db_max_open_files=200
+## fast_sync is now called utxo_cache
+## disable to prevent database corruption on restart
+#utxo_cache = 1024
+
+## allow syncing wallets with a large number of addresses
+max_subs_per_ip = 100000 # default: 75000" |
+    sudo -u fulcrum tee /home/fulcrum/.fulcrum/fulcrum.conf
 
   createSystemdService
 

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -410,7 +410,7 @@ worker_threads = 1
 ## optimize for 4-8 GB RAM
 db_mem=1024
 db_max_open_files=200
-## fast_sync is now called utxo_cache
+## fast-sync is now called utxo_cache
 ## disable to prevent database corruption on restart
 #utxo_cache = 1024
 

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -415,7 +415,7 @@ db_max_open_files=200
 #utxo_cache = 1024
 
 ## allow syncing wallets with a large number of addresses
-max_subs_per_ip = 100000 # default: 75000" |
+max_subs_per_ip = 1000000 # default: 75000" |
     sudo -u fulcrum tee /home/fulcrum/.fulcrum/fulcrum.conf
 
   createSystemdService


### PR DESCRIPTION
Successfully syncing a wallet with more than 20k transactions and more than 200k addresses monitored from an RPi5 in ~7 minutes with these settings.

* About the settings `utxo_cache` (was` fast_sync`) - will be disabled by default:
```
#-------------------------------------------------------------------------------
# OPTIONS USED ONLY DURING INITIAL SYNC
#-------------------------------------------------------------------------------

# UTXO cache = 'utxo_cache' - DEFAULT: 0
#
# If specified, Fulcrum will use a UTXO Cache that consumes extra memory but
# syncs up to to 2X faster. To use this feature, you must specify a memory value
# in MB to allocate to the cache. It is recommended that you give this facility
# at least 500 MB for it to really pay off, although any amount of memory given
# (minimum 64 MB) should be beneficial. Note that this feature is currently
# experimental and the tradeoffs are: it is faster because it avoids redundant
# disk I/O, however, this comes at the price of considerable memory consumption
# as well as a sync that is less resilient to crashes mid-sync. If the process
# is killed mid-sync, the database may become corrupt and lose UTXO data. Use
# this feature only if you are 100% sure that won't happen during a sync.
# The default is off (0). This option only takes effect on initial sync,
# otherwise this option has no effect.
#
#utxo_cache = 0
```
https://github.com/cculianu/Fulcrum/blob/master/doc/fulcrum-example-config.conf#L540-L559


* `max_subs_per_ip = 1000000` does not affect syncing on the localhost, but does affect when connected from the LAN:
```
# Maximum subscriptions (per-IP address) - 'max_subs_per_ip' - DEFAULT: 75000
#
# The maximum number of script hash subscriptions per IP address. Note that IP
# addresses matching 'subnets_to_exclude_from_per_ip_limits' will not be
# subjected to this limit (they will still be subjected to the global 'max_subs'
# limit, however).
#
# If a client attempts to subscribe beyond this limit for all the connections
# coming from their IP address, it will receive an error message.
#
#max_subs_per_ip = 75000

# Exclusion from per-IP limits - 'subnets_to_exclude_from_per_ip_limits'
# - DEFAULT: 127.0.0.1/32, ::1/128
#
# Specify a comma-delimited list of subnets to exclude from the per-IP limits
# (such as max_clients_per_ip). Clients connecting from one of these subnets
# will not be subjected to any per-IP limits. The default is for any clients
# connecting from localhost (this default is particularly useful if serving via
# Tor, where all clients come from localhost). Set this to the empty string to
# not have any excluded subnets, eg "subnets_to_exclude_from_per_ip_limits =".
#
# Examples: 10.10.2.0/24, 128.101.0.0/16, 123.45., 99.74.0.0/255.255.0.0, ...
#
#subnets_to_exclude_from_per_ip_limits = 127.0.0.1/32, ::1/128
```

