### PR TITLE
LND conf: enable bLIP-50: LSP Spec Transport Layer

### DIFF
--- a/home.admin/assets/lnd.bitcoin.conf
+++ b/home.admin/assets/lnd.bitcoin.conf
@@ -43,3 +43,6 @@ db.bolt.auto-compact-min-age=672h
 healthcheck.chainbackend.attempts=3
 healthcheck.chainbackend.timeout=2m0s 
 healthcheck.chainbackend.interval=1m30s
+
+[protocol]
+protocol.custom-message=37913

--- a/home.admin/config.scripts/lnd.install.sh
+++ b/home.admin/config.scripts/lnd.install.sh
@@ -328,6 +328,9 @@ bitcoin.node=bitcoind
 [bolt]
 db.bolt.auto-compact=true
 db.bolt.auto-compact-min-age=672h
+
+[protocol]
+protocol.custom-message=37913
 " | sudo -u bitcoin tee /home/bitcoin/.lnd/${netprefix}lnd.conf
   else
     echo "# The file /home/bitcoin/.lnd/${netprefix}lnd.conf is already present"


### PR DESCRIPTION
LSPS0/bLIP-50 has recently been [merged into the bLIP spec](https://github.com/lightning/blips/blob/master/blip-0050.md). This is a communication protocol over Lightning's p2p messaging layer called BOLT8, and is used for clients to communicate with Lightning Service Providers and vice versa.

At present, LND doesn't allow applications to communicate over BOLT8 with message types higher than 32768, without building with the `dev` tag or modifying the LND configuration. LSPS0/bLIP-50 uses type 37913.

This configuration change will allow RaspiBlitz users to interface with LSP spec-compliant services, such as ZEUS' Olympus.

====

Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.
