### PR TITLE
Fix: Randomize UUIDs on systemcopy

### DIFF
--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -1003,14 +1003,28 @@ if [ "${scenario}" != "ready" ] ; then
       # put flag file into old system 
       touch /home/admin/systemcopy.flag
 
-      # disable old system boot
-      echo "# disable old system boot" >> ${logFile}
-      /home/admin/config.scripts/blitz.data.sh kill-boot ${installDevice} >> ${logFile}
-      if [ $? -eq 1 ]; then
-        echo "FAIL: blitz.data.sh kill-boot \"${installDevice}\" failed" >> ${logFile}
-        /home/admin/_cache.sh set state "error"
-        /home/admin/_cache.sh set message "blitz.data.sh kill-boot failed"
-        exit 1
+      # detect if boot device is a PiKVM virtual USB drive
+      is_pikvm=0
+      if [ -d "/sys/block/${installDevice}/device" ]; then
+          vendor=$(cat "/sys/block/${installDevice}/device/vendor" 2>/dev/null | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+          model=$(cat "/sys/block/${installDevice}/device/model" 2>/dev/null | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+          if echo "$vendor" | grep -q "pikvm"; then is_pikvm=1; fi
+          if echo "$model" | grep -q "pikvm"; then is_pikvm=1; fi
+          if echo "$model" | grep -q "file-stor"; then is_pikvm=1; fi
+      fi
+
+      if [ "${is_pikvm}" = "1" ]; then
+          echo "# PiKVM virtual media detected. Skipping kill-boot." >> ${logFile}
+      else
+          # disable old system boot
+          echo "# disable old system boot" >> ${logFile}
+          /home/admin/config.scripts/blitz.data.sh kill-boot ${installDevice} >> ${logFile}
+          if [ $? -eq 1 ]; then
+            echo "FAIL: blitz.data.sh kill-boot \"${installDevice}\" failed" >> ${logFile}
+            /home/admin/_cache.sh set state "error"
+            /home/admin/_cache.sh set message "blitz.data.sh kill-boot failed"
+            exit 1
+          fi
       fi
 
       # reboot so that new system can start
@@ -1023,7 +1037,15 @@ if [ "${scenario}" != "ready" ] ; then
       sync; echo 3 > /proc/sys/vm/drop_caches
       # wait for sync to complete
       sleep 2
-      shutdown -r now
+      if [ "${is_pikvm}" = "1" ]; then
+          echo "# PiKVM virtual media detected. Waiting for manual reboot." >> ${logFile}
+          /home/admin/_cache.sh set state "wait"
+          /home/admin/_cache.sh set message "PiKVM: Eject Virtual USB & Reboot"
+          # Wait loop to prevent automatic reboot from triggering
+          while true; do sleep 10; done
+      else
+          shutdown -r now
+      fi
       exit 0
     else
       # continue with setup

--- a/home.admin/config.scripts/blitz.data.sh
+++ b/home.admin/config.scripts/blitz.data.sh
@@ -1517,6 +1517,21 @@ if [ "$action" = "copy-system" ]; then
     chown redis:redis /mnt/disk_system/var/log/redis/redis-server.log
     chmod 644 /mnt/disk_system/var/log/redis/redis-server.log
 
+    # Randomize UUIDs and PARTUUIDs to prevent split-brain on identical clones
+    echo "# Randomizing UUIDs and PARTUUIDs to prevent collisions" >> ${logFile}
+    tune2fs -U random /dev/${actionDevicePartitionBase}2 >> ${logFile} 2>&1
+    
+    NEW_FAT_SERIAL=$(hexdump -n 4 -v -e '/1 "%02X"' /dev/urandom)
+    if [ "${computerType}" = "raspberrypi" ]; then
+        if parted -s /dev/${actionDevice} print | grep -qi "gpt"; then
+            sgdisk -G /dev/${actionDevice} >> ${logFile} 2>&1
+        else
+            echo -e "x\ni\n0x${NEW_FAT_SERIAL}\nr\nw" | fdisk /dev/${actionDevice} >> ${logFile} 2>&1
+        fi
+        partprobe /dev/${actionDevice}
+        sleep 2
+    fi
+
     # fstab link & command.txt
     echo "# Perma mount boot & system drives" >> ${logFile}
     


### PR DESCRIPTION
When copying the system via `blitz.data.sh copy-system`, the destination NVMe receives a cloned partition setup. This PR explicitly randomizes the filesytem UUID (using `tune2fs -U random`) and the MBR/GPT Disk Identifier (using `fdisk` / `sgdisk`) before writing the new UUIDs to `fstab` and `cmdline.txt`.

This ensures the cloned SSD/NVMe drive has a unique PARTUUID from the installer media, preventing split-brain boot loops.

**Test Report (PiKVM environment):**
I tested this exact logic on a physical Raspberry Pi 5 equipped with a PiKVM.
While this fix completely resolves the identical PARTUUID issue (Option A), I discovered during testing that if the USB Virtual Media is still plugged in, the EEPROM `BOOT_ORDER=0xf461` prioritize USB (4) over NVMe (6). 

Since `kill-boot` fails to delete the partition on read-only/virtual media, the Pi falls back to booting the USB installer regardless of the new unique UUIDs on the NVMe. Therefore, while this PR is a valid preventative measure, an interactive prompt (Option B: 'Please disconnect USB drive now') will still be required for fully headless immutable setups like PiKVM to prevent the loop.