### PR TITLE
CLN update to v25.12.1, use zip release with CLN key verification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## What's new in Version 1.12.1 of RaspiBlitz?
 
 - Update: Bitcoin Core v29.2 [details](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-29.2.md)
-- Update: Core Lightning v25.12 [details](https://github.com/ElementsProject/lightning/releases/tag/v25.12)
+- Update: Core Lightning v25.12.1 [details](https://github.com/ElementsProject/lightning/releases/tag/v25.12.1)
 - Update: Electrum Server in Rust (electrs) v0.10.10 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#01010-jul-19-2025)
 - Update: AlbyHub v1.20.0 [details](https://github.com/getAlby/hub/releases/tag/v1.20.0)
 - Update: Specter Desktop 2.1.1 [details](https://github.com/cryptoadvance/specter-desktop/releases/tag/v2.1.1)

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -263,11 +263,9 @@ Do you really want to update LND now?
       if [ "${loop}" == "on" ]; then
         sudo -u admin /home/admin/config.scripts/bonus.loop.sh off
       fi
-      error=""
-      warn=""
-      source <(sudo -u admin /home/admin/config.scripts/lnd.update.sh verified)
-      if [ ${#error} -gt 0 ]; then
-        whiptail --title "ERROR" --msgbox "${error}" 8 30
+      sudo -u admin /home/admin/config.scripts/lnd.update.sh verified
+      if [ $? -ne 0 ]; then
+        whiptail --title "ERROR" --msgbox "LND update failed" 8 30
       else
         whiptail \
          --title " LND update " \
@@ -309,10 +307,9 @@ Do you really want to update LND now?
         echo "# cancel update"
         exit 0
       fi
-      error=""
-      source <(sudo -u admin /home/admin/config.scripts/lnd.update.sh reckless)
-      if [ ${#error} -gt 0 ]; then
-        whiptail --title "ERROR" --msgbox "${error}" 8 30
+      sudo -u admin /home/admin/config.scripts/lnd.update.sh reckless
+      if [ $? -ne 0 ]; then
+        whiptail --title "ERROR" --msgbox "LND update failed" 8 30
       else
         whiptail \
          --title " LND update " \
@@ -374,11 +371,9 @@ Do you really want to update Core Lightning now?
         echo "# cancel update"
         exit 0
       fi
-      error=""
-      warn=""
-      source <(sudo -u admin /home/admin/config.scripts/cl.update.sh verified)
-      if [ ${#error} -gt 0 ]; then
-        whiptail --title "ERROR" --msgbox "${error}" 8 30
+      sudo -u admin /home/admin/config.scripts/cl.update.sh verified
+      if [ $? -ne 0 ]; then
+        whiptail --title "ERROR" --msgbox "Core Lightning update failed" 8 40
       else
         echo "# Core Lightning was updated successfully"
         exit 0
@@ -399,10 +394,9 @@ Do you really want to update Core Lightning now?
         echo "# cancel update"
         exit 0
       fi
-      error=""
-      source <(sudo -u admin /home/admin/config.scripts/cl.update.sh reckless)
-      if [ ${#error} -gt 0 ]; then
-        whiptail --title "ERROR" --msgbox "${error}" 8 30
+      sudo -u admin /home/admin/config.scripts/cl.update.sh reckless
+      if [ $? -ne 0 ]; then
+        whiptail --title "ERROR" --msgbox "Core Lightning update failed" 8 40
       else
         echo "# Core Lightning was updated successfully"
 
@@ -503,33 +497,33 @@ Do you really want to update Bitcoin Core now?
         echo "# cancel update"
         exit 0
       fi
-      error=""
-      source <(sudo -u admin /home/admin/config.scripts/bitcoin.update.sh reckless)
-      if [ ${#error} -gt 0 ]; then
-        whiptail --title "ERROR" --msgbox "${error}" 8 30
-      fi
-      whiptail \
-        --title " Bitcoin Core update " \
-        --yes-button "Reboot" \
-        --no-button "Skip Reboot" \
-        --yesno \
+      sudo -u admin /home/admin/config.scripts/bitcoin.update.sh reckless
+      if [ $? -ne 0 ]; then
+        whiptail --title "ERROR" --msgbox "Bitcoin Core update failed" 8 40
+      else
+        whiptail \
+          --title " Bitcoin Core update " \
+          --yes-button "Reboot" \
+          --no-button "Skip Reboot" \
+          --yesno \
 "OK Bitcoin Core update is done.
 
 By default a reboot is advised.
-      " 9 40
-      if [ $? -eq 0 ]; then
-        clear
-        echo "REBOOT .."
-        sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+        " 9 40
+        if [ $? -eq 0 ]; then
+          clear
+          echo "REBOOT .."
+          sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
+          sleep 8
+          exit 1
+        else
+          echo "# SKIP REBOOT"
+          echo "# starting the bitcoind.service .."
+          sudo systemctl start bitcoind
+          exit 0
+        fi
         sleep 8
-        exit 1
-      else
-        echo "# SKIP REBOOT"
-        echo "# starting the bitcoind.service .."
-        sudo systemctl start bitcoind
-        exit 0
       fi
-      sleep 8
       ;;
     CUSTOM)
       if ! sudo -u admin /home/admin/config.scripts/bitcoin.update.sh custom; then

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -522,7 +522,6 @@ By default a reboot is advised.
           sudo systemctl start bitcoind
           exit 0
         fi
-        sleep 8
       fi
       ;;
     CUSTOM)
@@ -551,7 +550,6 @@ By default a reboot is advised.
           exit 0
         fi
       fi
-      sleep 8
       ;;
   esac
 }

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -2,7 +2,7 @@
 # https://lightning.readthedocs.io/
 
 # https://github.com/ElementsProject/lightning/releases
-CLVERSION="v25.12"
+CLVERSION="v25.12.1"
 
 # https://github.com/ElementsProject/lightning/tree/master/contrib/keys
 # rustyrussell D9200E6CD1ADB8F1
@@ -12,9 +12,10 @@ CLVERSION="v25.12"
 # sfarooqui (ShahanaFarooqui) B56B4453DA8C6DF7FC9BCFCBDCA40B7128DA62A8
 # amyers (endothermicdev) F3BF63F2747436AB
 # madel (Madeline Paech) A57AFC231B580804
-PGPsigner="madel"
+# cln (cln@blockstream.com) 616C52F99D0612B2A151B1074129A994AA7E9852
+PGPsigner="cln"
 PGPpubkeyLink="https://raw.githubusercontent.com/ElementsProject/lightning/master/contrib/keys/${PGPsigner}.txt"
-PGPpubkeyFingerprint="A57AFC231B580804"
+PGPpubkeyFingerprint="616C52F99D0612B2A151B1074129A994AA7E9852"
 
 # help
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
@@ -108,6 +109,75 @@ function buildAndInstallCLbinaries() {
   sudo RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust make install || exit 1
 }
 
+function downloadAndVerifySourceZip() {
+  # Downloads, verifies, and extracts the CLN source zip
+  # Uses CLVERSION variable for the version to download
+  cd /home/bitcoin || exit 1
+  echo
+  echo "- Downloading Core Lightning ${CLVERSION} source release"
+  echo
+
+  # Download the source zip and SHA256SUMS signature file
+  sudo -u bitcoin wget -O "lightning-${CLVERSION}.zip" \
+    "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/lightning-${CLVERSION}.zip" || exit 1
+  sudo -u bitcoin wget -O "SHA256SUMS-${CLVERSION}" \
+    "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/SHA256SUMS-${CLVERSION}" || exit 1
+  sudo -u bitcoin wget -O "SHA256SUMS-${CLVERSION}.asc" \
+    "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/SHA256SUMS-${CLVERSION}.asc" || exit 1
+
+  echo
+  echo "- Importing PGP key of ${PGPsigner} for verification"
+  echo
+
+  # Import PGP key
+  sudo -u bitcoin wget -O "/var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc" "${PGPpubkeyLink}" || exit 1
+  echo "# Verifying ${PGPsigner} key fingerprint"
+  fingerprint=$(gpg --show-keys --keyid-format LONG "/var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc" 2>/dev/null | grep -c "${PGPpubkeyFingerprint}")
+  if [ "${fingerprint}" -lt 1 ]; then
+    echo "# ERROR --> ${PGPsigner} PGP fingerprint mismatch"
+    exit 1
+  fi
+  sudo -u bitcoin gpg --import "/var/cache/raspiblitz/pgp_keys_${PGPsigner}.asc" || exit 1
+
+  echo
+  echo "- Verifying SHA256SUMS signature"
+  echo
+
+  # Verify the signature on SHA256SUMS
+  sudo -u bitcoin gpg --verify "SHA256SUMS-${CLVERSION}.asc" "SHA256SUMS-${CLVERSION}" 2>&1 | tee /tmp/cl_gpg_verify.txt
+  goodSignature=$(grep -c "Good signature" /tmp/cl_gpg_verify.txt)
+  if [ "${goodSignature}" -lt 1 ]; then
+    echo "# ERROR --> SHA256SUMS signature verification failed"
+    exit 1
+  fi
+  echo "# OK - SHA256SUMS signature verified"
+
+  echo
+  echo "- Verifying source zip checksum"
+  echo
+
+  # Verify the zip file checksum
+  expectedChecksum=$(grep "lightning-${CLVERSION}.zip" "SHA256SUMS-${CLVERSION}" | awk '{print $1}')
+  actualChecksum=$(sha256sum "lightning-${CLVERSION}.zip" | awk '{print $1}')
+  if [ "${expectedChecksum}" != "${actualChecksum}" ]; then
+    echo "# ERROR --> Checksum mismatch for lightning-${CLVERSION}.zip"
+    echo "# Expected: ${expectedChecksum}"
+    echo "# Actual: ${actualChecksum}"
+    exit 1
+  fi
+  echo "# OK - Checksum verified for lightning-${CLVERSION}.zip"
+
+  echo
+  echo "- Extracting source"
+  echo
+
+  # Extract and set up directory
+  sudo -u bitcoin unzip -q "lightning-${CLVERSION}.zip" || exit 1
+  sudo -u bitcoin rm -rf lightning
+  sudo -u bitcoin mv "lightning-${CLVERSION}" lightning
+  sudo -u bitcoin rm -f "lightning-${CLVERSION}.zip" "SHA256SUMS-${CLVERSION}" "SHA256SUMS-${CLVERSION}.asc"
+}
+
 function runTests() {
   # Test dependencies are managed by uv sync in installDependencies()
   cd /home/bitcoin/lightning || exit 1
@@ -168,18 +238,7 @@ if [ "$1" = "install" ]; then
   fi
 
   # download and verify the source from github
-  cd /home/bitcoin || exit 1
-  echo
-  echo "- Cloning https://github.com/ElementsProject/lightning.git"
-  echo
-  sudo -u bitcoin git clone https://github.com/ElementsProject/lightning.git
-  cd lightning || exit 1
-  echo
-  echo "- Reset to version ${CLVERSION}"
-  sudo -u bitcoin git reset --hard ${CLVERSION}
-
-  sudo -u bitcoin /home/admin/config.scripts/blitz.git-verify.sh \
-    "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${CLVERSION}" || exit 1
+  downloadAndVerifySourceZip
 
   installDependencies
 
@@ -238,32 +297,37 @@ if [ "$1" = on ] || [ "$1" = update ] || [ "$1" = testPR ]; then
     sudo apt-get update
 
     cd /home/bitcoin || exit 1
-    if [ "$1" = "update" ] || [ "$1" = "testPR" ]; then
-      echo
-      echo "# Deleting the old source code"
-      sudo rm -rf lightning
-    fi
     echo
-    echo "# Cloning https://github.com/ElementsProject/lightning.git"
-    echo
-    sudo -u bitcoin git clone https://github.com/ElementsProject/lightning.git
-    cd lightning || exit 1
-    echo
+    echo "# Deleting the old source code"
+    sudo rm -rf lightning
 
-    if [ "$1" = "update" ]; then
-      if [ $# -gt 1 ]; then
-        CLVERSION=$2
-        echo "# Installing the version ${CLVERSION}"
-        sudo -u bitcoin git reset --hard ${CLVERSION}
-      else
-        echo "# Updating to the latest commit in:"
-        echo "# https://github.com/ElementsProject/lightning"
-        echo "# Make sure this is intended, there might be no way to downgrade your database"
-        echo "# Press ENTER to continue or CTRL+C to abort the update"
-        read -r key
-      fi
+    if [ "$1" = "update" ] && [ $# -gt 1 ]; then
+      # Update to a specific version - use zip download with signature verification
+      CLVERSION=$2
+      downloadAndVerifySourceZip
+
+    elif [ "$1" = "update" ]; then
+      # Update to latest commit - use git clone (no verification)
+      echo
+      echo "# Cloning https://github.com/ElementsProject/lightning.git"
+      echo
+      sudo -u bitcoin git clone https://github.com/ElementsProject/lightning.git
+      cd lightning || exit 1
+      echo
+      echo "# Updating to the latest commit in:"
+      echo "# https://github.com/ElementsProject/lightning"
+      echo "# Make sure this is intended, there might be no way to downgrade your database"
+      echo "# Press ENTER to continue or CTRL+C to abort the update"
+      read -r key
 
     elif [ "$1" = "testPR" ]; then
+      # Test a PR - use git clone
+      echo
+      echo "# Cloning https://github.com/ElementsProject/lightning.git"
+      echo
+      sudo -u bitcoin git clone https://github.com/ElementsProject/lightning.git
+      cd lightning || exit 1
+      echo
       PRnumber=$2 || exit 1
       echo "# Using the PR:"
       echo "# https://github.com/ElementsProject/lightning/pull/${PRnumber}"
@@ -275,7 +339,7 @@ if [ "$1" = on ] || [ "$1" = update ] || [ "$1" = testPR ]; then
 
     currentCLversion=$(
       cd /home/bitcoin/lightning || exit 1
-      git describe --tags 2>/dev/null
+      git describe --tags 2>/dev/null || echo "${CLVERSION}"
     )
     echo "# Building from source Core Lightning $currentCLversion"
 

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -91,6 +91,9 @@ function installDependencies() {
 }
 
 function buildAndInstallCLbinaries() {
+  # Optional parameter: version to pass to make (for zip builds without git)
+  local buildVersion="$1"
+
   cd /home/bitcoin/lightning || exit 1
 
   # Ensure /opt/rust has correct permissions before building
@@ -103,7 +106,12 @@ function buildAndInstallCLbinaries() {
   sudo -u bitcoin RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust ./configure || exit 1
   echo
   echo "########## make (using uv run)"
-  sudo -u bitcoin RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust uv run make -j"$(nproc)" || exit 1
+  # Pass VERSION to make if provided (needed for zip builds without git history)
+  if [ -n "${buildVersion}" ]; then
+    sudo -u bitcoin RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust VERSION="${buildVersion}" uv run make -j"$(nproc)" || exit 1
+  else
+    sudo -u bitcoin RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust uv run make -j"$(nproc)" || exit 1
+  fi
   echo
   echo "########## install"
   sudo RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust make install || exit 1
@@ -242,7 +250,8 @@ if [ "$1" = "install" ]; then
 
   installDependencies
 
-  buildAndInstallCLbinaries || exit 1
+  # Pass version since zip has no git history
+  buildAndInstallCLbinaries "${CLVERSION}" || exit 1
 
   installed=$(sudo -u bitcoin lightning-cli --version)
   if [ ${#installed} -eq 0 ]; then
@@ -301,10 +310,14 @@ if [ "$1" = on ] || [ "$1" = update ] || [ "$1" = testPR ]; then
     echo "# Deleting the old source code"
     sudo rm -rf lightning
 
+    # Track if we're building from zip (no git history) or git clone
+    buildFromZip=0
+
     if [ "$1" = "update" ] && [ $# -gt 1 ]; then
       # Update to a specific version - use zip download with signature verification
       CLVERSION=$2
       downloadAndVerifySourceZip
+      buildFromZip=1
 
     elif [ "$1" = "update" ]; then
       # Update to latest commit - use git clone (no verification)
@@ -337,13 +350,17 @@ if [ "$1" = on ] || [ "$1" = update ] || [ "$1" = testPR ]; then
 
     installDependencies
 
-    currentCLversion=$(
-      cd /home/bitcoin/lightning || exit 1
-      git describe --tags 2>/dev/null || echo "${CLVERSION}"
-    )
-    echo "# Building from source Core Lightning $currentCLversion"
-
-    buildAndInstallCLbinaries || exit 1
+    if [ "${buildFromZip}" = "1" ]; then
+      echo "# Building from source Core Lightning ${CLVERSION}"
+      buildAndInstallCLbinaries "${CLVERSION}" || exit 1
+    else
+      currentCLversion=$(
+        cd /home/bitcoin/lightning || exit 1
+        git describe --tags 2>/dev/null || echo "unknown"
+      )
+      echo "# Building from source Core Lightning $currentCLversion"
+      buildAndInstallCLbinaries || exit 1
+    fi
 
   fi
 

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -118,8 +118,8 @@ function downloadAndVerifySourceZip() {
   echo
 
   # Download the source zip and SHA256SUMS signature file
-  sudo -u bitcoin wget -O "lightning-${CLVERSION}.zip" \
-    "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/lightning-${CLVERSION}.zip" || exit 1
+  sudo -u bitcoin wget -O "clightning-${CLVERSION}.zip" \
+    "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/clightning-${CLVERSION}.zip" || exit 1
   sudo -u bitcoin wget -O "SHA256SUMS-${CLVERSION}" \
     "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/SHA256SUMS-${CLVERSION}" || exit 1
   sudo -u bitcoin wget -O "SHA256SUMS-${CLVERSION}.asc" \
@@ -157,25 +157,25 @@ function downloadAndVerifySourceZip() {
   echo
 
   # Verify the zip file checksum
-  expectedChecksum=$(grep "lightning-${CLVERSION}.zip" "SHA256SUMS-${CLVERSION}" | awk '{print $1}')
-  actualChecksum=$(sha256sum "lightning-${CLVERSION}.zip" | awk '{print $1}')
+  expectedChecksum=$(grep "clightning-${CLVERSION}.zip" "SHA256SUMS-${CLVERSION}" | awk '{print $1}')
+  actualChecksum=$(sha256sum "clightning-${CLVERSION}.zip" | awk '{print $1}')
   if [ "${expectedChecksum}" != "${actualChecksum}" ]; then
-    echo "# ERROR --> Checksum mismatch for lightning-${CLVERSION}.zip"
+    echo "# ERROR --> Checksum mismatch for clightning-${CLVERSION}.zip"
     echo "# Expected: ${expectedChecksum}"
     echo "# Actual: ${actualChecksum}"
     exit 1
   fi
-  echo "# OK - Checksum verified for lightning-${CLVERSION}.zip"
+  echo "# OK - Checksum verified for clightning-${CLVERSION}.zip"
 
   echo
   echo "- Extracting source"
   echo
 
   # Extract and set up directory
-  sudo -u bitcoin unzip -q "lightning-${CLVERSION}.zip" || exit 1
+  sudo -u bitcoin unzip -q "clightning-${CLVERSION}.zip" || exit 1
   sudo -u bitcoin rm -rf lightning
-  sudo -u bitcoin mv "lightning-${CLVERSION}" lightning
-  sudo -u bitcoin rm -f "lightning-${CLVERSION}.zip" "SHA256SUMS-${CLVERSION}" "SHA256SUMS-${CLVERSION}.asc"
+  sudo -u bitcoin mv "clightning-${CLVERSION}" lightning
+  sudo -u bitcoin rm -f "clightning-${CLVERSION}.zip" "SHA256SUMS-${CLVERSION}" "SHA256SUMS-${CLVERSION}.asc"
 }
 
 function runTests() {

--- a/home.admin/config.scripts/cl.update.sh
+++ b/home.admin/config.scripts/cl.update.sh
@@ -123,7 +123,7 @@ if [ "${mode}" = "verified" ] || [ "${mode}" = "reckless" ]; then
 
   echo "# OK Core Lightning is installed"
   echo "# NOTE: RaspiBlitz may need to reboot now"
-  exit 1
+  exit 0
 
 else
 

--- a/home.admin/config.scripts/cl.update.sh
+++ b/home.admin/config.scripts/cl.update.sh
@@ -85,10 +85,10 @@ if [ "${mode}" = "verified" ]; then
       echo "# clInstalledVersion = clUpdateVersion (${clUpdateVersion})"
       echo "# There is no need to update again."
     else
-      /home/admin/config.scripts/cl.install.sh update ${clUpdateVersion}
+      /home/admin/config.scripts/cl.install.sh update ${clUpdateVersion} || exit 1
     fi
   else
-    /home/admin/config.scripts/cl.install.sh on
+    /home/admin/config.scripts/cl.install.sh on || exit 1
   fi
 
   # note: install will be done the same as reckless further down
@@ -110,7 +110,7 @@ if [ "${mode}" = "reckless" ]; then
     echo "# There is no need to update again."
     clInterimsUpdateNew="${clLatestVersion}"
   else
-    /home/admin/config.scripts/cl.install.sh update ${clLatestVersion}
+    /home/admin/config.scripts/cl.install.sh update ${clLatestVersion} || exit 1
     clInterimsUpdateNew="reckless"
   fi
 fi

--- a/home.admin/config.scripts/cl.update.sh
+++ b/home.admin/config.scripts/cl.update.sh
@@ -8,9 +8,9 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "info -> get actual state and possible actions"
   echo "verified -> only do recommended updates by RaspiBlitz team"
   echo "  binary will be checked by signature and checksum"
-  echo "reckless -> if you just want to update to the latest release"
-  echo "  published on Core Lightning GitHub releases without any"
-  echo "  testing or security checks."
+  echo "reckless -> update to the latest release from Core Lightning GitHub"
+  echo "  binary will be verified by signature and checksum, but the release"
+  echo "  may not have been tested with RaspiBlitz"
   echo
   exit 1
 fi
@@ -97,9 +97,9 @@ if [ "${mode}" = "verified" ]; then
 fi
 
 # RECKLESS
-# this mode is just for people running test and development nodes - its not recommended
-# for production nodes. In a update/recovery scenario it will not install a fixed version
-# it will always pick the latest release from the github
+# This mode installs the latest release from GitHub with signature verification.
+# Not recommended for production nodes as the release may not have been tested with RaspiBlitz.
+# In an update/recovery scenario it will always pick the latest release from GitHub.
 if [ "${mode}" = "reckless" ]; then
 
   echo "# cl.update.sh reckless"

--- a/home.admin/config.scripts/lnd.update.sh
+++ b/home.admin/config.scripts/lnd.update.sh
@@ -256,7 +256,7 @@ if [ "${mode}" = "verified" ] || [ "${mode}" = "reckless" ]; then
 
   echo "# OK LND Installed"
   echo "# NOTE: RaspiBlitz may need to reboot now"
-  exit 1
+  exit 0
 
 else
 


### PR DESCRIPTION
CLN update to v25.12.1
Uses zip release with CLN key verification (as git tags are not always signed).
This make CLN updates cryptographically verified even when labeled RECKLESS (untested).
Makes the update script more future proof.

- [x] test on 1.12.1rc2 rpi5
- [x] update from menu
- [x] fresh install after CLN is purged
