### PR TITLE
fix fulcrum status output

### DIFF
--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -30,11 +30,10 @@ fi
 
 if [ "$1" = "status-sync" ] || [ "$1" = "status" ]; then
   # Check if the command was successful or if it failed with "Connection refused"
-  if ! echo "$getInfoOutput" | jq -r '.version' 2>/dev/null; then
-    # Command failed, make getInfo empty
+  versionExtracted=$(echo "$getInfoOutput" | jq -r '.version' 2>/dev/null)
+  if [ -z "$versionExtracted" ] || [ "$versionExtracted" = "null" ]; then
     getInfo=""
   else
-    # Command succeeded, store the output in getInfo
     getInfo="$getInfoOutput"
   fi
   if systemctl is-active fulcrum >/dev/null; then


### PR DESCRIPTION
Previous output:
```
./config.scripts/bonus.fulcrum.sh status
Fulcrum 1.11.1
##### STATUS FULCRUM SERVICE
version='1.11.1'
configured=1
serviceInstalled=1
....
```

```
./config.scripts/bonus.fulcrum.sh status
Fulcrum 1.11.1
##### STATUS FULCRUM SERVICE
version='1.11.1'
configured=1
serviceInstalled=1
```

The fix removed the line:
```
Fulcrum 1.11.1
```
```
./config.scripts/bonus.fulcrum.sh status
##### STATUS FULCRUM SERVICE
version='1.11.1'
configured=1
serviceInstalled=1
...
```
```
./config.scripts/bonus.fulcrum.sh status-sync
serviceRunning=1
electrumResponding=1
syncProgress=100.00%
tipSynced=1
initialSynced=1
```

