### PR TITLE
clear error message if 'bitcoin-update.sh tested' fails

### DIFF
--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -459,7 +459,13 @@ Do you really want to update Bitcoin Core now?
 
       error=""
       warn=""
-      sudo -u admin /home/admin/config.scripts/bitcoin.update.sh tested
+      sudo -u admin /home/admin/config.scripts/bitcoin.update.sh tested || {
+        whiptail --title "ERROR" --msgbox "bitcoin.update.sh failed
+
+It was called at $(readlink -f "${BASH_SOURCE[0]}"):${LINENO}
+Consider running that manually to debug " 10 80
+        exit 0
+      }
       whiptail \
         --title " Bitcoin Core update " \
         --yes-button "Reboot" \


### PR DESCRIPTION
Currently, if `bitcoin-update.sh tested` fails, the menu system _thinks_ it has succeeded and advises the user to reboot their machine

However, it can fail, for example the `gpg` key verification failed for me. I was confused when I went through this update and reboot process multiple times but the version didn't actually increase!

In this PR, an error message is given to the user, telling them which command failed and suggesting they run it manually to debug.

**Here is the new error screen added by this PR**:

<img width="769" height="215" alt="image" src="https://github.com/user-attachments/assets/2cd2c240-1b5d-4172-8c32-8e22f6b04e75" />


Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.
