### PR TITLE
Update all issue / PR URLs to point to canonical repo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -185,7 +185,7 @@ This is just a quick patch release for v1.11.1
 - Update: JoinMarket v0.9.10 [details](https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.10)
 - Update: JoininBox v0.8.1 [details](https://github.com/openoms/joininbox/releases/tag/v0.8.1)
 - Update: Balance of Satoshis 15.11.0 (bos) [details](https://github.com/alexbosworth/balanceofsatoshis/blob/master/CHANGELOG.md#15110)
-- Fix: Homebanking Interface FinTS/HBCI (experimental) [details](https://github.com/rootzoll/raspiblitz/issues/1186)
+- Fix: Homebanking Interface FinTS/HBCI (experimental) [details](https://github.com/raspiblitz/raspiblitz/issues/1186)
 - Remove: Spark Wallet and Sparko CLN plugin (not maintained anymore)
 - Remove: Faraday, Loop, Pool single installs - used in the LiT package instead
 - Remove: deactivate LNproxy in the menu and in provision
@@ -193,16 +193,16 @@ This is just a quick patch release for v1.11.1
 
 ## What's new in Version 1.9.0 of RaspiBlitz?
 
-- New: Automated disk image build for amd64 (VM, laptop, desktop, server) and arm64-rpi (Raspberry Pi) [details](https://github.com/rootzoll/raspiblitz/tree/dev/ci/README.md)
+- New: Automated disk image build for amd64 (VM, laptop, desktop, server) and arm64-rpi (Raspberry Pi) [details](https://github.com/raspiblitz/raspiblitz/tree/dev/ci/README.md)
 - New: Fatpack & Minimal sd card builds [details](SECURITY.md#minimal-sd-card-build)
-- New: I2P support for Bitcoin Core (i2pacceptincoming=1) [details](https://github.com/rootzoll/raspiblitz/issues/2413)
+- New: I2P support for Bitcoin Core (i2pacceptincoming=1) [details](https://github.com/raspiblitz/raspiblitz/issues/2413)
 - New: CLN Watchtower (The Eye of Satoshi) [details](https://github.com/talaia-labs/rust-teos/tree/master/watchtower-plugin)
 - New: LNDg v1.6.0 [details](https://github.com/cryptosharks131/lndg)
-- New: Support of X708 UPS HAT [details](https://github.com/rootzoll/raspiblitz/pull/3087)
+- New: Support of X708 UPS HAT [details](https://github.com/raspiblitz/raspiblitz/pull/3087)
 - New: BOS Telegram Bot Support (see OPTIONS on LND Balance of Satoshis menu entry)
 - New: LightningTipBot v0.5 [details](https://github.com/LightningTipBot/LightningTipBot)
 - New: ↬lnproxy cli shortcut and server [details](https://github.com/lnproxy)
-- New: Homebanking Interface FinTS/HBCI (experimental) [details](https://github.com/rootzoll/raspiblitz/issues/1186)
+- New: Homebanking Interface FinTS/HBCI (experimental) [details](https://github.com/raspiblitz/raspiblitz/issues/1186)
 - New on WebUI: Jam (JoinMarket Web UI) v0.1.5 [details](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.1.5)
 - New on WebUI: Generate/Download Debug Report from Settings
 - Update: Bitcoin Core v24.0.1 [details](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-24.0.1.md)
@@ -226,7 +226,7 @@ This is just a quick patch release for v1.11.1
 - Update: Tallycoin Connect v1.8.0 [details](https://github.com/djbooth007/tallycoin_connect/releases/tag/v1.8.0)
 - Update: Fulcrum install script (CLI only) v1.9.1 [details](https://github.com/cculianu/Fulcrum/releases/tag/v1.9.1)
 - Fixed: SCB/Emergency-Backup to USB drive (now also with CLN emergency.recover file)
-- Info: Run RaspiBlitz on Proxmox [details](https://github.com/rootzoll/raspiblitz/tree/dev/alternative.platforms/Proxmox)
+- Info: Run RaspiBlitz on Proxmox [details](https://github.com/raspiblitz/raspiblitz/tree/dev/alternative.platforms/Proxmox)
 - Info: IP2Tor fix fulmo shop & added new ip2tor.com shop
 - Info: 32GB sdcard is now enforced (after being recommended since v1.5)
 - Info: 'Reindex Blockchain' is now part of 'repair' menu
@@ -244,13 +244,13 @@ This is just a quick patch release for v1.11.1
 
 - New: Multilanguage WebUI [details](https://github.com/cstenglein/raspiblitz-web)
 - New: BackendAPI [details](https://github.com/fusion44/blitz_api)
-- New: ZRAM - compressed swap in memory [details](https://github.com/rootzoll/raspiblitz/issues/2905)
-- New: Core Lightning GRPC plugin [details](https://github.com/rootzoll/raspiblitz/pull/3109)
-- New: Core Lightning connection to BTCPayServer (CONNECT menu) [details](https://github.com/rootzoll/raspiblitz/issues/3155)
+- New: ZRAM - compressed swap in memory [details](https://github.com/raspiblitz/raspiblitz/issues/2905)
+- New: Core Lightning GRPC plugin [details](https://github.com/raspiblitz/raspiblitz/pull/3109)
+- New: Core Lightning connection to BTCPayServer (CONNECT menu) [details](https://github.com/raspiblitz/raspiblitz/issues/3155)
 - New: Alby (Connection Menu) [details](https://getalby.com/)
 - New: Homer Dashboard 22.06.1 [details](https://github.com/bastienwirtz/homer#readme)
 - New: ItchySats 0.5.0 [details](https://github.com/itchysats/itchysats/)
-- New: ckbunker CLI install script (experimental) [details](https://github.com/rootzoll/raspiblitz/issues/1062)
+- New: ckbunker CLI install script (experimental) [details](https://github.com/raspiblitz/raspiblitz/issues/1062)
 - Update: Bitcoin Core v23.0 [details](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-23.0.md)
 - Update: Core Lightning (CLN - formerly C-lightning) v0.11.2 [details](https://github.com/ElementsProject/lightning/releases/tag/v0.11.2)
 - Update: LND v0.15.0 [details](https://github.com/lightningnetwork/lnd/releases/tag/v0.15.0-beta)
@@ -264,25 +264,25 @@ This is just a quick patch release for v1.11.1
 - Update: JoininBox v0.6.8 [details](https://github.com/openoms/joininbox/releases/tag/v0.6.8)
 - Update: JoinMarket Web UI (Jam) v0.0.9 (CLI install script) [details](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.9)
 - Update: Electrum Server in Rust (electrs) v0.9.7 [details](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md#097-apr-30-2022)
-- Update: Fulcrum Electrum server v1.7.0 (CLI install script) [issue](https://github.com/rootzoll/raspiblitz/issues/2924)
+- Update: Fulcrum Electrum server v1.7.0 (CLI install script) [issue](https://github.com/raspiblitz/raspiblitz/issues/2924)
 - Update: BTCPayServer 1.6.1 [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.6.1)
 - Update: Mempool 2.4.0 [details](hhttps://github.com/mempool/mempool/releases/tag/v2.4.0)
 - Update: Helipad (Podcasting 2.0 Boostagram reader) v0.1.10 [details](https://github.com/Podcastindex-org/helipad/releases/tag/v0.1.10)
 - Update: Adapted Umbrel Migration for new 0.5.0 version with Core Lightning
-- Info: Run RaspiBlitz on amd64 bare metal and virtual machines [details](https://github.com/rootzoll/raspiblitz/tree/dev/alternative.platforms)
+- Info: Run RaspiBlitz on amd64 bare metal and virtual machines [details](https://github.com/raspiblitz/raspiblitz/tree/dev/alternative.platforms)
 
 ## What's new in Version 1.7.2 of RaspiBlitz?
 
 - Refactor: Cache & Backgroundscan of Systeminfo
-- New: Compact the LND channel.db monthly on restart, on-demand from menu and before backups [issue](https://github.com/rootzoll/raspiblitz/issues/2752)
-- New: Run C-lightning backup-compact regularly [issue](https://github.com/rootzoll/raspiblitz/issues/2869)
-- New: Switch LNbits between lnd & c-lightning [issue](https://github.com/rootzoll/raspiblitz/issues/2556)
+- New: Compact the LND channel.db monthly on restart, on-demand from menu and before backups [issue](https://github.com/raspiblitz/raspiblitz/issues/2752)
+- New: Run C-lightning backup-compact regularly [issue](https://github.com/raspiblitz/raspiblitz/issues/2869)
+- New: Switch LNbits between lnd & c-lightning [issue](https://github.com/raspiblitz/raspiblitz/issues/2556)
 - New: Tallycoin Connect [details](https://github.com/djbooth007/tallycoin_connect#readme)
 - New: Helipad (Podcasting 2.0 Boostagram reader) [details](https://github.com/Podcastindex-org/helipad)
-- New: Migration from Citadel to RaspiBlitz [details](https://github.com/rootzoll/raspiblitz/issues/2642)
+- New: Migration from Citadel to RaspiBlitz [details](https://github.com/raspiblitz/raspiblitz/issues/2642)
 - New: Bitcoinminds.org local on RaspiBlitz [details](https://github.com/raulcano/bitcoinminds)
 - New: JoinMarket Web UI v0.0.3 (CLI install of the first public alpha release) [details](https://github.com/joinmarket-webui/joinmarket-webui/releases/tag/v0.0.3)
-- New: Fulcrum Electrum server v1.6.0 (CLI install script) [issue](https://github.com/rootzoll/raspiblitz/issues/2924)
+- New: Fulcrum Electrum server v1.6.0 (CLI install script) [issue](https://github.com/raspiblitz/raspiblitz/issues/2924)
 - Update: LND v0.14.2-beta [details](https://github.com/lightningnetwork/lnd/releases/tag/v0.14.2-beta)
 - Update: C-lightning v0.10.2 [details](https://github.com/ElementsProject/lightning/releases/tag/v0.10.2)
 - Update: LNbits 0.7.0 [details](https://github.com/lnbits/lnbits-legend/releases/tag/0.7.0)
@@ -304,8 +304,8 @@ This is just a quick patch release for v1.11.1
 - Update: Balance of Satoshis 11.50.0 (BOS) [details](https://github.com/alexbosworth/balanceofsatoshis/blob/master/CHANGELOG.md#11500)
 - Update: Re-Add connecting node with Zap mobile wallet iOS & Android
 - Update: additional redaction of private data in debug logs
-- Security: Verify git commits and tags everywhere possible [issue](https://github.com/rootzoll/raspiblitz/issues/2686)
-- Fixed: LND repair options, SEED+SCB and rescue-file restore, RESET options [issue](https://github.com/rootzoll/raspiblitz/issues/2832)
+- Security: Verify git commits and tags everywhere possible [issue](https://github.com/raspiblitz/raspiblitz/issues/2686)
+- Fixed: LND repair options, SEED+SCB and rescue-file restore, RESET options [issue](https://github.com/raspiblitz/raspiblitz/issues/2832)
 - Info: All existing IP2Tor subscriptions need to be canceled & renewed to be functional again.
 - Info: 32GB sd card is now required (was already long time recommended on shopping list)
 - Info: The touchscreen graphical mode is back to experimental for now and missing some UI fixes. This might take until v1.8.1 where the touchscreen will get a refactor/rewrite.
@@ -319,8 +319,8 @@ There was a small patch-update with raspiblitz-v1.7.1-2021-10-28.img.gz to fix a
 - New: CL Spark Wallet v0.3.0rc with BOLT12 offers [details](https://github.com/shesek/spark-wallet/releases)
 - New: CL plugin: Sparko [details](https://github.com/fiatjaf/sparko)
 - New: CL plugin: CLBOSS The Core Lightning Node Manager [details](https://github.com/ZmnSCPxj/clboss#clboss-the-c-lightning-node-manager)
-- New: Refactored Setup-Process [details](https://github.com/rootzoll/raspiblitz/issues/1126#issuecomment-829757665)
-- New: Suez - channel visualization for LND and CL [info](https://github.com/rootzoll/raspiblitz/issues/2366#issuecomment-939521302)[details](https://github.com/prusnak/suez)
+- New: Refactored Setup-Process [details](https://github.com/raspiblitz/raspiblitz/issues/1126#issuecomment-829757665)
+- New: Suez - channel visualization for LND and CL [info](https://github.com/raspiblitz/raspiblitz/issues/2366#issuecomment-939521302)[details](https://github.com/prusnak/suez)
 - New: LND Static Channel Backup to Nextcloud
 - New: Allow SphinxApp to connect over Tor
 - New: Parallel TESTNET & SIGNET services
@@ -343,19 +343,19 @@ There was a small patch-update with raspiblitz-v1.7.1-2021-10-28.img.gz to fix a
 - Update: Channel Tools (chantools) v0.9.3 [details](https://github.com/guggero/chantools/blob/master/README.md)
 - Update: Circuitbreaker v0.3.0 [details](https://github.com/lightningequipment/circuitbreaker/blob/master/README.md)
 - Remove: DropBox Backup (its recommended to change to Nextcloud Backup)
-- Remove: Litecoin (fork recommended) [details](https://github.com/rootzoll/raspiblitz/issues/2542)
+- Remove: Litecoin (fork recommended) [details](https://github.com/raspiblitz/raspiblitz/issues/2542)
 
 ## What's new in Version 1.7.0 of RaspiBlitz?
 
 - New: Raspberry Pi OS Base Image 64-bit (April 2021)
-- New: Build SD card Image with parameters & FatPack [details](https://github.com/rootzoll/raspiblitz/pull/2044)
-- New: Improve LND uptime and reliability over Tor [details](https://github.com/rootzoll/raspiblitz/pull/2148)
+- New: Build SD card Image with parameters & FatPack [details](https://github.com/raspiblitz/raspiblitz/pull/2044)
+- New: Improve LND uptime and reliability over Tor [details](https://github.com/raspiblitz/raspiblitz/pull/2148)
 - New: Lightning Terminal v0.4.1-alpha (Loop, Pool & Faraday UI Bundle) [details](https://github.com/lightninglabs/lightning-terminal#lightning-terminal-lit)
 - New: Channel Tools (chantools) v0.8.2 [details](https://github.com/guggero/chantools/blob/master/README.md)
 - New: Circuitbreaker LND firewall (settings menu) [details](https://github.com/lightningequipment/circuitbreaker/blob/master/README.md)
-- New: Telegraf metrics (experimental) [details](https://github.com/rootzoll/raspiblitz/issues/1369)
-- New: Download whitepaper from blockchain [details](https://github.com/rootzoll/raspiblitz/pull/2017)
-- New: Extended CONNECT and SYSTEM options in the ssh menu [details](https://github.com/rootzoll/raspiblitz/pull/2119)
+- New: Telegraf metrics (experimental) [details](https://github.com/raspiblitz/raspiblitz/issues/1369)
+- New: Download whitepaper from blockchain [details](https://github.com/raspiblitz/raspiblitz/pull/2017)
+- New: Extended CONNECT and SYSTEM options in the ssh menu [details](https://github.com/raspiblitz/raspiblitz/pull/2119)
 - Update: bitcoin-core version 0.21.0-beta with UPDATE option [details](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.21.0.md)
 - Update: LND version 0.12.1-beta [details](https://github.com/lightningnetwork/lnd/releases/tag/v0.12.1-beta)
 - Update: RTL 0.10.1 [details](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.10.1)
@@ -407,7 +407,7 @@ There was a small patch-update with raspiblitz-v1.7.1-2021-10-28.img.gz to fix a
 ## What's new in Version 1.6.1 of RaspiBlitz?
 
 - EMERGENCY-Update: LND version 0.11.1-beta [details](https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-October/002819.html)
-- Update: IP2Tor+LetsEncrypt Functional Test [details](https://github.com/rootzoll/raspiblitz/issues/1412)
+- Update: IP2Tor+LetsEncrypt Functional Test [details](https://github.com/raspiblitz/raspiblitz/issues/1412)
 - Update: JoininBox 0.1.12 (terminal based GUI for JoinMarket) [details](https://github.com/openoms/joininbox)
 - Update: BTCPayServer v1.0.5.8 [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v1.0.5.8)
 - Update: RTL 0.9.1
@@ -419,13 +419,13 @@ There was a small patch-update with raspiblitz-v1.7.1-2021-10-28.img.gz to fix a
 - Update: Faraday 0.2.1
 - Update: Improved IPv6 support
 - Update: LNbits new Quart-Framework install
-- New: Circuit Breaker (config-script) [details](https://github.com/rootzoll/raspiblitz/issues/1581)
+- New: Circuit Breaker (config-script) [details](https://github.com/raspiblitz/raspiblitz/issues/1581)
 - New: PyBlock (Python Util & Fun Scripts) [details](https://github.com/curly60e/pyblock/blob/master/README.md)
 - New: Mempool Explorer [details](https://github.com/mempool/mempool)
 - New: dynu.com as alternative option for LetsEncrypt FreeDNS provider
 - New: Experimental running RaspiBlitz as VM (vagrant & docker)
 
-For ALL small bug fixes & improvements see: https://github.com/rootzoll/raspiblitz/milestone/11
+For ALL small bug fixes & improvements see: https://github.com/raspiblitz/raspiblitz/milestone/11
 
 ## What's new in Version 1.6 of RaspiBlitz?
 
@@ -449,7 +449,7 @@ For ALL small bug fixes & improvements see: https://github.com/rootzoll/raspibli
 - New: JoininBox (terminal based GUI for JoinMarket) [details](https://github.com/openoms/joininbox)
 - New: ZeroTier [details](https://zerotier.com/manual/)
 - New: Kindle Display (on a jailbroken Kindle) [details](https://github.com/dennisreimann/kindle-display)
-- New: Static Channel Backup on USB Thumbdrive [details](https://github.com/rootzoll/raspiblitz/tree/v1.6#c-local-backup-target-usb-thumbdrive)
+- New: Static Channel Backup on USB Thumbdrive [details](https://github.com/raspiblitz/raspiblitz/tree/v1.6#c-local-backup-target-usb-thumbdrive)
 - New: Keep WIFI config over wpa_supplicant.conf for next update
 - Fix: DropBox StaticChannelBackup
 - Removed: Shango from the list of Mobile Wallets
@@ -475,17 +475,17 @@ Beside many small improvements and changes, these are most important changes:
 - Update: lndmanage 0.10.0 [details](https://github.com/bitromortac/lndmanage/releases/tag/v0.10.0)
 - Shoppinglist: Replace Shimfan with passive RP4-Heatcase
 - Shoppinglist: 1TB SSD is now default [details about migration to bigger SSD](README.md#import-a-migration-file)
-- Fix: (Control-D) Give root password for maintenance [details](https://github.com/rootzoll/raspiblitz/issues/1053)
+- Fix: (Control-D) Give root password for maintenance [details](https://github.com/raspiblitz/raspiblitz/issues/1053)
 - Fix: Screen Rotate on update from v1.3
 - New: Specter Desktop (connect DIY Specter-Wallet or ColdCard) [details](https://github.com/cryptoadvance/specter-desktop/blob/master/README.md)
 - New: JoinMarket [details](https://github.com/JoinMarket-Org/joinmarket-clientserver)
-- New: Activate 'Keysend' on LND by Service Menu [details](https://github.com/rootzoll/raspiblitz/issues/1000)
+- New: Activate 'Keysend' on LND by Service Menu [details](https://github.com/raspiblitz/raspiblitz/issues/1000)
 - New: SendMany App (wallet & chat over keysend) [details](https://github.com/fusion44/sendmany/blob/master/README.md)
 - New: Reset SSH cert if SSH login not working [details](FAQ.md#how-can-i-repair-my-ssh-login)
 - New: Make it easier to Copy The Blockchain over Network from running Blitz
 - New: Forwarding Fee Report on Main Menu
 - New: Easy Setup of Auto-Backup of SCB to Dropbox
-- New: LND Interims Updates (verified & reckless) [details](https://github.com/rootzoll/raspiblitz/issues/1116#issuecomment-619467148)
+- New: LND Interims Updates (verified & reckless) [details](https://github.com/raspiblitz/raspiblitz/issues/1116#issuecomment-619467148)
 - New: Sync RaspiBlitz with your forked GitHub repo thru menu [details](FAQ.md#how-can-i-sync-a-branch-of-my-forked-github-with-my-local-raspiblitz)
 - Removed: Clone Blockchain from second HDD (use CopyStation script)
 
@@ -513,10 +513,10 @@ Beside many small improvements and changes, these are most important changes:
 - New: Tor Support to connect mobile Apps
 - New: Migration Export/Import (e.g. HDD -> SSD) [details](README.md#import-a-migration-file)
 - New: Start without LCD (switch to HDMI) [details](FAQ.md#can-i-run-the-raspiblitz-without-a-displaylcd)
-- New: Recovery Sheet (PDF) [details](https://github.com/rootzoll/raspiblitz/raw/v1.4/home.admin/assets/RaspiBlitzRecoverySheet.pdf)
+- New: Recovery Sheet (PDF) [details](https://github.com/raspiblitz/raspiblitz/raw/v1.4/home.admin/assets/RaspiBlitzRecoverySheet.pdf)
 - Experimental: BTRFS [details](FAQ.md#why-use-btrfs-on-raspiblitz)
 
-For full details see issue list of [Release 1.4 Milestone](https://github.com/rootzoll/raspiblitz/milestone/7?closed=1).
+For full details see issue list of [Release 1.4 Milestone](https://github.com/raspiblitz/raspiblitz/milestone/7?closed=1).
 
 Find the full Tutorial how to build a RaspiBlitz in the [README](README.md) or follow the [instructions to update to the latest version](README.md#updating-raspiblitz-to-new-version).
 
@@ -543,7 +543,7 @@ Version 1.3 is using the new Raspbian Buster that is ready to use with the Raspb
 - Experimental: LCD Touchscreen Support
 - Experimental: UPS support (APC) [details](FAQ.md#how-to-connect-a-ups-to-the-raspiblitz)
 
-For full details see issue list of [Release 1.3 Milestone](https://github.com/rootzoll/raspiblitz/milestone/6?closed=1).
+For full details see issue list of [Release 1.3 Milestone](https://github.com/raspiblitz/raspiblitz/milestone/6?closed=1).
 
 ## What's new in Version 1.2 of RaspiBlitz?
 
@@ -572,7 +572,7 @@ Version 1.2 packs some more fixes and enhancements to make the RaspiBlitz more s
 - New: Temp in Fahrenheit on the LCD
 - Experimental: Backup Torrent Seeding (Service)
 
-For full details see issue list of [Release 1.2 Milestone](https://github.com/rootzoll/raspiblitz/milestone/5?closed=1).
+For full details see issue list of [Release 1.2 Milestone](https://github.com/raspiblitz/raspiblitz/milestone/5?closed=1).
 
 ## What's new in Version 1.1 of RaspiBlitz?
 
@@ -591,4 +591,4 @@ Version 1.1 packs some first fixes and enhancements to make the RaspiBlitz more 
 - New: Bootscreen with logo
 - Removed: FTP download option for blockchain
 
-For full details see issue list of [Release 1.1 Milestone](https://github.com/rootzoll/raspiblitz/milestone/3?closed=1).
+For full details see issue list of [Release 1.1 Milestone](https://github.com/raspiblitz/raspiblitz/milestone/3?closed=1).

--- a/alternative.platforms/QEMU/raspiblitz-on-qemu.md
+++ b/alternative.platforms/QEMU/raspiblitz-on-qemu.md
@@ -55,7 +55,7 @@ Documentation focused on install for macos dev environment. Do not rely on this 
 	    - review your changes, make a deep breath and use `w` to write the new partition table to disk. 
 	2. Reboot with `sudo reboot`.
 10. Make usb  filesystem  by running command  `mkfs.ext4 /dev/sda1` where `/dev/sda1` is your new disk.
-11. [Install raspiblitz via build script](https://github.com/rootzoll/raspiblitz/tree/v1.7/alternative.platforms#building-the-raspiblitz-scripts)
-12. [Configure signet](https://github.com/rootzoll/raspiblitz/issues/1500#issuecomment-982779830)
+11. [Install raspiblitz via build script](https://github.com/raspiblitz/raspiblitz/tree/v1.7/alternative.platforms#building-the-raspiblitz-scripts)
+12. [Configure signet](https://github.com/raspiblitz/raspiblitz/issues/1500#issuecomment-982779830)
 13. Reboot with `sudo reboot`.
 14. Login with `admin` user.  Default password: `raspiblitz`

--- a/alternative.platforms/README.md
+++ b/alternative.platforms/README.md
@@ -66,9 +66,9 @@ The process is similar if you want to run RaspiBlitz on the bare metal.
 Tested with:
 * Debian image in VirtualBox and linux virt-manager / [cockpit-machines](https://github.com/cockpit-project/cockpit-machines)
 * Ubuntu image in VirtualBox and linux virt-manager / [cockpit-machines](https://github.com/cockpit-project/cockpit-machines)
-* Debian image in VirtualBox https://github.com/rootzoll/raspiblitz/issues/2756#issuecomment-983532237
-* TrueNAS (FreeBSD bhyve) with an Ubuntu VM: https://github.com/rootzoll/raspiblitz/issues/2104#issuecomment-917444238
-* [QEMU+UTM](https://github.com/rootzoll/raspiblitz/blob/dev/alternative.platforms/QEMU/raspiblitz-on-qemu.md)
+* Debian image in VirtualBox https://github.com/raspiblitz/raspiblitz/issues/2756#issuecomment-983532237
+* TrueNAS (FreeBSD bhyve) with an Ubuntu VM: https://github.com/raspiblitz/raspiblitz/issues/2104#issuecomment-917444238
+* [QEMU+UTM](https://github.com/raspiblitz/raspiblitz/blob/dev/alternative.platforms/QEMU/raspiblitz-on-qemu.md)
 
 ### Create the base image
 * Download and install the base OS on an at least 32GB drive
@@ -100,7 +100,7 @@ These not need installation, password: `osboxes.org`
   ```
 
 * Switch off when ready
-* Attach an other disk (can be even small if you prune or [stop bitcoind](https://github.com/rootzoll/raspiblitz/issues/1500#issuecomment-982779830) manually.
+* Attach an other disk (can be even small if you prune or [stop bitcoind](https://github.com/raspiblitz/raspiblitz/issues/1500#issuecomment-982779830) manually.
 The second virtual disk will be used as the BLOCKCHAIN drive.
 This makes that data portable and independent from the OS similar to the combination of the SDcard and separate SSD.
 
@@ -129,7 +129,7 @@ password: `1234`
 
 Follow the instructions in the terminal. Set the new password to `raspiblitz` and name the new user `admin` to keep in line with the rest of the setup.
 
-Continue with building the SDcard: https://github.com/rootzoll/raspiblitz#build-the-sd-card-image
+Continue with building the SDcard: https://github.com/raspiblitz/raspiblitz#build-the-sd-card-image
 
 ---
 
@@ -160,7 +160,7 @@ if there is an error:
 run:
 `reboot` and update as above
 
-Continue with building the SDcard: https://github.com/rootzoll/raspiblitz#build-the-sd-card-image
+Continue with building the SDcard: https://github.com/raspiblitz/raspiblitz#build-the-sd-card-image
 
 ---
 
@@ -205,7 +205,7 @@ Continue with building the SDcard: https://github.com/rootzoll/raspiblitz#build-
 
 ## Manual image release for amd64
 
-Work notes partially based on: https://github.com/rootzoll/raspiblitz/blob/v1.7/FAQ.md#what-is-the-process-of-creating-a-new-sd-card-image-release
+Work notes partially based on: https://github.com/raspiblitz/raspiblitz/blob/v1.7/FAQ.md#what-is-the-process-of-creating-a-new-sd-card-image-release
 
 ### Requirements:
 * amd64 Laptop or Server connected to the internet via a LAN cable
@@ -406,7 +406,7 @@ Work notes partially based on: https://github.com/rootzoll/raspiblitz/blob/v1.7/
 
     raspiblitz-raspiblitz-amd64-vX.X.X-YEAR-MONTH-DAY image, sha256sum and signature
 
-    Find more info at: https://github.com/rootzoll/raspiblitz/tree/dev/alternative.platforms
+    Find more info at: https://github.com/raspiblitz/raspiblitz/tree/dev/alternative.platforms
 
     # Import the signing pubkey:
     curl https://keybase.io/oms/pgp_keys.asc | gpg --import

--- a/alternative.platforms/amd64/README.md
+++ b/alternative.platforms/amd64/README.md
@@ -35,4 +35,4 @@ You will need to connect a virtual data drive to the RaspiBlitzVM ... todo so:
 Every file in `home.admin` will be linked to `/home/admin` inside the VM,
 if you add a new file you should run `vagrant provision` to make sure it gets linked inside the VM. Every time you boot the VM, `home.admin` files will be linked automatically.
 
-The content of the `/home/admin/assets` folder is not kept in sync at the moment (see [#1578](https://github.com/rootzoll/raspiblitz/issues/1578)). You can still access your development assets file inside the VM in `/vagrant/home.admin/assets/`.
+The content of the `/home/admin/assets` folder is not kept in sync at the moment (see [#1578](https://github.com/raspiblitz/raspiblitz/issues/1578)). You can still access your development assets file inside the VM in `/vagrant/home.admin/assets/`.

--- a/build_sdcard.sh
+++ b/build_sdcard.sh
@@ -393,7 +393,7 @@ echo -e "\n*** SOFTWARE UPDATE ***"
 # autossh telnet vnstat -> network tools bandwidth monitoring for future statistics
 # parted dosfstools -> prepare for format data drive
 # btrfs-progs -> prepare for BTRFS data drive raid
-# fbi -> prepare for display graphics mode. https://github.com/rootzoll/raspiblitz/pull/334
+# fbi -> prepare for display graphics mode. https://github.com/raspiblitz/raspiblitz/pull/334
 # sysbench -> prepare for powertest
 # build-essential -> check for build dependencies on Ubuntu, Armbian
 # dialog -> dialog bc python3-dialog
@@ -410,7 +410,7 @@ echo -e "\n*** SOFTWARE UPDATE ***"
 general_utils="sudo htop git curl bash-completion vim jq dphys-swapfile bsdmainutils autossh telnet vnstat parted dosfstools fbi sysbench build-essential dialog bc python3-dialog unzip whois fdisk lsb-release smartmontools rsyslog qrencode dnsutils"
 # add btrfs-progs if not bookworm on aarch64
 [ "${architecture}" = "aarch64" ] && ! grep "12 (bookworm)" < /etc/os-release && general_utils="${general_utils} btrfs-progs"
-# python3-mako --> https://github.com/rootzoll/raspiblitz/issues/3441
+# python3-mako --> https://github.com/raspiblitz/raspiblitz/issues/3441
 python_dependencies="python3-venv python3-dev python3-wheel python3-jinja2 python3-pip python3-mako"
 server_utils="rsync net-tools xxd netcat-openbsd openssh-client openssh-sftp-server sshpass psmisc ufw sqlite3"
 [ "${architecture}" = "amd64" ] && amd64_dependencies="network-manager" # add amd64 dependency
@@ -519,7 +519,7 @@ if [ "${baseimage}" = "raspios_arm64" ]; then
   # set WIFI country so boot does not block
   # this will undo the softblock of rfkill on RaspiOS
   [ "${wifi_region}" != "off" ] && raspi-config nonint do_wifi_country $wifi_region
-  # see https://github.com/rootzoll/raspiblitz/issues/428#issuecomment-472822840
+  # see https://github.com/raspiblitz/raspiblitz/issues/428#issuecomment-472822840
 
   if ! grep "Raspiblitz" $raspi_configfile; then
     echo "# Adding Raspiblitz Edits to $raspi_configfile"
@@ -540,8 +540,8 @@ if [ "${baseimage}" = "raspios_arm64" ]; then
   fi
 
   # run fsck on sd root partition on every startup to prevent "maintenance login" screen
-  # see: https://github.com/rootzoll/raspiblitz/issues/782#issuecomment-564981630
-  # see https://github.com/rootzoll/raspiblitz/issues/1053#issuecomment-600878695
+  # see: https://github.com/raspiblitz/raspiblitz/issues/782#issuecomment-564981630
+  # see https://github.com/raspiblitz/raspiblitz/issues/1053#issuecomment-600878695
   # use command to check last fsck check: tune2fs -l /dev/mmcblk0p2
   if [ "${tweak_boot_drive}" == "true" ]; then
     echo "* running tune2fs"
@@ -606,7 +606,7 @@ if [ "${baseimage}" = "raspios_arm64" ]; then
   if [ ${autostartDone} -eq 0 ]; then
     # bash autostart for pi
     # run as exec to dont allow easy physical access by keyboard
-    # see https://github.com/rootzoll/raspiblitz/issues/54
+    # see https://github.com/raspiblitz/raspiblitz/issues/54
     bash -c 'echo "# automatic start the LCD info loop" >> /home/pi/.bashrc'
     bash -c 'echo "SCRIPT=\"sudo /home/admin/00infoLCD.sh\"" >> /home/pi/.bashrc'
     bash -c 'echo "# replace shell with script => logout when exiting script" >> /home/pi/.bashrc'
@@ -757,17 +757,17 @@ bash -c "echo 'PATH=\$PATH:/sbin' >> /etc/profile"
 echo -e "\n*** RASPIBLITZ EXTRAS ***"
 
 # screen for background processes
-# tmux for multiple (detachable/background) sessions when using SSH https://github.com/rootzoll/raspiblitz/issues/990
+# tmux for multiple (detachable/background) sessions when using SSH https://github.com/raspiblitz/raspiblitz/issues/990
 # fzf install a command-line fuzzy finder (https://github.com/junegunn/fzf)
 apt_install tmux screen fzf
 
 bash -c "echo '' >> /home/admin/.bashrc"
-bash -c "echo '# https://github.com/rootzoll/raspiblitz/issues/1784' >> /home/admin/.bashrc"
+bash -c "echo '# https://github.com/raspiblitz/raspiblitz/issues/1784' >> /home/admin/.bashrc"
 bash -c "echo 'NG_CLI_ANALYTICS=ci' >> /home/admin/.bashrc"
 
 # raspiblitz custom command prompt #2400
 if ! grep -Eq "^[[:space:]]*PS1.*₿" /home/admin/.bashrc; then
-    sed -i '/^unset color_prompt force_color_prompt$/i # raspiblitz custom command prompt https://github.com/rootzoll/raspiblitz/issues/2400' /home/admin/.bashrc
+    sed -i '/^unset color_prompt force_color_prompt$/i # raspiblitz custom command prompt https://github.com/raspiblitz/raspiblitz/issues/2400' /home/admin/.bashrc
     sed -i '/^unset color_prompt force_color_prompt$/i raspiIp=$(hostname -I | cut -d " " -f1)' /home/admin/.bashrc
     sed -i '/^unset color_prompt force_color_prompt$/i if [ "$color_prompt" = yes ]; then' /home/admin/.bashrc
     sed -i '/^unset color_prompt force_color_prompt$/i \    PS1=\x27${debian_chroot:+($debian_chroot)}\\[\\033[00;33m\\]\\u@$raspiIp:\\[\\033[00;34m\\]\\w\\[\\033[01;35m\\]$(__git_ps1 "(%s)") \\[\\033[01;33m\\]₿\\[\\033[00m\\] \x27' /home/admin/.bashrc
@@ -868,7 +868,7 @@ if [ "${baseimage}" = "raspios_arm64"  ] || [ "${baseimage}" = "debian" ]; then
   sed -i "s/^dtoverlay=${dtoverlay}/# dtoverlay=${dtoverlay}/g" ${raspi_configfile}
 
   # I2C fix (make sure dtparam=i2c_arm is not on)
-  # see: https://github.com/rootzoll/raspiblitz/issues/1058#issuecomment-739517713
+  # see: https://github.com/raspiblitz/raspiblitz/issues/1058#issuecomment-739517713
   sed -i "s/^dtparam=i2c_arm=.*//g" ${raspi_configfile}
 fi
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -47,7 +47,7 @@ https://github.com/raspiblitz/raspiblitz/actions/workflows/arm64-rpi-lean-image.
 * The images are built in GitHub actions
 * To see the downloadable artifacts will need to log in to GitHub
 * Find the latest successful build of the default amd64 image:
-https://github.com/rootzoll/raspiblitz/actions/workflows/amd64-lean-image.yml?query=workflow%3Aamd64-lean-image-build+branch%3Adev+is%3Asuccess++
+https://github.com/raspiblitz/raspiblitz/actions/workflows/amd64-lean-image.yml?query=workflow%3Aamd64-lean-image-build+branch%3Adev+is%3Asuccess++
   ```
   # unpack the artifact to the same directory
   unzip ./raspiblitz-amd64-image-*.zip
@@ -147,7 +147,7 @@ https://github.com/rootzoll/raspiblitz/actions/workflows/amd64-lean-image.yml?qu
   ```
 
 ## Local build
-with the [Makefile](https://github.com/rootzoll/raspiblitz/blob/dev/Makefile)
+with the [Makefile](https://github.com/raspiblitz/raspiblitz/blob/dev/Makefile)
 * needs ~20 GB free space
 * tested on:
   * Ubuntu Live (jammy)
@@ -161,7 +161,7 @@ with the [Makefile](https://github.com/rootzoll/raspiblitz/blob/dev/Makefile)
   # install git and make
   apt update && apt install -y git make
   # download the repo (or your fork)
-  git clone https://github.com/rootzoll/raspiblitz
+  git clone https://github.com/raspiblitz/raspiblitz
   cd raspiblitz
   # checkout the desired branch
   git checkout dev

--- a/home.admin/00raspiblitz.sh
+++ b/home.admin/00raspiblitz.sh
@@ -287,7 +287,7 @@ MAINMENU > REPAIR > REPAIR-LND > RETRYSCB
       echo "ERROR - please report to development team"
       echo "***********************************************************"
       echo "state(${state}) message(${message})"
-      echo "https://github.com/rootzoll/raspiblitz#support"
+      echo "https://github.com/raspiblitz/raspiblitz#support"
       echo "command to shutdown --> off"
       exit 1
     elif [ "${state}" == "" ]; then

--- a/home.admin/99lndMenu.sh
+++ b/home.admin/99lndMenu.sh
@@ -148,7 +148,7 @@ case $CHOICE in
     $lncli_alias wallet accounts list --name default | grep --color=never .*,
     echo
     echo "EXPERIMENTAL - DONT USE FOR SERIOUS FUND RECEIVING YET"
-    echo "Report your experience to: https://github.com/rootzoll/raspiblitz/issues/2192"
+    echo "Report your experience to: https://github.com/raspiblitz/raspiblitz/issues/2192"
     echo 
     echo "Press ENTER to return to main menu."
     read key

--- a/home.admin/99updateMenu.sh
+++ b/home.admin/99updateMenu.sh
@@ -12,7 +12,7 @@ release()
   whiptail --title "Update Instructions" --yes-button "Not Now" --no-button "Start Update" --yesno "To update your RaspiBlitz to a new version:
 
 - Download the new SD card image to your laptop:
-  https://github.com/rootzoll/raspiblitz
+  https://github.com/raspiblitz/raspiblitz
 - Flash that SD card image to a new SD card (best)
   or override old SD card after shutdown (fallback)
 - Choose 'Start Update' below.

--- a/home.admin/BlitzPy/setup.py
+++ b/home.admin/BlitzPy/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     description="Common Uses Cases for RaspiBlitz",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/rootzoll/raspiblitz",
+    url="https://github.com/raspiblitz/raspiblitz",
     packages=setuptools.find_packages(exclude=("tests", "docs")),
     classifiers=[
         # How mature is this project? Common values are

--- a/home.admin/BlitzTUI/docs/tutorial.md
+++ b/home.admin/BlitzTUI/docs/tutorial.md
@@ -7,7 +7,7 @@ This *Mini-Tutorial* shows the basic workflow for doing changes to the Blitz-Tou
 * A physical RaspiBlitz and SSH access to it (to verify your changes on the real screen)
 * A Computer (Mac and Windows should work)
 * The "Qt Designer" software (https://build-system.fman.io/qt-designer-download)
-* A copy of the current RaspiBlitz codebase (`git clone https://github.com/rootzoll/raspiblitz.git`)
+* A copy of the current RaspiBlitz codebase (`git clone https://github.com/raspiblitz/raspiblitz.git`)
 
 ## Scenario
 

--- a/home.admin/BlitzTUI/setup.py
+++ b/home.admin/BlitzTUI/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     description="Touch User Interface for RaspiBlitz",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/rootzoll/raspiblitz",
+    url="https://github.com/raspiblitz/raspiblitz",
     packages=setuptools.find_packages(exclude=("tests", "docs")),
     classifiers=[
         # How mature is this project? Common values are

--- a/home.admin/_background.sh
+++ b/home.admin/_background.sh
@@ -42,7 +42,7 @@ do
 
   ####################################################
   # SKIP BACKGROUND TASK LOOP ON CERTAIN SYSTEM STATES
-  # https://github.com/rootzoll/raspiblitz/issues/160
+  # https://github.com/raspiblitz/raspiblitz/issues/160
   ####################################################
 
   if [ "${state}" == "" ] || [ "${state}" == "copysource" ] || [ "${state}" == "copytarget" ]; then
@@ -74,7 +74,7 @@ do
 
   ####################################################
   # MONITOR LOG SIZES
-  # https://github.com/rootzoll/raspiblitz/issues/2659
+  # https://github.com/raspiblitz/raspiblitz/issues/2659
   ####################################################
 
   # once a day
@@ -86,7 +86,7 @@ do
 
   ####################################################
   # RECHECK DHCP-SERVER
-  # https://github.com/rootzoll/raspiblitz/issues/160
+  # https://github.com/raspiblitz/raspiblitz/issues/160
   ####################################################
 
   # every 5 minutes

--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -249,7 +249,7 @@ fi
 ################################
 
 # Emergency cleaning logs when over 1GB (to prevent SD card filling up)
-# see https://github.com/rootzoll/raspiblitz/issues/418#issuecomment-472180944
+# see https://github.com/raspiblitz/raspiblitz/issues/418#issuecomment-472180944
 echo "*** Checking Log Size ***"
 logsMegaByte=$(du -c -m /var/log | grep "total" | awk '{print $1;}')
 if [ ${logsMegaByte} -gt 1000 ]; then
@@ -272,9 +272,9 @@ echo ""
 ################################
 
 # display 3 secs logo - try to kickstart LCD
-# see https://github.com/rootzoll/raspiblitz/issues/195#issuecomment-469918692
-# see https://github.com/rootzoll/raspiblitz/issues/647
-# see https://github.com/rootzoll/raspiblitz/pull/1580
+# see https://github.com/raspiblitz/raspiblitz/issues/195#issuecomment-469918692
+# see https://github.com/raspiblitz/raspiblitz/issues/647
+# see https://github.com/raspiblitz/raspiblitz/pull/1580
 randnum=$(shuf -i 0-7 -n 1)
 /home/admin/config.scripts/blitz.display.sh image /home/admin/raspiblitz/pictures/startlogo${randnum}.png
 sleep 5
@@ -1333,14 +1333,14 @@ else
 
   #################################
   # FIX BLOCKCHAINDATA OWNER (just in case)
-  # https://github.com/rootzoll/raspiblitz/issues/239#issuecomment-450887567
+  # https://github.com/raspiblitz/raspiblitz/issues/239#issuecomment-450887567
   #################################
   chown bitcoin:bitcoin -R /mnt/hdd/bitcoin 2>/dev/null
 
   #################################
   # FIX BLOCKING FILES (just in case)
-  # https://github.com/rootzoll/raspiblitz/issues/1901#issue-774279088
-  # https://github.com/rootzoll/raspiblitz/issues/1836#issue-755342375
+  # https://github.com/raspiblitz/raspiblitz/issues/1901#issue-774279088
+  # https://github.com/raspiblitz/raspiblitz/issues/1836#issue-755342375
   rm -f /mnt/hdd/bitcoin/bitcoind.pid 2>/dev/null
   rm -f /mnt/hdd/bitcoin/.lock 2>/dev/null
 
@@ -1355,7 +1355,7 @@ else
   fi
   # /mnt/hdd/app-data/lnd/logs/bitcoin/mainnet/lnd.log
   rm /mnt/hdd/app-data/lnd/logs/${network}/${chain}net/lnd.log 2>/dev/null
-  # https://github.com/rootzoll/raspiblitz/issues/1700
+  # https://github.com/raspiblitz/raspiblitz/issues/1700
   rm /mnt/storage/app-storage/electrs/db/mainnet/LOCK 2>/dev/null
 
   ####################################

--- a/home.admin/_provision.setup.sh
+++ b/home.admin/_provision.setup.sh
@@ -44,7 +44,7 @@ fi
 ###################################
 # Preserve SSH keys
 # just copy dont link anymore
-# see: https://github.com/rootzoll/raspiblitz/issues/1798
+# see: https://github.com/raspiblitz/raspiblitz/issues/1798
 /home/admin/_cache.sh set message "SSH Keys"
 
 # link ssh directory from SD card to HDD

--- a/home.admin/_provision.update.sh
+++ b/home.admin/_provision.update.sh
@@ -83,8 +83,8 @@ if [ ${configExists} -eq 1 ]; then
   echo "Checking old bitcoin.conf ..." >> ${logFile}
 
   # make sure to fix bitcoind RPC port if not done in old version
-  # https://github.com/rootzoll/raspiblitz/issues/217
-  # https://github.com/rootzoll/raspiblitz/issues/950
+  # https://github.com/raspiblitz/raspiblitz/issues/217
+  # https://github.com/raspiblitz/raspiblitz/issues/950
 
   if ! grep -Eq "^rpcallowip=.*" /mnt/hdd/app-data/${network}/${network}.conf; then
     echo "fix issue #217 -> adding rpcallowip=127.0.0.1" >> ${logFile}
@@ -142,7 +142,7 @@ else
   echo "WARN: /mnt/hdd/app-data/bitcoin/bitcoin.conf not found" >> ${logFile}
 fi
 
-# delete old Tor v1 addresses from config -  see: https://github.com/rootzoll/raspiblitz/issues/3659
+# delete old Tor v1 addresses from config -  see: https://github.com/raspiblitz/raspiblitz/issues/3659
 sed -i -E "/^addnode=[a-z0-9]{8,18}\.onion/d" /mnt/hdd/app-data/${network}/${network}.conf 2>/dev/null
 
 echo "Version Code: ${codeVersion}" >> ${logFile}

--- a/home.admin/_provision_.sh
+++ b/home.admin/_provision_.sh
@@ -54,7 +54,7 @@ echo "# Make sure the user bitcoin is in the debian-tor group"
 usermod -a -G debian-tor bitcoin
 
 # make sure to have bitcoin core >=22 is backwards comp
-# see https://github.com/rootzoll/raspiblitz/issues/2546
+# see https://github.com/raspiblitz/raspiblitz/issues/2546
 sed -i '/^deprecatedrpc=.*/d' /mnt/hdd/app-data/bitcoin/bitcoin.conf 2>/dev/null
 echo "deprecatedrpc=addresses" >> /mnt/hdd/app-data/bitcoin/bitcoin.conf 2>/dev/null
 
@@ -81,7 +81,7 @@ fi
 # PREPARE LND (if activated)
 if [ "${lightning}" == "lnd" ] || [ "${lnd}" == "on" ]; then
   # backup LND TLS certs
-  # https://github.com/rootzoll/raspiblitz/issues/324
+  # https://github.com/raspiblitz/raspiblitz/issues/324
   echo "*** Make backup of LND TLS files" >> ${logFile}
   rm -r  /var/cache/raspiblitz/tls_backup 2>/dev/null
   mkdir /var/cache/raspiblitz/tls_backup 2>/dev/null
@@ -768,7 +768,7 @@ else
 fi
 
 # replay backup LND conf & tlscerts
-# https://github.com/rootzoll/raspiblitz/issues/324
+# https://github.com/raspiblitz/raspiblitz/issues/324
 echo "" >> ${logFile}
 echo "*** Replay backup of LND conf/tls" >> ${logFile}
 if [ -d "/var/cache/raspiblitz/tls_backup" ]; then
@@ -808,8 +808,8 @@ sed -i '/^lndKeysend=/d' /mnt/hdd/app-data/raspiblitz.conf
 /home/admin/_cache.sh set message "Setup Done"
 
 # set the local network hostname (just if set in config - will not be set anymore by default in newer version)
-# have at the end - see https://github.com/rootzoll/raspiblitz/issues/462
-# see also https://github.com/rootzoll/raspiblitz/issues/819
+# have at the end - see https://github.com/raspiblitz/raspiblitz/issues/462
+# see also https://github.com/raspiblitz/raspiblitz/issues/819
 if [ ${#hostname} -gt 0 ]; then
   hostnameSanatized=$(echo "${hostname}"| tr -dc '[:alnum:]\n\r')
   if [ ${#hostnameSanatized} -gt 0 ]; then

--- a/home.admin/config.scripts/blitz.bootdrive.sh
+++ b/home.admin/config.scripts/blitz.bootdrive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # basic background on this feature
-# see: https://github.com/rootzoll/raspiblitz/issues/936
+# see: https://github.com/raspiblitz/raspiblitz/issues/936
 
 # get basic system information
 # these are the same set of infos the WebGUI dialog/controler has

--- a/home.admin/config.scripts/blitz.display.sh
+++ b/home.admin/config.scripts/blitz.display.sh
@@ -26,7 +26,7 @@ source /home/admin/raspiblitz.info
 source /mnt/hdd/app-data/raspiblitz.conf 2>/dev/null
 
 # check if LCD (/dev/fb1) or HDMI (/dev/fb0)
-# see https://github.com/rootzoll/raspiblitz/pull/1580
+# see https://github.com/raspiblitz/raspiblitz/pull/1580
 # but basically this just says if the driver for GPIO LCD is installed - not if connected
 fb1Exists=$(ls /dev/fb1 2>/dev/null | grep -c "/dev/fb1")
 
@@ -91,7 +91,7 @@ if [ "${command}" == "image" ]; then
     fi
   fi
 
-  # see https://github.com/rootzoll/raspiblitz/pull/1580
+  # see https://github.com/raspiblitz/raspiblitz/pull/1580
   if [ ${fb1Exists} -eq 1 ] ; then
     # LCD
     fbi -a -T 1 -d /dev/fb1 --noverbose ${imagePath} 2> /dev/null
@@ -115,7 +115,7 @@ if [ "${command}" == "qr" ]; then
   fi
 
   qrencode -l L -o /var/cache/raspiblitz/qr.png "${datastring}" > /dev/null
-  # see https://github.com/rootzoll/raspiblitz/pull/1580
+  # see https://github.com/raspiblitz/raspiblitz/pull/1580
   if [ ${fb1Exists} -eq 1 ] ; then
     # LCD
     fbi -a -T 1 -d /dev/fb1 --noverbose /var/cache/raspiblitz/qr.png 2> /dev/null
@@ -138,7 +138,7 @@ fi
 
 ##################
 # ROTATE
-# see issue: https://github.com/rootzoll/raspiblitz/issues/681
+# see issue: https://github.com/raspiblitz/raspiblitz/issues/681
 ###################
 
 if [ "${command}" == "rotate" ]; then
@@ -189,7 +189,7 @@ fi
 ###################
 # TEST LCD CONNECT
 # only tested on RaspiOS 64-bit with RaspberryPi 4
-# https://github.com/rootzoll/raspiblitz/issues/1265#issuecomment-813660030
+# https://github.com/raspiblitz/raspiblitz/issues/1265#issuecomment-813660030
 ###################
 
 if [ "${command}" == "test-lcd-connect" ]; then
@@ -281,7 +281,7 @@ function install_lcd() {
     #sed -i "s/^#framebuffer_height=.*/framebuffer_height=320/g" ${raspi_configfile}
     #echo "hdmi_force_hotplug=1" >> ${raspi_configfile}
     sed -i "s/^dtparam=i2c_arm=.*//g" ${raspi_configfile}
-    # echo "dtparam=i2c_arm=on" >> ${raspi_configfile} --> this is to be called I2C errors - see: https://github.com/rootzoll/raspiblitz/issues/1058#issuecomment-739517713
+    # echo "dtparam=i2c_arm=on" >> ${raspi_configfile} --> this is to be called I2C errors - see: https://github.com/raspiblitz/raspiblitz/issues/1058#issuecomment-739517713
     # don't enable SPI and UART ports by default
     # echo "dtparam=spi=on" >> ${raspi_configfile}
     # echo "enable_uart=1" >> ${raspi_configfile}
@@ -312,7 +312,7 @@ function install_lcd() {
     # https://github.com/tux1c/wavesharelcd-64bit-rpi#adapting-guide-to-other-lcds
 
     # set font that fits the LCD screen
-    # https://github.com/rootzoll/raspiblitz/issues/244#issuecomment-476713706
+    # https://github.com/raspiblitz/raspiblitz/issues/244#issuecomment-476713706
     # there can be a different font for different types of LCDs with using the displayType parameter in the future
     setfont /usr/share/consolefonts/Uni3-TerminusBold16.psf.gz
 

--- a/home.admin/config.scripts/blitz.fatpack.sh
+++ b/home.admin/config.scripts/blitz.fatpack.sh
@@ -102,7 +102,7 @@ echo "* Adding Core Lightning ..."
 
 # *** AUTO UPDATE FALLBACK NODE LIST FROM INTERNET (only in fatpack)
 echo "*** FALLBACK NODE LIST ***"
-# see https://github.com/rootzoll/raspiblitz/issues/1888
+# see https://github.com/raspiblitz/raspiblitz/issues/1888
 sudo -u admin curl -H "Accept: application/json; indent=4" https://bitnodes.io/api/v1/snapshots/latest/ -o /home/admin/fallback.bitnodes.nodes
 # Fallback Nodes List from Bitcoin Core
 sudo -u admin curl https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/seeds/nodes_main.txt -o /home/admin/fallback.bitcoin.nodes

--- a/home.admin/config.scripts/blitz.release.sh
+++ b/home.admin/config.scripts/blitz.release.sh
@@ -48,7 +48,7 @@ echo "cpu=${cpu}" >> /home/admin/raspiblitz.info
 echo "blitzapi=${blitzapi}" >> /home/admin/raspiblitz.info
 echo "displayClass=${displayClass}" >> /home/admin/raspiblitz.info
 
-# https://github.com/rootzoll/raspiblitz/issues/1371
+# https://github.com/raspiblitz/raspiblitz/issues/1371
 echo
 echo "deactivate local WIFI ..."
 sudo nmcli radio wifi off
@@ -69,7 +69,7 @@ echo "deleting redis data (if still there) ..."
 sudo rm /var/lib/redis/dump.rdb 2>/dev/null
 echo "OK"
 
-# https://github.com/rootzoll/raspiblitz/issues/1068#issuecomment-599267503
+# https://github.com/raspiblitz/raspiblitz/issues/1068#issuecomment-599267503
 echo
 echo "reset DNS confs ..."
 echo -e "nameserver 1.1.1.1\nnameserver 84.200.69.80" | sudo tee /etc/resolv.conf > /dev/null

--- a/home.admin/config.scripts/blitz.subscriptions.letsencrypt.py
+++ b/home.admin/config.scripts/blitz.subscriptions.letsencrypt.py
@@ -213,7 +213,7 @@ def dynu_update(domain, token, ip):
 def subscriptions_new(ip, dnsservice, domain, token, target):
 
     # check if already one subscription exists (limit to just one)
-    # https://github.com/rootzoll/raspiblitz/issues/1786
+    # https://github.com/raspiblitz/raspiblitz/issues/1786
     if Path(SUBSCRIPTIONS_FILE).is_file():
         subs = toml.load(SUBSCRIPTIONS_FILE)
         if "subscriptions_letsencrypt" in subs:
@@ -633,7 +633,7 @@ to reach the service you wanted.
     except Exception as e:
 
         # service flaky
-        # https://github.com/rootzoll/raspiblitz/issues/1772
+        # https://github.com/raspiblitz/raspiblitz/issues/1772
         if "failed oAuth Service" in str(e):
             Dialog(dialog="dialog", autowidgetsize=True).msgbox('''
 A temporary error with the DYNU API happened:\nInvalid OAuth Bearer Token

--- a/home.admin/config.scripts/blitz.touchscreen.sh
+++ b/home.admin/config.scripts/blitz.touchscreen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# see issue: https://github.com/rootzoll/raspiblitz/issues/646
-# and issue: https://github.com/rootzoll/raspiblitz/issues/809
+# see issue: https://github.com/raspiblitz/raspiblitz/issues/646
+# and issue: https://github.com/raspiblitz/raspiblitz/issues/809
 # to check debug logs: sudo cat /home/pi/.cache/lxsession/LXDE-pi/run.log
 
 source /home/admin/raspiblitz.info

--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -662,7 +662,7 @@ WantedBy=multi-user.target
       hasFailed=$(sudo systemctl status nbxplorer | grep -c "Active: failed")
       if [ ${hasFailed} -eq 1 ]; then
         echo "# seems like starting nbxplorer service has failed - see: systemctl status nbxplorer"
-        echo "# maybe report here: https://github.com/rootzoll/raspiblitz/issues/214"
+        echo "# maybe report here: https://github.com/raspiblitz/raspiblitz/issues/214"
       fi
     done
   else
@@ -714,7 +714,7 @@ WantedBy=multi-user.target
       hasFailed=$(sudo systemctl status btcpayserver | grep -c "Active: failed")
       if [ ${hasFailed} -eq 1 ]; then
         echo "# seems like starting btcpayserver service has failed - see: systemctl status btcpayserver"
-        echo "# maybe report here: https://github.com/rootzoll/raspiblitz/issues/214"
+        echo "# maybe report here: https://github.com/raspiblitz/raspiblitz/issues/214"
       fi
     done
   else

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -252,7 +252,7 @@ Check 'sudo nginx -t' for a detailed error message.
     echo "'${localIP}':'${portSSL}':s' instead of '${localIP}':'${portTCP}':t"
     echo
     echo "For more details check the RaspiBlitz README on ElectRS:"
-    echo "https://github.com/rootzoll/raspiblitz"
+    echo "https://github.com/raspiblitz/raspiblitz"
     echo
     echo "Press ENTER to get back to main menu."
     read key

--- a/home.admin/config.scripts/bonus.fullynoded.sh
+++ b/home.admin/config.scripts/bonus.fullynoded.sh
@@ -25,7 +25,7 @@ fi
 /home/admin/config.scripts/tor.onion-service.sh bitcoin${BITCOINRPCPORT} ${BITCOINRPCPORT} ${BITCOINRPCPORT}
 
 hiddenService=$(sudo cat /mnt/hdd/app-data/tor/bitcoin${BITCOINRPCPORT}/hostname)
-# https://github.com/rootzoll/raspiblitz/issues/2339
+# https://github.com/raspiblitz/raspiblitz/issues/2339
 if [ ${#hiddenService} -eq 0 ];then
   hiddenService=$(sudo cat /mnt/hdd/app-data/tor/bitcoin/hostname)
 fi

--- a/home.admin/config.scripts/bonus.kindle-display.sh
+++ b/home.admin/config.scripts/bonus.kindle-display.sh
@@ -142,7 +142,7 @@ EOF
     echo "# enable kindle-display service"
     sudo systemctl enable kindle-display
 
-    # https://github.com/rootzoll/raspiblitz/issues/1375
+    # https://github.com/raspiblitz/raspiblitz/issues/1375
     if [ "${state}" == "ready" ]; then
       echo "# starting kindle-display service"
       sudo systemctl start kindle-display

--- a/home.admin/config.scripts/bonus.lnbits.sh
+++ b/home.admin/config.scripts/bonus.lnbits.sh
@@ -1039,7 +1039,7 @@ if [ "$1" = "switch" ]; then
     else
       CLCONF="/home/bitcoin/.lightning${clrpcsubdir}/config"
     fi
-    # https://github.com/rootzoll/raspiblitz/issues/3007
+    # https://github.com/raspiblitz/raspiblitz/issues/3007
     if [ "$(sudo cat ${CLCONF} | grep -c "^rpc-file-mode=0660")" -eq 0 ]; then
       echo "rpc-file-mode=0660" | sudo tee -a ${CLCONF}
     fi

--- a/home.admin/config.scripts/bonus.lndconnect.sh
+++ b/home.admin/config.scripts/bonus.lndconnect.sh
@@ -257,5 +257,5 @@ if [ $(echo "${host}" | grep -c '192.168') -gt 0 ]; then
   echo "- Check that your WIFI devices can talk to the LAN devices on your router (deactivate IP isolation or guest mode)."
 fi
 echo "- try to refresh the TLS & macaroons: Main Menu 'EXPORT > 'RESET'"
-echo "- check issues: https://github.com/rootzoll/raspiblitz/issues"
+echo "- check issues: https://github.com/raspiblitz/raspiblitz/issues"
 echo ""

--- a/home.admin/config.scripts/cl-plugin.clboss.sh
+++ b/home.admin/config.scripts/cl-plugin.clboss.sh
@@ -41,7 +41,7 @@ CLBOSS does the following automatically:
 - Set forwarding fees so that they're competitive to other nodes
 
 Links with more info:
-https://github.com/rootzoll/raspiblitz/blob/dev/FAQ.cl.md#clboss
+https://github.com/raspiblitz/raspiblitz/blob/dev/FAQ.cl.md#clboss
 https://github.com/ZmnSCPxj/clboss#operating
 " 0 0
   exit $?

--- a/home.admin/config.scripts/cl-plugin.http.sh
+++ b/home.admin/config.scripts/cl-plugin.http.sh
@@ -25,7 +25,7 @@ source <(/home/admin/config.scripts/network.aliases.sh getvars cl mainnet)
 if [ $1 = connect ];then
   toraddress=$(sudo cat /mnt/hdd/app-data/tor/clHTTPplugin/hostname)
   PASSWORD_B=$(sudo cat /mnt/hdd/app-data/bitcoin/bitcoin.conf | grep rpcpassword | cut -c 13-)
-  # https://github.com/rootzoll/raspiblitz/issues/2579#issuecomment-936091256
+  # https://github.com/raspiblitz/raspiblitz/issues/2579#issuecomment-936091256
   # http://rpcuser:rpcpassword@xxx.onion:9080
   url="http://lightning:${PASSWORD_B}@${toraddress}:9080"
   clear

--- a/home.admin/config.scripts/cl.check.sh
+++ b/home.admin/config.scripts/cl.check.sh
@@ -24,12 +24,12 @@ source <(/home/admin/config.scripts/network.aliases.sh getvars cl $2)
 
 if [ "$1" == "prestart" ]; then
 
-  # make sure plugins are loaded https://github.com/rootzoll/raspiblitz/issues/2953
+  # make sure plugins are loaded https://github.com/raspiblitz/raspiblitz/issues/2953
   if [ $(grep -c "^plugin-dir=/home/bitcoin/${netprefix}cl-plugins-enabled" <${CLCONF}) -eq 0 ]; then
     echo "plugin-dir=/home/bitcoin/${netprefix}cl-plugins-enabled" | tee -a ${CLCONF}
   fi
 
-  # do not announce 127.0.0.1 https://github.com/rootzoll/raspiblitz/issues/2634
+  # do not announce 127.0.0.1 https://github.com/raspiblitz/raspiblitz/issues/2634
   if [ $(grep -c "^announce-addr=127.0.0.1" <${CLCONF}) -gt 0 ]; then
     sed -i "/^announce-addr=127.0.0.1/d" ${CLCONF}
   fi
@@ -58,7 +58,7 @@ if [ "$1" == "prestart" ]; then
     fi
   fi
 
-  # https://github.com/rootzoll/raspiblitz/issues/3007
+  # https://github.com/raspiblitz/raspiblitz/issues/3007
   # add for test networks as well if needed on mainnet
   if [ "${blitzapi}" = "on" ] ||
     [ "${LNBitsFunding}" = "${netprefix}cl" ] ||

--- a/home.admin/config.scripts/cl.hsmtool.sh
+++ b/home.admin/config.scripts/cl.hsmtool.sh
@@ -417,7 +417,7 @@ elif [ "$1" = "encrypt" ]; then
 # The words cannot be generated from the hsm_secret (one way function).
 # If you don't have the words the hsm_secret can be still backed up as a file or in hex:
 # https://lightning.readthedocs.io/BACKUP.html#hsm-secret
-# https://github.com/rootzoll/raspiblitz/blob/dev/FAQ.cl.md#seed
+# https://github.com/raspiblitz/raspiblitz/blob/dev/FAQ.cl.md#seed
 " | sudo -u bitcoin tee /home/bitcoin/.lightning/${CLNETWORK}/seedwords.info
   # encrypt
   walletPassword=$4
@@ -467,7 +467,7 @@ elif [ "$1" = "change-password" ]; then
 
 
 elif [ "$1" = "check" ]; then
-  # TODO https://github.com/rootzoll/raspiblitz/issues/2897
+  # TODO https://github.com/raspiblitz/raspiblitz/issues/2897
   # dumponchaindescriptors <path/to/hsm_secret> [network]
   # get current descriptors
   sudo -u bitcoin /home/bitcoin/lightning/tools/hsmtool dumponchaindescriptors \

--- a/home.admin/config.scripts/dropbox.upload.sh
+++ b/home.admin/config.scripts/dropbox.upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# DEPRECATED: https://github.com/rootzoll/raspiblitz/issues/2264#issuecomment-872655605
+# DEPRECATED: https://github.com/raspiblitz/raspiblitz/issues/2264#issuecomment-872655605
 # script will stay on v1.7.1 ... but should be removed after that
 
 # command info
@@ -32,7 +32,7 @@ if [ "${MODE}" == "on" ]; then
     whiptail --title " Static Channel Backup on Dropbox " --inputbox "
 Follow the steps described at the following link
 to get the DropBox-Authtoken from your account:
-https://github.com/rootzoll/raspiblitz/#a-dropbox-backup-target" 11 70 2>/home/admin/.tmp
+https://github.com/raspiblitz/raspiblitz/#a-dropbox-backup-target" 11 70 2>/home/admin/.tmp
     authtoken=$(cat /home/admin/.tmp)
     shred -u /home/admin/.tmp
   fi

--- a/home.admin/config.scripts/internet.sh
+++ b/home.admin/config.scripts/internet.sh
@@ -193,7 +193,7 @@ if [ ${runGlobal} -eq 1 ]; then
   fi
 
   # sanity check on IP data
-  # see https://github.com/rootzoll/raspiblitz/issues/371#issuecomment-472416349
+  # see https://github.com/raspiblitz/raspiblitz/issues/371#issuecomment-472416349
   echo "# sanity check of IP data:"
   if [[ $globalIP =~ ^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$ ]]; then
     echo "# OK IPv6 for ${globalIP}"
@@ -205,7 +205,7 @@ if [ ${runGlobal} -eq 1 ]; then
   fi
 
   # prevent having no publicIP set at all and LND getting stuck
-  # https://github.com/rootzoll/raspiblitz/issues/312#issuecomment-462675101
+  # https://github.com/raspiblitz/raspiblitz/issues/312#issuecomment-462675101
   if [ ${#globalIP} -eq 0 ]; then
     if [ "${ipv6}" == "on" ]; then
       globalIP="::1"

--- a/home.admin/config.scripts/internet.sshtunnel.py
+++ b/home.admin/config.scripts/internet.sshtunnel.py
@@ -238,7 +238,7 @@ def on(restore_on_update=False):
     print("*** WIN - SSH TUNNEL SERVICE SETUP ***")
     print("**************************************")
     print("See chapter 'How to setup port-forwarding with a SSH tunnel?' in:")
-    print("https://github.com/rootzoll/raspiblitz/blob/dev/FAQ.md")
+    print("https://github.com/raspiblitz/raspiblitz/blob/dev/FAQ.md")
     print("- Tunnel service needs final reboot to start.")
     print("- After reboot check logs: sudo journalctl -f -u {}".format(SERVICE_NAME))
     print("- Make sure the SSH pub key of this RaspiBlitz is in 'authorized_keys' of {}:".format(ssh_server_host))

--- a/home.admin/config.scripts/internet.wifi.sh
+++ b/home.admin/config.scripts/internet.wifi.sh
@@ -76,7 +76,7 @@ if [ "$1" == "off" ]; then
   exit 0
 fi
 
-# https://github.com/rootzoll/raspiblitz/issues/560
+# https://github.com/raspiblitz/raspiblitz/issues/560
 # when calling this it will backup the wifi config to HDD/SSD (if WIFI is active)
 # or when WIFI is inactive but a backup on HDD/SSD exists restore this
 if [ "$1" == "backup-restore" ]; then

--- a/home.admin/config.scripts/lnd.autounlock.sh
+++ b/home.admin/config.scripts/lnd.autounlock.sh
@@ -32,7 +32,7 @@ if [ "${turn}" = "on" ] && [ ${#passwordC} -eq 0 ]; then
 
 For more details see chapter in GitHub README 
 'Auto-unlock LND on startup'
-https://github.com/rootzoll/raspiblitz
+https://github.com/raspiblitz/raspiblitz
 
 Password C will be stored on the device.
 " 13 52 2>./.tmp

--- a/home.admin/config.scripts/lnd.check.sh
+++ b/home.admin/config.scripts/lnd.check.sh
@@ -77,7 +77,7 @@ if [ "$1" == "prestart" ]; then
   ##### APPLICATION OPTIONS SECTION #####
 
   # remove sync-freelist=1 (use =true if you want to overrule raspiblitz)
-  # https://github.com/rootzoll/raspiblitz/issues/3251
+  # https://github.com/raspiblitz/raspiblitz/issues/3251
   sed -i "/^# Avoid slow startup time/d" ${lndConfFile}
   sed -i "/^sync-freelist=1/d" ${lndConfFile}
 
@@ -310,7 +310,7 @@ if [ "$1" == "prestart" ]; then
     setting ${lndConfFile} ${insertLine} "tor.v3" "true"
     setting ${lndConfFile} ${insertLine} "tor.active" "true"
 
-    # take care of incompatible settings https://github.com/rootzoll/raspiblitz/issues/2787#issuecomment-991245694
+    # take care of incompatible settings https://github.com/raspiblitz/raspiblitz/issues/2787#issuecomment-991245694
     if [ $(cat ${lndConfFile} | grep -c "^tor.skip-proxy-for-clearnet-targets=true") -gt 0 ] ||
       [ $(cat ${lndConfFile} | grep -c "^tor.skip-proxy-for-clearnet-targets=1") -gt 0 ]; then
       setting ${lndConfFile} ${insertLine} "tor.streamisolation" "false"

--- a/home.admin/config.scripts/lnd.setname.sh
+++ b/home.admin/config.scripts/lnd.setname.sh
@@ -61,7 +61,7 @@ setting ${lndConfFile} ${insertLine} "alias" "${newName}"
 /home/admin/config.scripts/blitz.conf.sh set hostname "${newName}"
 
 # set name in local network just if forced (not anymore by default)
-# see https://github.com/rootzoll/raspiblitz/issues/819
+# see https://github.com/raspiblitz/raspiblitz/issues/819
 if [ "$3" = "alsoNetwork" ]; then
   # OS: change hostname
   sudo raspi-config nonint do_hostname ${newName}

--- a/home.admin/config.scripts/lnd.setport.sh
+++ b/home.admin/config.scripts/lnd.setport.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# based on: https://github.com/rootzoll/raspiblitz/issues/100#issuecomment-465997126
-# based on: https://github.com/rootzoll/raspiblitz/issues/386
+# based on: https://github.com/raspiblitz/raspiblitz/issues/100#issuecomment-465997126
+# based on: https://github.com/raspiblitz/raspiblitz/issues/386
 
 if [ $# -eq 0 ]; then
  echo "script set the port LND is running on"

--- a/home.admin/config.scripts/network.chain.sh
+++ b/home.admin/config.scripts/network.chain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# deprecated - see: https://github.com/rootzoll/raspiblitz/issues/2290
+# deprecated - see: https://github.com/raspiblitz/raspiblitz/issues/2290
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then

--- a/home.admin/config.scripts/tor.install.sh
+++ b/home.admin/config.scripts/tor.install.sh
@@ -230,7 +230,7 @@ ReadWriteDirectories=-${tor_data_dir}
 After=network.target nss-lookup.target mnt-hdd.mount
 " | sudo tee /etc/systemd/system/tor@default.service.d/raspiblitz.conf
 
-  # fix apparmor - https://github.com/rootzoll/raspiblitz/issues/2531
+  # fix apparmor - https://github.com/raspiblitz/raspiblitz/issues/2531
   if [ $(systemctl --type=service | grep -c apparmor) -gt 0 ]; then
     echo "- add custom directories to apparmor"
     echo "\


### PR DESCRIPTION
Issues and PRs were moved from rootzoll/raspiblitz to raspiblitz/raspiblitz when the main repo moved GitHub org. Many of the old URLs now return a 404 error when users attempt to access them.

This commit updates the links across docs and scripts.

Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [X] That its based against the `dev` branch - not the default release branch.
