### PR TITLE
fulcrum update to 2.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - Update: Bitcoin Core v29.2 [details](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-29.2.md)
 - Update: Electrum Server in Rust (electrs) v0.10.10 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#01010-jul-19-2025)
 - Update: AlbyHub v1.20.0 [details](https://github.com/getAlby/hub/releases/tag/v1.20.0)
+- Update: Fulcrum Electrum server v2.1.0 [details](https://github.com/cculianu/Fulcrum/releases/tag/v2.1.0)
 - Update: Bitcoin Knots 29.2 (optional) [details](https://github.com/bitcoinknots/bitcoin/releases/tag/v29.2.knots20251010)
 
 ## What's new in Version 1.12.0 of RaspiBlitz?

--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -13,6 +13,7 @@ if [ ${#BTCRPCexplorer} -eq 0 ]; then BTCRPCexplorer="off"; fi
 if [ ${#specter} -eq 0 ]; then specter="off"; fi
 if [ ${#BTCPayServer} -eq 0 ]; then BTCPayServer="off"; fi
 if [ ${#ElectRS} -eq 0 ]; then ElectRS="off"; fi
+if [ ${#fulcrum} -eq 0 ]; then fulcrum="off"; fi
 if [ ${#lndmanage} -eq 0 ]; then lndmanage="off"; fi
 if [ ${#joinmarket} -eq 0 ]; then joinmarket="off"; fi
 if [ ${#jam} -eq 0 ]; then jam="off"; fi

--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -44,6 +44,7 @@ OPTIONS=()
 # just available for BTC
 if [ "${network}" == "bitcoin" ]; then
   OPTIONS+=(ea 'BTC Electrum Rust Server' ${ElectRS})
+  OPTIONS+=(fu 'BTC Fulcrum Electrum Server' ${fulcrum})
   OPTIONS+=(pa 'BTC PayServer' ${BTCPayServer})
   OPTIONS+=(ba 'BTC RPC-Explorer' ${BTCRPCexplorer})
   OPTIONS+=(sa 'BTC Specter Desktop' ${specter})
@@ -253,6 +254,56 @@ When finished use the new 'ELECTRS' entry in Main Menu for more info.\n
 
 else
   echo "ElectRS Setting unchanged."
+fi
+
+# Fulcrum process choice
+choice="off"; check=$(echo "${CHOICES}" | grep -c "fu")
+if [ ${check} -eq 1 ]; then choice="on"; fi
+if [ "${fulcrum}" != "${choice}" ]; then
+  echo "Fulcrum Setting changed .."
+  anychange=1
+  extraparameter=""
+  if [ "${choice}" =  "on" ]; then
+    # check on HDD size
+    source <(sudo /home/admin/config.scripts/blitz.data.sh status)
+    if [ ${storageSizeGB} -lt 800 ]; then
+      whiptail --title " HDD/SSD TOO SMALL " --msgbox "\
+We recommend at least a 1TB HDD/SSD if you want to run Fulcrum.\n
+This is due to the electrum index that will grow over time and needs space.\n
+To migrate to a bigger HDD/SSD check RaspiBlitz README on 'migration'.\n
+" 14 50
+    else
+      /home/admin/config.scripts/bonus.fulcrum.sh on ${extraparameter}
+      errorOnInstall=$?
+      if [ ${errorOnInstall} -eq 0 ]; then
+        sudo systemctl start fulcrum
+        whiptail --title " Installed Fulcrum Server " --msgbox "\
+The index database needs to be created before Fulcrum can be used.\n
+This can take hours/days depending on your RaspiBlitz.\n
+When finished use the new 'FULCRUM' entry in Main Menu for more info.\n
+" 14 50
+      needsReboot=0
+      else
+        l1="# FAIL on Fulcrum install #"
+        l2="Try manual install on terminal after reboot with:"
+        l3="/home/admin/config.scripts/bonus.fulcrum.sh on"
+        dialog --title 'FAIL' --msgbox "${l1}\n${l2}\n${l3}" 7 65
+      fi
+    fi
+  fi
+  if [ "${choice}" =  "off" ]; then
+	  whiptail --title "Delete Fulcrum Index?" \
+    --yes-button "Keep Index" \
+    --no-button "Delete Index" \
+    --yesno "Fulcrum is getting uninstalled. Do you also want to delete the Fulcrum Index? It contains no important data, but can take multiple hours to rebuild if needed again." 10 60
+	  if [ $? -eq 1 ]; then
+      extraparameter="deleteindex"
+	  fi
+    /home/admin/config.scripts/bonus.fulcrum.sh off ${extraparameter}
+  fi
+
+else
+  echo "Fulcrum Setting unchanged."
 fi
 
 # BTCPayServer process choice

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -591,6 +591,10 @@ if [ "${ElectRS}" == "on" ]; then
   OPTIONS+=(ELECTRS "Update Electrs")
 fi
 
+if [ "${fulcrum}" == "on" ]; then
+  OPTIONS+=(FULCRUM "Update Fulcrum")
+fi
+
 if [ "${RTL}" == "on" ]||[ "${cRTL}" == "on" ]; then
   OPTIONS+=(RTL "Update RTL")
 fi
@@ -661,6 +665,9 @@ case $CHOICE in
     ;;
   ELECTRS)
     /home/admin/config.scripts/bonus.electrs.sh update
+    ;;
+  FULCRUM)
+    /home/admin/config.scripts/bonus.fulcrum.sh update
     ;;
   RTL)
     /home/admin/config.scripts/bonus.rtl.sh update

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -325,7 +325,7 @@ StartLimitBurst=2
 StartLimitIntervalSec=20
 
 [Service]
-ExecStart=/home/fulcrum/Fulcrum /home/fulcrum/.fulcrum/fulcrum.conf
+ExecStart=/home/fulcrum/Fulcrum --db-upgrade /home/fulcrum/.fulcrum/fulcrum.conf
 KillSignal=SIGINT
 User=fulcrum
 LimitNOFILE=8192
@@ -501,6 +501,15 @@ if [ "$1" = update ]; then
   downloadAndVerifyBinary
 
   sudo systemctl disable --now fulcrum
+
+  # Update config file: remove deprecatedutxo_cache and fast_sync entries
+  configFile="/home/fulcrum/.fulcrum/fulcrum.conf"
+  if [ -f "$configFile" ]; then
+    echo "# Updating Fulcrum config file"
+    # Remove utxo_cache and fast_sync entries
+    sudo -u fulcrum sed -i '/^utxo_cache/d' "$configFile"
+    sudo -u fulcrum sed -i '/^fast_sync/d' "$configFile"
+  fi
 
   createSystemdService
 

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/cculianu/Fulcrum/releases
-fulcrumVersion="1.12.0"
+fulcrumVersion="2.0.0"
 
 portTCP="50021"
 portSSL="50022"
@@ -404,11 +404,8 @@ bitcoind_timeout = 600
 bitcoind_clients = 1
 worker_threads = 1
 ## optimize for 4-8 GB RAM
-db_mem=1024
-db_max_open_files=200
-## fast-sync is now called utxo_cache
-## disable to prevent database corruption on restart
-#utxo_cache = 1024
+db_mem = 256
+db_max_open_files = 200
 
 ## allow syncing wallets with a large number of addresses
 max_subs_per_ip = 1000000 # default: 75000" |

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/cculianu/Fulcrum/releases
-fulcrumVersion="2.0.0"
+fulcrumVersion="2.1.0"
 
 portTCP="50021"
 portSSL="50022"

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -46,8 +46,8 @@ fi
 
 if [ "$1" = "status" ]; then
   echo "##### STATUS FULCRUM SERVICE"
-  fulcrumVersion=$(/home/fulcrum/Fulcrum -v 2>/dev/null | grep -oP 'Fulcrum \K\d+\.\d+\.\d+')
-  echo "version='${fulcrumVersion}'"
+  displayVersion=$(/home/fulcrum/Fulcrum -v 2>/dev/null | grep Fulcrum)
+  echo "version='${displayVersion}'"
 
   source /mnt/hdd/app-data/raspiblitz.conf
   if [ "${fulcrum}" = "on" ]; then

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -403,8 +403,6 @@ bitcoind_timeout = 600
 ## reduce load
 bitcoind_clients = 1
 worker_threads = 1
-## optimize for 4-8 GB RAM
-db_mem = 256
 db_max_open_files = 200
 
 ## allow syncing wallets with a large number of addresses

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -218,11 +218,23 @@ Check 'sudo nginx -t' for a detailed error message.
 
   OPTIONS=(
     CONNECT "How to connect"
-    REINDEX "Delete and rebuild the Fulcrum database"
     STATUS "Fulcrum status info"
+    LOGS "Show service logs"
+    CONF "Edit fulcrum.conf"
+    SERVICE "Edit systemd service"
+    REINDEX "Delete and rebuild the Fulcrum database"
   )
 
-  CHOICE=$(whiptail --clear --title "Fulcrum Electrum Server" --menu "menu" 10 50 3 "${OPTIONS[@]}" 2>&1 >/dev/tty)
+  WIDTH=64
+  CHOICE_HEIGHT=$(("${#OPTIONS[@]}/2+1"))
+  HEIGHT=$((CHOICE_HEIGHT+7))
+  CHOICE=$(dialog --clear \
+                --title "Fulcrum Electrum Server" \
+                --ok-label "Select" \
+                --cancel-label "Back" \
+                --menu "Choose an option:" \
+                $HEIGHT $WIDTH $CHOICE_HEIGHT \
+                "${OPTIONS[@]}" 2>&1 >/dev/tty)
   clear
 
   case $CHOICE in
@@ -253,15 +265,82 @@ Check 'sudo nginx -t' for a detailed error message.
     echo "For more details check the RaspiBlitz README on Fulcrum:"
     echo "https://github.com/raspiblitz/raspiblitz"
     echo
-    echo "Press ENTER to get back to main menu."
-    read key
+    echo "Press ENTER to continue..."
+    read -r
     sudo /home/admin/config.scripts/blitz.display.sh hide
     ;;
   STATUS)
     sudo /home/admin/config.scripts/bonus.fulcrum.sh status
     echo
-    echo "Press ENTER to get back to main menu."
-    read key
+    echo "Press ENTER to continue..."
+    read -r
+    ;;
+  LOGS)
+    echo "######## Fulcrum Service Logs ########"
+    echo "# Running: 'sudo journalctl -fu fulcrum -n 100'"
+    echo "# Showing the last 100 log entries and following new ones..."
+    echo "# Press CTRL+C to exit the log view and return to menu"
+    echo "# Press ENTER to continue"
+    read -r
+    sudo journalctl -fu fulcrum -n 100
+    echo
+    echo "Press ENTER to continue..."
+    read -r
+    ;;
+  CONF)
+    echo "######## Edit Fulcrum Configuration ########"
+    configFile="/home/fulcrum/.fulcrum/fulcrum.conf"
+    if [ -f "$configFile" ]; then
+      echo "# Opening fulcrum.conf for editing with nano..."
+      echo "# Save changes with CTRL+O, then press ENTER"
+      echo "# Exit nano with CTRL+X"
+      echo "# Press ENTER to continue or CTRL+C to cancel"
+      read -r
+      sudo nano "$configFile"
+      echo
+      echo "# Configuration file editing completed."
+      echo "# Do you want to restart the Fulcrum service now? (y/N)"
+      read -r restart
+      if [ "$restart" = "y" ] || [ "$restart" = "Y" ]; then
+        echo "# Restarting Fulcrum service..."
+        sudo systemctl restart fulcrum
+        echo "# Service restarted."
+      else
+        echo "# Remember to restart the service manually: sudo systemctl restart fulcrum"
+      fi
+    else
+      echo "# ERROR: Configuration file not found at $configFile"
+    fi
+    echo
+    echo "Press ENTER to continue..."
+    read -r
+    ;;
+  SERVICE)
+    echo "######## Edit Fulcrum Systemd Service ########"
+    echo "# Running: 'sudo systemctl edit --full fulcrum'"
+    echo "# Opening systemd service editor..."
+    echo "# This will open the full service file for editing"
+    echo "# Press ENTER to continue or CTRL+C to cancel"
+    read -r
+    sudo systemctl edit --full fulcrum
+    echo
+    echo "# Systemd service file edited."
+    echo "# Do you want to reload systemd and restart Fulcrum? (y/N)"
+    read -r restart
+    if [ "$restart" = "y" ] || [ "$restart" = "Y" ]; then
+      echo "# Reloading systemd daemon..."
+      sudo systemctl daemon-reload
+      echo "# Restarting Fulcrum service..."
+      sudo systemctl restart fulcrum
+      echo "# Service restarted."
+    else
+      echo "# Remember to reload systemd and restart manually:"
+      echo "# sudo systemctl daemon-reload"
+      echo "# sudo systemctl restart fulcrum"
+    fi
+    echo
+    echo "Press ENTER to continue..."
+    read -r
     ;;
   REINDEX)
     echo "######## Delete and rebuild the Fulcrum database ########"
@@ -277,7 +356,7 @@ Check 'sudo nginx -t' for a detailed error message.
     sudo systemctl start fulcrum
     echo "# ok"
     echo
-    echo "Press ENTER to get back to main menu."
+    echo "Press ENTER to continue..."
     read -r
     ;;
   esac

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -396,6 +396,17 @@ function downloadAndVerifyBinary() {
 
 function createSystemdService() {
   echo "# Create a systemd service"
+
+  # Check if database already exists
+  # Add --db-upgrade flag when no v2 db exists
+  local dbUpgradeFlag=""
+  if [ -d "/mnt/hdd/app-storage/fulcrum/db/fulc2_db/" ]; then
+    echo "# Existing database found - skipping --db-upgrade flag"
+  else
+    echo "# No version 2 database detected - adding --db-upgrade flag"
+    dbUpgradeFlag="--db-upgrade "
+  fi
+
   echo "\
 [Unit]
 Description=Fulcrum
@@ -404,7 +415,7 @@ StartLimitBurst=2
 StartLimitIntervalSec=20
 
 [Service]
-ExecStart=/home/fulcrum/Fulcrum --db-upgrade /home/fulcrum/.fulcrum/fulcrum.conf
+ExecStart=/home/fulcrum/Fulcrum ${dbUpgradeFlag}/home/fulcrum/.fulcrum/fulcrum.conf
 KillSignal=SIGINT
 User=fulcrum
 LimitNOFILE=8192
@@ -415,6 +426,7 @@ Restart=on-failure
 [Install]
 WantedBy=multi-user.target
 " | sudo tee /etc/systemd/system/fulcrum.service
+  sudo systemctl daemon-reload
 }
 
 # set the platform

--- a/home.admin/config.scripts/bonus.fulcrum.sh
+++ b/home.admin/config.scripts/bonus.fulcrum.sh
@@ -595,17 +595,45 @@ if [ "$1" = update ]; then
 fi
 
 if [ "$1" = off ]; then
+  echo "# Stopping and disabling Fulcrum service..."
   sudo systemctl disable --now fulcrum
+
+  # remove systemd service file
+  isInstalled=$(sudo ls /etc/systemd/system/fulcrum.service 2>/dev/null | grep -c 'fulcrum.service')
+  if [ ${isInstalled} -eq 1 ]; then
+    sudo rm /etc/systemd/system/fulcrum.service
+  else
+    echo "# fulcrum.service is not installed."
+  fi
+
+  # remove the database directory if deleteindex parameter is given
+  if [ "$2" = "deleteindex" ]; then
+    echo "# Deleting Fulcrum database..."
+    sudo rm -rf /mnt/hdd/app-storage/fulcrum
+  fi
+
+  echo "# Removing Fulcrum user and home directory..."
   sudo userdel -rf fulcrum
+
   # remove Tor service
+  echo "# Removing Tor hidden service..."
   /home/admin/config.scripts/tor.onion-service.sh off fulcrum
+
   # close ports on firewall
+  echo "# Closing firewall ports..."
   sudo ufw delete allow ${portTCP}
   sudo ufw delete allow ${portSSL}
-  # to remove the database directory:
-  # sudo rm -rf /mnt/hdd/app-storage/fulcrum
+
+  # NOTE: nginx stream configuration is left in place
+  # To manually remove, edit: sudo nano /etc/nginx/nginx.conf
+  # and remove the 'upstream fulcrum' and related 'server' block
+
   # setting value in raspiblitz config
   /home/admin/config.scripts/blitz.conf.sh set fulcrum "off"
+
+  echo "# Fulcrum uninstalled successfully"
+  echo "# NOTE: nginx configuration for Fulcrum remains in /etc/nginx/nginx.conf"
+  echo "# To remove manually: sudo nano /etc/nginx/nginx.conf"
   exit 0
 fi
 


### PR DESCRIPTION
- new setups should just work with the new version
- adding `--db-update` option converting the database (it is ignored if there is no database to convert with the log message: `CLI argument --db-upgrade requested but no complete Fulcrum 1.x database found in /home/fulcrum/.fulcrum/db`)
- update removes the deprecated config values: `fast_sync` and `utxo_cache`

IMPORTANT:
if upgrading the database the process shouldn't be interrupted, will need to warm about this im the logs:
![510860735-21d52d81-9f9c-4758-92df-ce84dda3f252.png](https://github.com/user-attachments/assets/b614af2f-3498-49b8-8e00-1adfa7186dfc)

- [x] tested on amd64 with an existing v2 database
- [x] test on Rpi 
   - [x] started a new sync on Rpi5 8GB + 2TB nvme
   - [x] sync finished in ~5 days, no problems
Changing the version display to the full string:
```
##### STATUS FULCRUM SERVICE
version='Fulcrum 2.0 (Release df51b8a)'
configured=1
serviceInstalled=1
...
```
just checking is this ok for the blitz-api / web-ui @fusion44 ? 

New comprehensive options:
<img width="449" height="230" alt="image" src="https://github.com/user-attachments/assets/64fbd6c4-99c9-4f7d-9beb-53fccb13bdf7" />

Can try with:
```
# download
wget https://raw.githubusercontent.com/raspiblitz/raspiblitz/fulcrum2/home.admin/config.scripts/bonus.fulcrum.sh -O /home/admin/config.scripts/bonus.fulcrum.sh

# update
/home/admin/config.scripts/bonus.fulcrum.sh update
```
