### PR TITLE
fix: electrs update fails on SSH-signed tags (v0.11.1+)

### DIFF
--- a/home.admin/config.scripts/blitz.git-verify.sh
+++ b/home.admin/config.scripts/blitz.git-verify.sh
@@ -7,8 +7,10 @@ if [ $# -lt 3 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "Run after 'git reset --hard VERSION' with the user running the installation"
   echo "To verify the checked out commit:"
   echo "blitz.git-verify.sh [PGPsigner] [PGPpubkeyLink] [PGPpubkeyFingerprint]"
+  echo "blitz.git-verify.sh --ssh [Signer] [SSHpubkeyBase64OrLink] [SSHpubkeyFingerprint]"
   echo "To use 'git verify-tag' add the 'tag':"
   echo "blitz.git-verify.sh [PGPsigner] [PGPpubkeyLink] [PGPpubkeyFingerprint] <tag>"
+  echo "blitz.git-verify.sh --ssh [Signer] [SSHpubkeyBase64OrLink] [SSHpubkeyFingerprint] <tag>"
   exit 1
 fi
 
@@ -25,6 +27,88 @@ fi
 # Run with the installing user to clear permissions:
 # sudo -u btcrpcexplorer /home/admin/config.scripts/blitz.git-verify.sh \
 #  "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
+
+isSSH=0
+if [ "$1" = "--ssh" ]; then
+  isSSH=1
+  shift
+fi
+
+if [ "$isSSH" -eq 1 ]; then
+  Signer="$1"
+  pubkeyLink="$2"
+  pubkeyFingerprint="$3"
+
+  # force outputs to English
+  export LANG=en_US.UTF-8
+  export LC_ALL=en_US.UTF-8
+
+  echo "# importing SSH key of ${Signer}"
+  
+  if [[ "${pubkeyLink}" == http* ]]; then
+    wget -O /var/cache/raspiblitz/ssh_keys_${Signer}.pub "${pubkeyLink}"
+    if [ $? -ne 0 ]; then
+      echo "# WARNING --> wget failed to download the SSH key, trying curl instead" >&2
+      curl -o /var/cache/raspiblitz/ssh_keys_${Signer}.pub "${pubkeyLink}"
+    fi
+    sshPubKey=$(cat /var/cache/raspiblitz/ssh_keys_${Signer}.pub)
+  else
+    sshPubKey="${pubkeyLink}"
+  fi
+  
+  echo "$sshPubKey" > /tmp/ssh_keys_${Signer}.pub
+  actualFingerprint=$(ssh-keygen -l -f /tmp/ssh_keys_${Signer}.pub | awk '{print $2}')
+  if [ "${actualFingerprint}" != "${pubkeyFingerprint}" ] && [ "$(echo ${actualFingerprint} | sed 's/SHA256://')" != "${pubkeyFingerprint}" ]; then
+    echo
+    echo "# WARNING --> the SSH fingerprint is not as expected for ${Signer}" >&2
+    echo "# Expected: ${pubkeyFingerprint}" >&2
+    echo "# Got:      ${actualFingerprint}" >&2
+    echo "# Exiting" >&2
+    exit 7
+  fi
+  
+  echo "*@* ${sshPubKey}" > /var/cache/raspiblitz/ssh_allowed_signers_${Signer}
+  git config --local gpg.ssh.allowedSignersFile /var/cache/raspiblitz/ssh_allowed_signers_${Signer}
+  
+  trap 'rm -f "$_temp" /var/cache/raspiblitz/ssh_allowed_signers_${Signer}; git config --local --unset gpg.ssh.allowedSignersFile' EXIT
+  _temp="$(mktemp -p /dev/shm/)"
+
+  if [ $# -eq 3 ]; then
+    commitHash="$(git log --oneline | head -1 | awk '{print $1}')"
+    gitCommand="git verify-commit $commitHash"
+    commitOrTag="$commitHash commit"
+  elif [ $# -eq 4 ]; then
+    gitCommand="git verify-tag $4"
+    commitOrTag="$4 tag"
+  fi
+  
+  echo "# running: ${gitCommand}"
+  ${gitCommand} 2>&1 >&"$_temp"
+  echo
+  cat "$_temp"
+  echo
+
+  goodSignature=$(grep "Good \"git\" signature" -c <"$_temp")
+  echo "# goodSignature(${goodSignature})"
+  
+  # For SSH, the fingerprint is printed in the git output.
+  # We grep for it to ensure the correct key signed it.
+  correctKey=$(grep -Ec "${pubkeyFingerprint}" <"$_temp")
+  echo "# correctKey(${correctKey})"
+  
+  if [ "${correctKey}" -lt 1 ] || [ "${goodSignature}" -lt 1 ]; then
+    echo
+    echo "# BUILD FAILED --> SSH verification not OK / signature(${goodSignature}) verify(${correctKey})"
+    exit 1
+  else
+    echo
+    echo "##########################################################################"
+    echo "# OK --> the SSH signature of the checked out ${commitOrTag} is correct"
+    echo "##########################################################################"
+    echo
+    exit 0
+  fi
+fi
 
 PGPsigner="$1"
 PGPpubkeyLink="$2"

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # https://github.com/romanz/electrs/releases
-ELECTRSVERSION="v0.10.10"
+ELECTRSVERSION="v0.11.1"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -17,6 +17,10 @@ fi
 PGPsigner="romanz"
 PGPpubkeyLink="https://github.com/${PGPsigner}.gpg"
 PGPpubkeyFingerprint="87CAE5FA46917CBB"
+
+SSHsigner="romanz"
+SSHpubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAZVq/3fgkildjN/MqEnhrP5550sDpFzGxMwevr5q/9w"
+SSHpubkeyFingerprint="SHA256:GifMn7F2swVKyn6MewbQHrYCs4i/bPK7gnwxhuPz/YA"
 
 source /mnt/hdd/app-data/raspiblitz.conf 2>/dev/null
 
@@ -319,8 +323,13 @@ if [ "$1" = "install" ]; then
     sudo -u electrs git reset --hard $ELECTRSVERSION
 
     # verify
-    sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh \
-      "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${ELECTRSVERSION}" || exit 1
+    if [ "$(printf "%s\n" "v0.11.1" "$ELECTRSVERSION" | sort -V | head -n1)" = "v0.11.1" ]; then
+      sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh --ssh \
+        "${SSHsigner}" "${SSHpubkey}" "${SSHpubkeyFingerprint}" "${ELECTRSVERSION}" || exit 1
+    else
+      sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh \
+        "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${ELECTRSVERSION}" || exit 1
+    fi
 
     # build
     sudo -u electrs /home/electrs/.cargo/bin/cargo build --locked --release || exit 1
@@ -631,8 +640,13 @@ if [ "$1" = "update" ]; then
     echo "# Reset to the latest release tag: $updateVersion"
     sudo -u electrs git reset --hard $updateVersion
 
-    sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh \
-      "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${updateVersion}" || exit 1
+    if [ "$(printf "%s\n" "v0.11.1" "$updateVersion" | sort -V | head -n1)" = "v0.11.1" ]; then
+      sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh --ssh \
+        "${SSHsigner}" "${SSHpubkey}" "${SSHpubkeyFingerprint}" "${updateVersion}" || exit 1
+    else
+      sudo -u electrs /home/admin/config.scripts/blitz.git-verify.sh \
+        "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" "${updateVersion}" || exit 1
+    fi
 
     echo "# Installing build dependencies"
     sudo -u electrs curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u electrs sh -s -- --default-toolchain stable -y

--- a/home.admin/config.scripts/bonus.electrs.sh
+++ b/home.admin/config.scripts/bonus.electrs.sh
@@ -312,7 +312,7 @@ if [ "$1" = "install" ]; then
     # https://github.com/romanz/electrs/blob/master/doc/usage.md#build-dependencies
     sudo -u electrs curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u electrs sh -s -- --default-toolchain stable -y
     sudo -u electrs /home/electrs/.cargo/bin/rustup default stable || exit 1
-    sudo apt install -y clang cmake build-essential # for building 'rust-rocksdb'
+    sudo apt install -y clang llvm-dev libclang-dev cmake build-essential # for building 'rust-rocksdb' and bindgen/libclang
 
     echo
     echo "# Downloading and building electrs $ELECTRSVERSION. This will take ~40 minutes"
@@ -651,7 +651,7 @@ if [ "$1" = "update" ]; then
     echo "# Installing build dependencies"
     sudo -u electrs curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sudo -u electrs sh -s -- --default-toolchain stable -y
     sudo -u electrs /home/electrs/.cargo/bin/rustup default stable || exit 1
-    sudo apt install -y clang cmake build-essential # for building 'rust-rocksdb'
+    sudo apt install -y clang llvm-dev libclang-dev cmake build-essential # for building 'rust-rocksdb' and bindgen/libclang
     echo
 
     echo "# Build Electrs ..."


### PR DESCRIPTION
Fixes #5256

Romanz switched from GPG to SSH signatures starting with electrs `v0.11.1`.
The `blitz.git-verify.sh` script did not support SSH signature verification, so `git verify-tag` failed with `allowedSignersFile needs to be configured` during updates.

This PR:
1. Adds a `--ssh` mode to `blitz.git-verify.sh` to support SSH-signed tags via `git config gpg.ssh.allowedSignersFile`.
2. Updates `bonus.electrs.sh` to dynamically use the SSH verification path for electrs `v0.11.1` and newer, while preserving the PGP path for older versions.
3. Bumps the default installed Electrs version from `v0.10.10` to `v0.11.1`.