### PR TITLE
update Joininbox to v0.8.5 to fix JoinMarket installation, Jam to v0.4.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
 - Update: Bitcoin Knots 29.2 (optional) [details](https://github.com/bitcoinknots/bitcoin/releases/tag/v29.2.knots20251010)
 - Update: Suez commit:8f29314 [details](https://github.com/prusnak/suez/commits/master)
 - Update: Labelbase 2.3.0 [details](https://x.com/labelbase_space)
+- Update: JoininBox v0.8.5 [details](https://github.com/openoms/joininbox/releases/tag/v0.8.5)
+- Update: Jam v0.4.1 [details](https://github.com/joinmarket-webui/jam/releases/tag/v0.4.1)
 - Fix: Speedup data layout migration from 1.11.4 to 1.12.1 [details](https://github.com/raspiblitz/raspiblitz/issues/5194)
 
 ## What's new in Version 1.12.0 of RaspiBlitz?

--- a/home.admin/config.scripts/bonus.jam.sh
+++ b/home.admin/config.scripts/bonus.jam.sh
@@ -2,7 +2,7 @@
 
 # https://github.com/joinmarket-webui/jam
 
-WEBUI_VERSION=0.4.0
+WEBUI_VERSION=0.4.1
 REPO=joinmarket-webui/jam
 USERNAME=jam
 HOME_DIR=/home/$USERNAME

--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -6,14 +6,15 @@
 # https://github.com/openoms/joininbox
 
 # https://github.com/openoms/joininbox/tags
-JBTAG="v0.8.4" # installs JoinMarket v0.9.11
+JBTAG="v0.8.5" # installs JoinMarket commit https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/ce32bafbb5d716bde61830f71266410249d43dbc
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "JoinMarket install script to install and switch JoinMarket on or off"
   echo "sudo /home/admin/config.scripts/bonus.joinmarket.sh install"
   echo "sudo /home/admin/config.scripts/bonus.joinmarket.sh on|off"
-  echo "Installs JoininBox $JBTAG with JoinMarket v0.9.5"
+  echo "Installs JoininBox $JBTAG with JoinMarket commit:"
+  echo "https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/ce32bafbb5d716bde61830f71266410249d43dbc"
   exit 1
 fi
 


### PR DESCRIPTION
Changed to focus on fixing the installation first when with https://github.com/openoms/joininbox/pull/178 is merged and tagged in Joininbox v0.8.5.

The migration to the descriptor wallet can be followed on in a later release when Raspiblitz defaults to Bitcoin Core v30.x.

Test:
- [x] install of Jam and JM on Raspiblitz 1.12.1rc2 Rpi5