### PR TITLE
Update README with Debian version details

### DIFF
--- a/alternative.platforms/Proxmox/README.md
+++ b/alternative.platforms/Proxmox/README.md
@@ -13,7 +13,7 @@ You have several options for the SSD: Either you install the 1TB SSD in the syst
 
 ## Create Debian VM
 
-We install Raspiblitz on a fresh Debian machine. Therefore we have to download the ISO file from Debian first. Here just choose the right processor architecture: (For me it is amd64)
+We install Raspiblitz on a fresh Debian machine. Therefore we have to download the ISO file from Debian first. Here make sure to select same version of Debian (currently "**Bookworm**") as Raspiblitz is based on and to choose the right processor architecture: (For me it is amd64)
 
 [https://www.debian.org/distrib/netinst](https://www.debian.org/distrib/netinst)
 


### PR DESCRIPTION
Clarify Debian version requirement for Raspiblitz installation. As of recently Debian 13 (Trixie) is out - but trying to run the build_sd.sh script on it won't be successful!

Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.
