### PR TITLE
fix: electrs initial-sync detection fails due to pipe/connection issues

### DIFF
--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -111,10 +111,14 @@ if [ "$1" = "status-sync" ]; then
   if [ ${serviceRunning} -eq 1 ]; then
 
     # check if initial sync was done, by setting a file as once electrs is the first time responding on port 50001
-    electrumResponding=$(echo '{"jsonrpc":"2.0","method":"server.ping","params":[],"id":"electrs-check"}' | netcat -w 2 127.0.0.1 50001 | grep -c "result")
-    if [ ${electrumResponding} -gt 1 ]; then
+    # write response to a temp file to avoid pipe failures (os error 107) losing the response
+    electrumResponding=0
+    tmpResponse=$(mktemp)
+    echo '{"jsonrpc":"2.0","method":"server.ping","params":[],"id":"electrs-check"}' | netcat -w 2 127.0.0.1 50001 > "${tmpResponse}" 2>/dev/null
+    if grep -q "result" "${tmpResponse}" 2>/dev/null; then
       electrumResponding=1
     fi
+    rm -f "${tmpResponse}"
     echo "electrumResponding=${electrumResponding}"
 
     blockheight=0
@@ -125,6 +129,9 @@ if [ "$1" = "status-sync" ]; then
       syncedBlock=$(echo '{"id": 1, "method": "blockchain.headers.subscribe", "params": []}' | nc -w 20 -q 1 localhost 50001 | jq '.result.height')
       if [ "$syncedBlock" -eq "$syncedBlock" ] 2>/dev/null; then
         blockheight=${syncedBlock}
+
+        # if we got a valid blockheight, electrs is actually responding
+        electrumResponding=1
 
         # calculate the progress
         source <(/home/admin/_cache.sh get btc_mainnet_blocks_verified)


### PR DESCRIPTION
## Problem

The `status-sync` check in `bonus.electrs.sh` uses a piped command to detect whether electrs is responding:

```bash
electrumResponding=$(echo '{...}' | netcat -w 2 127.0.0.1 50001 | grep -c "result")
```

This fails when the TCP connection drops (`os error 107: Transport endpoint is not connected`) before the response reaches `grep` through the pipe. When this happens:

1. `electrumResponding` stays at 0
2. The `initial-sync.done` file is never created
3. The WebUI permanently shows electrs as "syncing" even though it's fully operational and wallets can connect fine

The journal gets flooded with the health check polling:
```
sudo[...]: root : COMMAND=/usr/bin/ls /mnt/hdd/app-storage/electrs/initial-sync.done
```

Multiple users on v1.12.1 (RPI5) have reported this — electrs works perfectly for wallet connections, but the UI says it's still syncing.

## Fix

Two changes:

1. **Write netcat response to a temp file** instead of piping directly to grep. This avoids the race condition where the TCP connection drops before the pipe completes.

2. **Fallback detection**: If the ping check fails but `blockchain.headers.subscribe` returns a valid blockheight, set `electrumResponding=1` — getting a valid blockheight proves electrs is operational.

## Testing

- Verified the script logic with/without the file present
- Both changes are backwards-compatible — if electrs genuinely isn't synced, the behavior is unchanged

## Related Issues

- Fixes #5192 (Electrs Status on WebUI != SSH)
- Related: #5141 (Apps tab won't load — bitcoin-only setups)