### PR TITLE
Update API repo references for org transfer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -243,7 +243,7 @@ This is just a quick patch release for v1.11.1
 ## What's new in Version 1.8.0 of RaspiBlitz?
 
 - New: Multilanguage WebUI [details](https://github.com/cstenglein/raspiblitz-web)
-- New: BackendAPI [details](https://github.com/fusion44/blitz_api)
+- New: BackendAPI [details](https://github.com/raspiblitz/raspiblitz-api)
 - New: ZRAM - compressed swap in memory [details](https://github.com/rootzoll/raspiblitz/issues/2905)
 - New: Core Lightning GRPC plugin [details](https://github.com/rootzoll/raspiblitz/pull/3109)
 - New: Core Lightning connection to BTCPayServer (CONNECT menu) [details](https://github.com/rootzoll/raspiblitz/issues/3155)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![RaspiBlitz](pictures/raspilogo_tile_400px.png)
 
-_Build your own Bitcoin & Lightning Fullnode on a RaspberryPi with an optional Display._ ([API](https://github.com/fusion44/blitz_api)|[WebUI](https://github.com/raspiblitz/raspiblitz-web))
+_Build your own Bitcoin & Lightning Fullnode on a RaspberryPi with an optional Display._ ([API](https://github.com/raspiblitz/raspiblitz-api)|[WebUI](https://github.com/raspiblitz/raspiblitz-web))
 
 ![RaspiBlitz](pictures/raspiblitz.jpg)
 
@@ -32,7 +32,7 @@ RaspiBlitz is mainly targeted for learning how to run your own node decentralize
 This is main RaspiBlitz repo containing the **bash & python** scripts to build the RaspiBlitz software. It it complimented by the following side repos:
 
 - [WebUI](https://github.com/raspiblitz/raspiblitz-web) (React & Tailwind)
-- [API](https://github.com/fusion44/blitz_api) (Python FastAPI)
+- [API](https://github.com/raspiblitz/raspiblitz-api) (Python FastAPI)
 - [Documentation](https://github.com/raspiblitz/raspiblitz-docs) (Docusaurus)
 
 To get started with RaspiBlitz Development check the [Community Development](CONTRIBUTING.md) notes.

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -30,8 +30,8 @@ fi
 defaultRepo="raspiblitz" # user that hosts a `raspiblitz` repo
 defaultBranch="v1.12" # latest version branch
 
-defaultAPIuser="fusion44"
-defaultAPIrepo="blitz_api"
+defaultAPIuser="raspiblitz"
+defaultAPIrepo="raspiblitz-api"
 
 defaultWEBUIuser="raspiblitz"
 defaultWEBUIrepo="raspiblitz-web"

--- a/home.admin/config.scripts/blitz.web.api.sh
+++ b/home.admin/config.scripts/blitz.web.api.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# main repo: https://github.com/fusion44/blitz_api
+# main repo: https://github.com/raspiblitz/raspiblitz-api
 
 # restart the systemd `blitzapi` when credentials of lnd or bitcoind are changed and it will
 # excute the `update-config` automatically before restarting
@@ -288,7 +288,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   cd /home/blitzapi || exit 1
 
-  # git clone https://github.com/fusion44/blitz_api.git /home/blitzapi/blitz_api
+  # git clone https://github.com/raspiblitz/raspiblitz-api.git /home/blitzapi/blitz_api
   echo "# clone github: ${GITHUB_USER}/${GITHUB_REPO}"
   if ! sudo -u blitzapi git clone https://github.com/${GITHUB_USER}/${GITHUB_REPO}.git blitz_api; then
     echo "error='git clone failed'"


### PR DESCRIPTION
## Summary

Prepares the codebase for transferring the `blitz_api` repository from `fusion44/blitz_api` into the `raspiblitz` GitHub organization as `raspiblitz/raspiblitz-api`.

- Update `defaultAPIuser` and `defaultAPIrepo` in `build_sdcard.sh`
- Update hardcoded GitHub links in `README.md` (2 occurrences)
- Update comment URLs in `blitz.web.api.sh` (2 occurrences)
- Update historical changelog link in `CHANGES.md`

**Note:** Local filesystem paths (`/home/blitzapi/blitz_api/`) are intentionally left unchanged — the clone target directory name is independent of the repo name and changing it would require touching 30+ references across the codebase. That can be a separate refactor later if desired.

The `git clone` logic in `blitz.web.api.sh` already uses variables (`GITHUB_USER`/`GITHUB_REPO`) derived from `build_sdcard.sh`, so the build pipeline adapts automatically via the two variable changes.

## Context

This was discussed in the openclaw test Telegram group. Key points from the discussion:

1. **GitHub redirects:** After transferring, GitHub will automatically redirect from `fusion44/blitz_api` → `raspiblitz/raspiblitz-api`. This means older RaspiBlitz versions with the old values in `build_sdcard.sh` will continue to work via the redirect.
2. **Redirect protection:** Renaming during transfer (to `raspiblitz-api`) protects the redirect — if fusion44 later forks the repo back, the fork lands at `fusion44/raspiblitz-api` (different name), so it won't override the redirect on `fusion44/blitz_api`.
3. **The redirect only breaks** if someone creates a *new* repo at `fusion44/blitz_api` — a fork won't do this.

## Human action checklist

After merging this PR, the following manual steps are needed:

- [ ] **Transfer the repository:** Go to `fusion44/blitz_api` → Settings → Danger Zone → Transfer ownership → Transfer to `raspiblitz` organization, rename to `raspiblitz-api`
- [ ] **Verify the redirect:** Confirm `https://github.com/fusion44/blitz_api` redirects to `https://github.com/raspiblitz/raspiblitz-api`
- [ ] **Update branch protection rules** on the new `raspiblitz/raspiblitz-api` repo if needed
- [ ] **Update any CI/CD secrets or webhooks** that reference the old repo URL
- [ ] **Notify contributors** of the new repo location
- [ ] **Do NOT create a new repo** at `fusion44/blitz_api` to preserve the redirect for older versions

## Test plan

- [ ] Verify `build_sdcard.sh` correctly sets the new API user/repo values
- [ ] Verify `blitz.web.api.sh` clones from the correct URL when the new repo exists
- [ ] Verify older branches still work via GitHub's redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)