### PR TITLE
Use knots with bip110 from dathonohm

### DIFF
--- a/home.admin/00settingsMenuBasics.sh
+++ b/home.admin/00settingsMenuBasics.sh
@@ -143,7 +143,7 @@ if [ "${clNode}" == "on" ]; then
   fi
 fi
 
-OPTIONS+=(k 'Bitcoin Knots (experimental)' ${knots})
+OPTIONS+=(k 'Bitcoin Knots with BIP110 (experimental)' ${knots})
 
 CHOICE_HEIGHT=$(("${#OPTIONS[@]}/2+1"))
 HEIGHT=$((CHOICE_HEIGHT+6))

--- a/home.admin/config.scripts/bonus.knots.sh
+++ b/home.admin/config.scripts/bonus.knots.sh
@@ -12,18 +12,20 @@ APPID="knots" # one-word lower-case no-specials
 
 # clean human readable version - will be displayed in UI
 # just numbers only separated by dots (2 or 0.1 or 1.3.4 or 3.4.5.2)
-VERSION="29.2.2"
+VERSION="29.2.4"
 
-FILEMASTER="29.x"
-FILEMASTERTAG="29.2.knots20251110"
+# https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1rc3/bitcoin-29.2.knots20251110+bip110-v0.1rc3-arm-linux-gnueabihf.tar.gz
+# https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1/bitcoin-29.2.knots20251110+bip110-v0.1-arm-linux-gnueabihf.tar.gz
+FILEMASTER="v29.2.knots20251110%2Bbip110-v0.1"
+FILEMASTERTAG="29.2.knots20251110+bip110-v0.1"
 
 # the git repo to get the source code from for install
-GITHUB_REPO="https://github.com/bitcoinknots/bitcoin"
+GITHUB_REPO="https://github.com/dathonohm/bitcoin"
 
 # the github tag of the version of the source code to install
 # can also be a commit hash
 # if empty it will use the latest source version
-GITHUB_TAG="v29.2.knots20251110"
+GITHUB_TAG="v29.2.knots20251110+bip110-v0.1"
 
 # the github signature to verify the author
 # leave GITHUB_SIGN_AUTHOR empty to skip verifying
@@ -142,12 +144,12 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # other install scripts to see how that implement code download & verify.
   echo "# download the tarball & verify"
   mkdir /home/${APPID}/${APPID}
-  sudo -u ${APPID} wget "https://bitcoinknots.org/files/${FILEMASTER}/${FILEMASTERTAG}/bitcoin-${FILEMASTERTAG}-${bitcoinOSversion}.tar.gz" -P /home/${APPID}/${APPID}
-  sudo -u ${APPID} wget "https://bitcoinknots.org/files/${FILEMASTER}/${FILEMASTERTAG}/SHA256SUMS" -P /home/${APPID}/${APPID}
-  sudo -u ${APPID} wget "https://bitcoinknots.org/files/${FILEMASTER}/${FILEMASTERTAG}/SHA256SUMS.asc" -P /home/${APPID}/${APPID}
+  sudo -u ${APPID} wget "${GITHUB_REPO}/releases/download/${FILEMASTER}/bitcoin-${FILEMASTERTAG}-${bitcoinOSversion}.tar.gz" -P /home/${APPID}/${APPID}
+  sudo -u ${APPID} wget "${GITHUB_REPO}/releases/download/${FILEMASTER}/SHA256SUMS" -P /home/${APPID}/${APPID}
+  sudo -u ${APPID} wget "${GITHUB_REPO}/releases/download/${FILEMASTER}/SHA256SUMS.asc" -P /home/${APPID}/${APPID}
   
   echo "# Receive signer keys"
-  curl -s "https://api.github.com/repos/bitcoinknots/guix.sigs/contents/builder-keys" |
+  curl -s "https://api.github.com/repos/dathonohm/guix.sigs/contents/builder-keys" |
     jq -r '.[].download_url' | while read url; do curl -s "$url" | sudo -u ${APPID} gpg --import; done
   
   echo "Verify bin"

--- a/home.admin/config.scripts/bonus.knots.sh
+++ b/home.admin/config.scripts/bonus.knots.sh
@@ -12,12 +12,11 @@ APPID="knots" # one-word lower-case no-specials
 
 # clean human readable version - will be displayed in UI
 # just numbers only separated by dots (2 or 0.1 or 1.3.4 or 3.4.5.2)
-VERSION="29.2.4"
+VERSION="29.3"
 
-# https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1rc3/bitcoin-29.2.knots20251110+bip110-v0.1rc3-arm-linux-gnueabihf.tar.gz
-# https://github.com/dathonohm/bitcoin/releases/download/v29.2.knots20251110%2Bbip110-v0.1/bitcoin-29.2.knots20251110+bip110-v0.1-arm-linux-gnueabihf.tar.gz
-FILEMASTER="v29.2.knots20251110%2Bbip110-v0.1"
-FILEMASTERTAG="29.2.knots20251110+bip110-v0.1"
+# https://github.com/dathonohm/bitcoin/releases/download/v29.3.knots20260210%2Bbip110-v0.3/bitcoin-29.3.knots20260210+bip110-v0.3-arm-linux-gnueabihf.tar.gz
+FILEMASTER="v29.3.knots20260210%2Bbip110-v0.3"
+FILEMASTERTAG="29.3.knots20260210+bip110-v0.3"
 
 # the git repo to get the source code from for install
 GITHUB_REPO="https://github.com/dathonohm/bitcoin"
@@ -25,7 +24,7 @@ GITHUB_REPO="https://github.com/dathonohm/bitcoin"
 # the github tag of the version of the source code to install
 # can also be a commit hash
 # if empty it will use the latest source version
-GITHUB_TAG="v29.2.knots20251110+bip110-v0.1"
+GITHUB_TAG="v29.3.knots20260210+bip110-v0.3"
 
 # the github signature to verify the author
 # leave GITHUB_SIGN_AUTHOR empty to skip verifying
@@ -143,15 +142,15 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # verify the author. If you app provides its source/binaries in another way, may check
   # other install scripts to see how that implement code download & verify.
   echo "# download the tarball & verify"
-  mkdir /home/${APPID}/${APPID}
+  sudo -u ${APPID} mkdir -p /home/${APPID}/${APPID}
   sudo -u ${APPID} wget "${GITHUB_REPO}/releases/download/${FILEMASTER}/bitcoin-${FILEMASTERTAG}-${bitcoinOSversion}.tar.gz" -P /home/${APPID}/${APPID}
   sudo -u ${APPID} wget "${GITHUB_REPO}/releases/download/${FILEMASTER}/SHA256SUMS" -P /home/${APPID}/${APPID}
   sudo -u ${APPID} wget "${GITHUB_REPO}/releases/download/${FILEMASTER}/SHA256SUMS.asc" -P /home/${APPID}/${APPID}
-  
+
   echo "# Receive signer keys"
   curl -s "https://api.github.com/repos/dathonohm/guix.sigs/contents/builder-keys" |
     jq -r '.[].download_url' | while read url; do curl -s "$url" | sudo -u ${APPID} gpg --import; done
-  
+
   echo "Verify bin"
   cd /home/${APPID}/${APPID}
   sudo -u ${APPID} gpg --verify SHA256SUMS.asc SHA256SUMS


### PR DESCRIPTION
This PR switches to use knots with BIP110 from dathonohm. 

Uses the latest version 0.1.https://github.com/dathonohm/bitcoin/releases/tag/v29.2.knots20251110%2Bbip110-v0.1

https://bip110.org/

### Upgrade guide
If you are already running knots on your raspiblitz, you need to turn knots off and then on again. Either in the settings menu or manually using the script: `~/config.scripts/bonus.knots.sh off && ~/config.scripts/bonus.knots.sh on`. This will trigger it to download knots with bip110 and run that instead.

### Manual upgrade guide
Follow these steps if you want to run knots+bip110 before this PR gets merged and released.
- SSH into your raspberry pi.
- Copy the content of `bonus.knots.sh` from this pr into `~/config.scripts/` on your raspberry pi. You can use wget like this: `wget --output-document ~/config.scripts/bonus.knots-bip110.sh https://raw.githubusercontent.com/lindelleric/raspiblitz/6cf9d857c761853fd45df724d2a13116f3337119/home.admin/config.scripts/bonus.knots.sh`
- This will save the setup script of knots+bip110 into a separate file: `~/config.scripts/bonus.knots-bip110.sh`
- Mark it as an executable: `chmod +x ~/config.scripts/bonus.knots-bip110.sh`. 
- If you are already running knots, run this to instead use knots with bip110 instead: `~/config.scripts/bonus.knots.sh off && ~/config.scripts/bonus.knots-bip110.sh on`.
- If you are running core, enable knots with bip110 with this: `~/config.scripts/bonus.knots-bip110.sh on`.

Note that with this manual step you wont have the bip110 option in the settings page. 

## Screenshots
<img width="683" height="280" alt="image" src="https://github.com/user-attachments/assets/8cccc0b4-c8c9-41f2-8e71-e340bf25ec92" />
<img width="656" height="151" alt="2026-01-28_22-01" src="https://github.com/user-attachments/assets/a1dcbc14-5dc6-4b8a-ac04-65257a39caa9" />


