### PR TITLE
update Bitcoin Knots to v29.1.knots20250903

### DIFF
--- a/home.admin/config.scripts/bonus.knots.sh
+++ b/home.admin/config.scripts/bonus.knots.sh
@@ -12,10 +12,10 @@ APPID="knots" # one-word lower-case no-specials
 
 # clean human readable version - will be displayed in UI
 # just numbers only separated by dots (2 or 0.1 or 1.3.4 or 3.4.5.2)
-VERSION="28.1"
+VERSION="29.1"
 
-FILEMASTER="28.x"
-FILEMASTERTAG="28.1.knots20250305"
+FILEMASTER="29.x"
+FILEMASTERTAG="29.1.knots20250903"
 
 # the git repo to get the source code from for install
 GITHUB_REPO="https://github.com/bitcoinknots/bitcoin"
@@ -23,7 +23,7 @@ GITHUB_REPO="https://github.com/bitcoinknots/bitcoin"
 # the github tag of the version of the source code to install
 # can also be a commit hash
 # if empty it will use the latest source version
-GITHUB_TAG="v28.1.knots20250305"
+GITHUB_TAG="v29.1.knots20250903"
 
 # the github signature to verify the author
 # leave GITHUB_SIGN_AUTHOR empty to skip verifying


### PR DESCRIPTION
- [x] That its based against the `dev` branch - not the default release branch.
