### PR TITLE
lnbits: Wait for CLN RPC socket to become available

### DIFF
--- a/home.admin/config.scripts/bonus.lnbits.sh
+++ b/home.admin/config.scripts/bonus.lnbits.sh
@@ -585,6 +585,12 @@ if [ "$1" = "prestart" ]; then
       exit 1
     fi
 
+    CLIGHTNING_RPC=$(grep '^CLIGHTNING_RPC=' ${lnbitsConfig} | cut -d'=' -f2-)
+    while ! lightning-cli --rpc-file=${CLIGHTNING_RPC} getinfo &> /dev/null; do
+      echo "Waiting for CLN RPC socket to become available..."
+      sleep 1
+    done
+
     echo "# everything looks OK for lnbits config on CLN on ${LNBitsChain}net"
 
   else


### PR DESCRIPTION
lnbits: Wait for CLN RPC socket to become available before allowing lnbits to start up. This avoids a VoidWallet being activated, requiring the user to manually restart lnbits whenever CLN is restarted.

For example:

```
2025-01-19 04:01:58.41 | ERROR | Error initializing CLightningWallet: [Errno 111] Connection refused
2025-01-19 04:01:58.41 | WARNING | Fallback to VoidWallet, because the backend for CLightningWallet isn't working properly
2025-01-19 04:01:58.41 | INFO | Connecting to backend VoidWallet...
2025-01-19 04:01:58.41 | WARNING | This backend does nothing, it is here just as a placeholder, you must configure an actual backend before being able to do anything useful with LNbits.
2025-01-19 04:01:58.41 | SUCCESS | ✔️ Backend VoidWallet connected and with a balance of 0 msat.
```

Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.
