### PR TITLE
bitcoin.update.sh: bump tested Bitcoin Core version 30.0 -> 30.2

### DIFF
--- a/home.admin/config.scripts/bitcoin.update.sh
+++ b/home.admin/config.scripts/bitcoin.update.sh
@@ -28,7 +28,7 @@ fi
 mode="$1"
 
 # RECOMMENDED UPDATE BY RASPIBLITZ TEAM (latest tested version available)
-bitcoinVersion="30.0" # example: 22.0 .. keep empty if no newer version as sd card build is available
+bitcoinVersion="30.2" # example: 22.0 .. keep empty if no newer version as sd card build is available
 
 # GATHER DATA
 # setting download directory to the current user


### PR DESCRIPTION
## Summary

- Bumps the recommended/tested Bitcoin Core version in `bitcoin.update.sh` from **30.0** to **30.2**
- Bitcoin Core v30.0 and v30.1 were yanked from bitcoincore.org due to a critical wallet migration bug that can cause data loss when migrating legacy descriptor wallets to new descriptor wallet format
- v30.2 is the safe replacement and is now the current stable release

## Background

The Bitcoin Core project pulled v30.0 and v30.1 binaries from the official download server after a critical bug was discovered in the wallet migration path. Users running the `tested` update path on RaspiBlitz would currently be pointed at a yanked release.

References:
- https://github.com/bitcoin/bitcoin/releases/tag/v30.2
- https://bitcoincore.org/bin/bitcoin-core-30.2/

## SHA256 hashes for v30.2 Linux binaries (for reference)

| Architecture | SHA256 |
|---|---|
| `aarch64-linux-gnu` | `73e76c14edc79808a0511c744d102ffbb494807ee90cbcba176568243254b532` |
| `x86_64-linux-gnu` | `6aa7bb4feb699c4c6262dd23e4004191f6df7f373b5d5978b5bcdd4bb72f75d8` |
| `arm-linux-gnueabihf` | `d510542842318ea34d87cb2c93d6a7fe091dcac2e8684460be2b3c44843fb502` |

Note: The update script fetches and verifies the signed `SHA256SUMS` file dynamically at runtime from bitcoincore.org, so no hardcoded hash constants needed updating.

## Test plan

- [x] Run `bitcoin.update.sh info` and confirm `bitcoinVersion='30.2'` is reported
- [x] Run `bitcoin.update.sh tested` on an aarch64 (Raspberry Pi) node and confirm download, signature verification, and install succeed
- [ ] Run `bitcoin.update.sh tested` on an x86_64 node and confirm the same
- [x] Verify `bitcoind --version` reports 30.2 after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)