### PR TITLE
fix: add SSH disconnect notice on reboot/shutdown

### DIFF
--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -390,7 +390,8 @@ case $CHOICE in
                clear
                echo ""
                sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
-               exit 1
+               echo "If your SSH session does not close automatically, press ENTER then ~. to disconnect."
+               exit 0
 	          fi
             ;;
         OFF)
@@ -401,7 +402,8 @@ case $CHOICE in
                clear
                echo ""
                sudo /home/admin/config.scripts/blitz.shutdown.sh
-               exit 1
+               echo "If your SSH session does not close automatically, press ENTER then ~. to disconnect."
+               exit 0
 	          fi
             ;;
         DELETE)

--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -391,9 +391,8 @@ case $CHOICE in
                echo ""
                sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
                echo ""
-               echo "Shutting down below services for reboot - please wait ..."
                echo "If your SSH session does not close automatically:"
-               echo "  Press ENTER, then type ~. to disconnect."
+               echo "  Press Ctrl+C to disconnect."
                exit 1
 	          fi
             ;;
@@ -406,9 +405,8 @@ case $CHOICE in
                echo ""
                sudo /home/admin/config.scripts/blitz.shutdown.sh
                echo ""
-               echo "Shutting down below services for shutdown - please wait ..."
                echo "If your SSH session does not close automatically:"
-               echo "  Press ENTER, then type ~. to disconnect."
+               echo "  Press Ctrl+C to disconnect."
                exit 1
 	          fi
             ;;

--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -390,8 +390,11 @@ case $CHOICE in
                clear
                echo ""
                sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
-               echo "If your SSH session does not close automatically, press ENTER then ~. to disconnect."
-               exit 0
+               echo ""
+               echo "Shutting down below services for reboot - please wait ..."
+               echo "If your SSH session does not close automatically:"
+               echo "  Press ENTER, then type ~. to disconnect."
+               exit 1
 	          fi
             ;;
         OFF)
@@ -402,8 +405,11 @@ case $CHOICE in
                clear
                echo ""
                sudo /home/admin/config.scripts/blitz.shutdown.sh
-               echo "If your SSH session does not close automatically, press ENTER then ~. to disconnect."
-               exit 0
+               echo ""
+               echo "Shutting down below services for shutdown - please wait ..."
+               echo "If your SSH session does not close automatically:"
+               echo "  Press ENTER, then type ~. to disconnect."
+               exit 1
 	          fi
             ;;
         DELETE)


### PR DESCRIPTION
## Problem

When a user triggers REBOOT or OFF from the SSH menu, `blitz.shutdown.sh` issues a non-blocking `shutdown` command. The SSH session often hangs because `sshd` gets killed during kernel shutdown before the TCP connection is properly closed.

## What changed

~~Originally attempted to fix this by changing `exit 1` to `exit 0` to reach the existing graceful handler in `00raspiblitz.sh` — but testing confirmed the SSH session still hangs.~~

**Updated approach:** Reverted exit code back to `exit 1` and added a user-facing notice after the shutdown command:

```
Shutting down below services for reboot - please wait ...
If your SSH session does not close automatically:
  Press ENTER, then type ~. to disconnect.
```

The `~.` sequence is the standard OpenSSH escape to force-close a hung session.

## Changes

- `home.admin/00mainMenu.sh`: Added SSH disconnect instructions after `blitz.shutdown.sh` call in both REBOOT and OFF cases

## Test Plan

- [ ] SSH into RaspiBlitz, select REBOOT, confirm — verify the disconnect notice is displayed
- [ ] SSH in, select OFF, confirm — verify the disconnect notice is displayed
- [ ] Verify `Enter` then `~.` successfully disconnects a hung SSH session
- [ ] Verify DELETE (factory reset) behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)