### PR TITLE
Update Alby Hub to v1.20.0

### DIFF
--- a/home.admin/config.scripts/bonus.albyhub.sh
+++ b/home.admin/config.scripts/bonus.albyhub.sh
@@ -7,7 +7,7 @@
 APPID="albyhub" # one-word lower-case no-specials
 
 # https://github.com/getAlby/hub/releases
-VERSION="1.17.2"
+VERSION="1.20.0"
 
 # port numbers the app should run on
 # delete if not an web app


### PR DESCRIPTION
This updates AlbyHub to version 1.20.0 
I could not test this change. 
Also I am wondering if we somehow can/should set this to always use the latest version? 
