### PR TITLE
docs: update NVMe hardware info and add Pi 5 specs (#5220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ RaspiBlitz is mainly targeted for learning how to run your own node decentralize
 
 - [Project Homepage: raspiblitz.org](https://raspiblitz.org)
 - [How to build & setup your own RaspiBlitz & Documentation](https://docs.raspiblitz.org/docs/setup/intro)
+- [Hardware Setup Guide & NVMe Recommendations](https://docs.raspiblitz.org/docs/setup/get-hardware)
 - [Download latest SD Card images](https://docs.raspiblitz.org/docs/setup/software-setup/download)
 - [How to get Support](https://docs.raspiblitz.org/docs/community/support)
 

--- a/alternative.platforms/README.md
+++ b/alternative.platforms/README.md
@@ -40,6 +40,7 @@
 * \> 2GB DDR3 ECC RAM (8GB+ if using ZFS)
 * USB 3.0 / SATA / PCIE / NVME connectors
 * SSD - multiple disks for redundancy
+* For Raspberry Pi 5: NVMe storage via PCIe HAT is recommended — see [NVMe setup info in hw_comparison.md](hw_comparison.md#nvme-storage-recommendations)
 
 Specifications of the tested hardware: [hw_comparison.md](hw_comparison.md)
 

--- a/alternative.platforms/hw_comparison.md
+++ b/alternative.platforms/hw_comparison.md
@@ -4,6 +4,33 @@ https://github.com/ThomasKaiser/sbc-bench/blob/master/Results.md
 
 https://dietpi.com/survey/#benchmark
 
+### Raspberry Pi 5 (Recommended)
+
+* SoC: Broadcom BCM2712 quad-core Cortex-A76 (ARMv8-A) 64-bit @ 2.4GHz
+* GPU: VideoCore VII
+* Networking: 2.4 GHz and 5 GHz 802.11b/g/n/ac wireless LAN, Gigabit Ethernet (PoE+ supported via separate HAT)
+* RAM: 4GB or 8GB LPDDR4X SDRAM
+* Bluetooth: Bluetooth 5.0, Bluetooth Low Energy (BLE)
+* GPIO: 40-pin GPIO header (new pinout — see [Raspberry Pi documentation](https://www.raspberrypi.com/documentation/computers/raspberry-pi-5.html))
+* Storage: microSD for initial boot; **NVMe SSD via PCIe HAT** (recommended for production — see [NVMe storage section](#nvme-storage-recommendations) below)
+* Ports: 2 × micro-HDMI 2.1, 2 × USB 3.0, 2 × USB 2.0, Gigabit Ethernet (PoE+), 4-pin PCIe 2.0 x1 FPC interface, CSI/DSI via FPC ribbon cables
+* Dimensions: 85 mm × 56 mm × 12 mm, 46 g
+* Power: USB-C 5V/5A (27W PD)
+
+The Pi 5 is the recommended platform for RaspiBlitz as of v1.11+. The PCIe FPC connector enables direct NVMe SSD attachment via a compatible HAT, providing significantly better I/O performance than USB SSDs or microSD cards.
+
+### Raspberry Pi 4
+
+* SoC: Broadcom BCM2711B0 quad-core A72 (ARMv8-A) 64-bit @ 1.5GHz
+* GPU: Broadcom VideoCore VI
+* Networking: 2.4 GHz and 5 GHz 802.11b/g/n/ac wireless LAN
+* RAM: 1GB, 2GB, 4GB, or 8GB LPDDR4 SDRAM
+* Bluetooth: Bluetooth 5.0, Bluetooth Low Energy (BLE)
+* GPIO: 40-pin GPIO header, populated
+* Storage: microSD
+* Ports: 2 × micro-HDMI 2.0, 3.5 mm analogue audio-video jack, 2 × USB 2.0, 2 × USB 3.0, Gigabit Ethernet, Camera Serial Interface (CSI), Display Serial Interface (DSI)
+* Dimensions: 88 mm × 58 mm × 19.5 mm, 46 g
+
 ###  Raspberry Pi 3 Model B+
 
 * Broadcom BCM2837B0, Cortex-A53 (ARMv8) 64-bit SoC @ 1.4GHz
@@ -20,17 +47,24 @@ https://dietpi.com/survey/#benchmark
 * 5V/2.5A DC power input
 * Power-over-Ethernet (PoE) support (requires separate PoE HAT)
 
-### Raspberry Pi 4
+> **Note:** The Raspberry Pi 3B+ is no longer recommended for new RaspiBlitz installations due to limited RAM and I/O performance. Consider upgrading to Pi 4 or Pi 5.
 
-* SoC: Broadcom BCM2711B0 quad-core A72 (ARMv8-A) 64-bit @ 1.5GHz
-* GPU: Broadcom VideoCore VI
-* Networking: 2.4 GHz and 5 GHz 802.11b/g/n/ac wireless LAN
-* RAM: 1GB, 2GB, or 4GB LPDDR4 SDRAM
-* Bluetooth: Bluetooth 5.0, Bluetooth Low Energy (BLE)
-* GPIO: 40-pin GPIO header, populated
-* Storage: microSD
-* Ports: 2 × micro-HDMI 2.0, 3.5 mm analogue audio-video jack, 2 ×* USB 2.0, 2 × USB 3.0, Gigabit Ethernet, Camera Serial Interface* (CSI), Display Serial Interface (DSI)
-* Dimensions: 88 mm × 58 mm × 19.5 mm, 46 g
+### NVMe Storage Recommendations
+
+For Raspberry Pi 5 with a PCIe HAT (e.g., Pimoroni NVMe Base, Radxa Penta SATA/NVMe HAT, or Pineberry Pi NVMe HAT):
+
+* **Minimum:** 500 GB NVMe M.2 SSD (2230 or 2280 form factor, depending on HAT)
+* **Recommended:** 1 TB+ NVMe SSD for comfortable Bitcoin full node + Lightning
+* **Interface:** PCIe 2.0 x1 via the Pi 5 FPC connector (max ~500 MB/s)
+* **Form factor:** M.2 2280 is most common; check your HAT's supported sizes
+* **TLC over QLC:** Prefer TLC NAND for better sustained write endurance under blockchain workloads
+* **Power draw:** M.2 SSDs typically draw 2-5W — ensure your power supply can handle Pi 5 + HAT + SSD + USB peripherals (5V/5A minimum, 5V/5A PD recommended)
+
+With RaspiBlitz v1.12+, the system can boot and run entirely from NVMe, eliminating the need for a microSD card as the OS drive.
+
+For a full compatibility list, see the [RPi PCIe NVMe adapter compatibility database](https://pipci.jeffgeerling.com/#m2-and-nvme-adapters) and [Pimoroni NVMe Base compatibility list](https://shop.pimoroni.com/products/nvme-base?variant=41219587178579).
+
+> **Note:** Avoid QLC NAND SSDs (e.g., Crucial P3 Plus) for node operation — they may exhibit high IO wait times under sustained write loads. See [issue #4745](https://github.com/raspiblitz/raspiblitz/issues/4745) for community discussion.
 
 ### Odroid HC1
 


### PR DESCRIPTION
## Summary

Updates hardware documentation to reflect current recommendations for NVMe storage on Raspberry Pi 5.

Closes #5220

## Changes

### `alternative.platforms/hw_comparison.md`
- **Added Raspberry Pi 5** as the recommended platform with full hardware specs (BCM2712, VideoCore VII, PCIe FPC connector, etc.)
- **Added NVMe Storage Recommendations section** covering:
  - Compatible PCIe HAT options (Pimoroni NVMe Base, Radxa Penta, Pineberry Pi)
  - SSD sizing guidance (min 500 GB, recommended 1 TB+)
  - TLC vs QLC NAND recommendation with QLC warning
  - Power draw considerations
  - Links to Jeff Geerling's Pi PCIe compatibility database and Pimoroni compatibility list
  - Reference to community discussion in #4745
- **Fixed Pi 4 RAM specs** — added missing 8GB variant
- **Reordered boards** — Pi 5 → Pi 4 → Pi 3B+ (newest first)
- **Added deprecation note** for Pi 3B+

### `README.md`
- Added **"Hardware Setup Guide & NVMe Recommendations"** link to quickstart section

### `alternative.platforms/README.md`
- Added NVMe storage note for Pi 5 with link to hw_comparison.md NVMe section