### PR TITLE
Switch to bitcoin user for version verification

### DIFF
--- a/home.admin/config.scripts/bitcoin.update.sh
+++ b/home.admin/config.scripts/bitcoin.update.sh
@@ -288,7 +288,7 @@ if [ "${mode}" = "tested" ] || [ "${mode}" = "reckless" ] || [ "${mode}" = "cust
   tar -xvf ${binaryName}
   sudo install -m 0755 -o root -g root -t /usr/local/bin/ bitcoin-${bitcoinVersion}/bin/*
   sleep 3
-  if ! sudo /usr/local/bin/bitcoind --version | grep "${bitcoinVersion}"; then
+  if ! sudo -u bitcoin /usr/local/bin/bitcoind --version | grep "${bitcoinVersion}"; then
     echo
     echo "# BUILD FAILED --> Was not able to install bitcoind version(${bitcoinVersion})"
     exit 1


### PR DESCRIPTION
We normally run bitcoind as user bitcoin.
Running it here as **root** could potentially at some point cause issues (e.g. if files are created and the ownership is then off).

What do you think @openoms ?

Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [X] That its based against the `dev` branch - not the default release branch.
