### PR TITLE
ci(amd64): improve Debian ISO resolution and add packer syntax check

### DIFF
--- a/.github/workflows/amd64-lean-image.yml
+++ b/.github/workflows/amd64-lean-image.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 12288
-          temp-reserve-mb: 12288
+          # Keep conservative reserves to avoid negative allocation sizes on runner images.
+          root-reserve-mb: 4096
+          temp-reserve-mb: 4096
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/amd64-lean-image.yml
+++ b/.github/workflows/amd64-lean-image.yml
@@ -34,9 +34,10 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          # Keep conservative reserves to avoid negative allocation sizes on runner images.
+          # Keep conservative reserves and a smaller swap size so temp PV sizing stays positive.
           root-reserve-mb: 4096
-          temp-reserve-mb: 4096
+          temp-reserve-mb: 2048
+          swap-size-mb: 1024
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/packer-syntax-check.yml
+++ b/.github/workflows/packer-syntax-check.yml
@@ -1,0 +1,60 @@
+name: Packer Syntax Check
+
+concurrency:
+  group: packer-syntax-check-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['dev', 'v1.10', 'v1.11']
+    paths:
+      - '.github/workflows/packer-syntax-check.yml'
+      - 'ci/amd64/**/*.pkr.hcl'
+      - 'ci/amd64/**/*.pkrvars.hcl'
+      - 'ci/amd64/packer.build.amd64-debian.sh'
+      - 'ci/arm64-rpi/**/*.pkr.hcl'
+      - 'ci/arm64-rpi/**/*.pkrvars.hcl'
+      - 'ci/arm64-rpi/packer.build.arm64-rpi.sh'
+  pull_request:
+    branches: ['dev', 'v1.10', 'v1.11']
+    paths:
+      - '.github/workflows/packer-syntax-check.yml'
+      - 'ci/amd64/**/*.pkr.hcl'
+      - 'ci/amd64/**/*.pkrvars.hcl'
+      - 'ci/amd64/packer.build.amd64-debian.sh'
+      - 'ci/arm64-rpi/**/*.pkr.hcl'
+      - 'ci/arm64-rpi/**/*.pkrvars.hcl'
+      - 'ci/arm64-rpi/packer.build.arm64-rpi.sh'
+
+jobs:
+  validate-packer-syntax:
+    name: Validate Packer Syntax
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Packer
+        uses: hashicorp/setup-packer@v3
+
+      - name: Show Packer version
+        run: packer version
+
+      - name: Validate templates and var files (syntax only)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t templates < <(find ci/amd64 ci/arm64-rpi -type f \( -name '*.pkr.hcl' -o -name '*.pkrvars.hcl' \) | sort)
+
+          if [ ${#templates[@]} -eq 0 ]; then
+            echo "No Packer templates found under ci/amd64 or ci/arm64-rpi"
+            exit 1
+          fi
+
+          for template in "${templates[@]}"; do
+            echo "Validating ${template}"
+            packer validate -syntax-only "${template}"
+          done

--- a/ci/amd64/debian/build.amd64-debian.pkr.hcl
+++ b/ci/amd64/debian/build.amd64-debian.pkr.hcl
@@ -1,8 +1,10 @@
 # images, checksums and signatures are at:
 # https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/
-# Defaults below are safe fallbacks.
-# ci/amd64/packer.build.amd64-debian.sh resolves and injects the latest point-release
-# ISO name and matching checksum at runtime to avoid point-release breakage.
+# NOTE: This template is intended to be invoked via the wrapper script:
+#   ci/amd64/packer.build.amd64-debian.sh
+# The wrapper resolves and injects the latest point-release ISO name and matching checksum
+# at runtime. Defaults below are placeholders and are not guaranteed to work if you run
+# `packer build` directly.
 variable "iso_name" { default = "debian-13-amd64-netinst.iso" }
 variable "iso_checksum" { default = "file:https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS" }
 

--- a/ci/amd64/debian/build.amd64-debian.pkr.hcl
+++ b/ci/amd64/debian/build.amd64-debian.pkr.hcl
@@ -1,7 +1,10 @@
 # images, checksums and signatures are at:
 # https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/
-variable "iso_name" { default = "debian-13.2.0-amd64-netinst.iso" }
-variable "iso_checksum" { default = "677c4d57aa034dc192b5191870141057574c1b05df2b9569c0ee08aa4e32125d" }
+# Defaults below are safe fallbacks.
+# ci/amd64/packer.build.amd64-debian.sh resolves and injects the latest point-release
+# ISO name and matching checksum at runtime to avoid point-release breakage.
+variable "iso_name" { default = "debian-13-amd64-netinst.iso" }
+variable "iso_checksum" { default = "file:https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS" }
 
 variable "pack" { default = "lean" }
 variable "github_user" { default = "raspiblitz" }
@@ -59,7 +62,7 @@ source "qemu" "debian" {
   disk_size        = var.image_size
   http_directory   = "./http"
   iso_checksum     = var.iso_checksum
-  iso_url          = "https://cdimage.debian.org/cdimage/release/current/amd64/iso-cd/${var.iso_name}"
+  iso_url          = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/${var.iso_name}"
   memory           = var.memory
   output_directory = "../builds/${local.name_template}-qemu"
   shutdown_command = "echo 'raspiblitz' | sudo /sbin/shutdown -hP now"

--- a/ci/amd64/packer.build.amd64-debian.sh
+++ b/ci/amd64/packer.build.amd64-debian.sh
@@ -23,6 +23,103 @@ echo "# Setting the variables: $*"
 source ../set_variables.sh
 set_variables "$@"
 
+# Resolve latest Debian 13 amd64 netinst ISO from SHA256SUMS.
+# This avoids 404s and checksum mismatches when Debian point releases rotate.
+debian_major=${DEBIAN_MAJOR:-13}
+debian_iso_dir="https://cdimage.debian.org/debian-cd/current/amd64/iso-cd"
+debian_sums_url="${debian_iso_dir}/SHA256SUMS"
+debian_sums_sig_url="${debian_iso_dir}/SHA256SUMS.sign"
+debian_cd_key_urls=(
+  "https://www.debian.org/CD/key-DA87E80D6294BE9B.txt"
+  "https://www.debian.org/CD/key-988021A964E6EA7D.txt"
+)
+debian_cd_expected_fprs=(
+  "DF9B9C49EAA9298432589D76DA87E80D6294BE9B"
+  "10460DAD76165AD81FBC0CE9988021A964E6EA7D"
+)
+
+if ! command -v gpgv >/dev/null 2>&1; then
+  echo "# Installing gpgv"
+  sudo apt-get install -y gpgv
+fi
+
+if ! command -v gpgv >/dev/null 2>&1; then
+  echo "ERROR: gpgv is required for signature verification"
+  exit 1
+fi
+
+tmp_checksums_dir=$(mktemp -d)
+trap 'rm -rf "${tmp_checksums_dir}"' EXIT
+
+echo "# Downloading checksum files"
+curl -fsSL "${debian_sums_url}" -o "${tmp_checksums_dir}/SHA256SUMS"
+curl -fsSL "${debian_sums_sig_url}" -o "${tmp_checksums_dir}/SHA256SUMS.sign"
+
+echo "# Verifying SHA256SUMS signature (PGP)"
+cd_keyring="${tmp_checksums_dir}/debian-cd-signing-keys.gpg"
+tmp_gnupg_home="${tmp_checksums_dir}/gnupg-home"
+mkdir -p "${tmp_gnupg_home}"
+chmod 700 "${tmp_gnupg_home}"
+
+for i in "${!debian_cd_key_urls[@]}"; do
+  key_url="${debian_cd_key_urls[$i]}"
+  expected_fpr="${debian_cd_expected_fprs[$i]}"
+  key_file="${tmp_checksums_dir}/cd-key-${i}.asc"
+  curl -fsSL "${key_url}" -o "${key_file}"
+  actual_fpr=$(gpg --homedir "${tmp_gnupg_home}" --show-keys --with-colons "${key_file}" 2>/dev/null | awk -F: '/^fpr:/ {print $10; exit}')
+  if [ -z "${actual_fpr}" ] || [ "${actual_fpr}" != "${expected_fpr}" ]; then
+    echo "# SHA256SUMS signature: FAIL"
+    echo "ERROR: Unexpected fingerprint for ${key_url}"
+    exit 1
+  fi
+  gpg --homedir "${tmp_gnupg_home}" --no-default-keyring --keyring "${cd_keyring}" --import "${key_file}" >/dev/null 2>&1
+done
+
+if gpgv --keyring "${cd_keyring}" "${tmp_checksums_dir}/SHA256SUMS.sign" "${tmp_checksums_dir}/SHA256SUMS" >/dev/null 2>&1; then
+  echo "# SHA256SUMS signature: PASS"
+else
+  echo "# SHA256SUMS signature: FAIL"
+  echo "ERROR: PGP signature verification failed for ${debian_sums_url}"
+  exit 1
+fi
+
+echo "# Resolving latest Debian ${debian_major} amd64 netinst ISO from ${debian_sums_url}"
+latest_iso_line=$(awk -v major="${debian_major}" '$2 ~ ("^\\*?\\.?/?debian-" major "\\.[0-9]+\\.[0-9]+-amd64-netinst\\.iso$") {print $1 " " $2}' "${tmp_checksums_dir}/SHA256SUMS" | \
+  sort -k2 -V | tail -1)
+
+if [ -z "${latest_iso_line}" ]; then
+  echo "ERROR: Could not resolve latest Debian ${debian_major} amd64 netinst ISO from ${debian_sums_url}"
+  exit 1
+fi
+
+latest_iso_checksum=$(echo "${latest_iso_line}" | awk '{print $1}')
+latest_iso_name=$(echo "${latest_iso_line}" | awk '{print $2}' | sed 's#^\*##; s#^\./##; s#^/##')
+
+if [ -z "${latest_iso_name}" ] || [ -z "${latest_iso_checksum}" ]; then
+  echo "ERROR: Failed parsing ISO name/checksum from: ${latest_iso_line}"
+  exit 1
+fi
+
+resolved_checksum=$(awk -v iso="${latest_iso_name}" '($2 == iso || $2 == "*" iso || $2 == "./" iso || $2 == "/" iso) {print $1; exit}' "${tmp_checksums_dir}/SHA256SUMS")
+if [ -z "${resolved_checksum}" ]; then
+  echo "ERROR: Could not find checksum entry for ${latest_iso_name} in ${debian_sums_url}"
+  exit 1
+fi
+
+echo "# Debian ISO selection"
+echo "# ISO filename      : ${latest_iso_name}"
+echo "# SHA256 (selected) : ${latest_iso_checksum}"
+echo "# SHA256 (resolved) : ${resolved_checksum}"
+if [ "${latest_iso_checksum}" = "${resolved_checksum}" ]; then
+  echo "# Checksum verify   : PASS"
+else
+  echo "# Checksum verify   : FAIL"
+  echo "ERROR: Checksum mismatch for ${latest_iso_name}"
+  exit 1
+fi
+
+vars="${vars} -var iso_name=${latest_iso_name} -var iso_checksum=${latest_iso_checksum}"
+
 # Build the image
 echo "# Build the image ..."
 cd debian


### PR DESCRIPTION
Port Debian amd64 build reliability improvements for rolling point releases and checksum signature verification, plus CI syntax validation for Packer templates.

Reference: https://github.com/openoms/joininbox/pull/181
