### PR TITLE
feat: update alby hub to latest version

### DIFF
--- a/home.admin/config.scripts/bonus.albyhub.sh
+++ b/home.admin/config.scripts/bonus.albyhub.sh
@@ -7,7 +7,7 @@
 APPID="albyhub" # one-word lower-case no-specials
 
 # https://github.com/getAlby/hub/releases
-VERSION="1.17.2"
+VERSION="1.20.0"
 
 # port numbers the app should run on
 # delete if not an web app


### PR DESCRIPTION
In a recent episode of the Nodesignal podcast they mentioned Alby Hub is still on a very old version, so I thought I'd update it. 

Is this everything that needs to be done? Will users manually have to install this update by running a shell script? 

How do we make sure this is updated in regular intervals? Should @getAlby add that to their release checklist? 