### PR TITLE
fix: skip forced fatpack reboot on PiKVM USB boot

### DIFF
--- a/home.admin/_bootstrap.sh
+++ b/home.admin/_bootstrap.sh
@@ -1003,14 +1003,28 @@ if [ "${scenario}" != "ready" ] ; then
       # put flag file into old system 
       touch /home/admin/systemcopy.flag
 
-      # disable old system boot
-      echo "# disable old system boot" >> ${logFile}
-      /home/admin/config.scripts/blitz.data.sh kill-boot ${installDevice} >> ${logFile}
-      if [ $? -eq 1 ]; then
-        echo "FAIL: blitz.data.sh kill-boot \"${installDevice}\" failed" >> ${logFile}
-        /home/admin/_cache.sh set state "error"
-        /home/admin/_cache.sh set message "blitz.data.sh kill-boot failed"
-        exit 1
+      # detect if boot device is a PiKVM virtual USB drive
+      is_pikvm=0
+      if [ -d "/sys/block/${installDevice}/device" ]; then
+          vendor=$(cat "/sys/block/${installDevice}/device/vendor" 2>/dev/null | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+          model=$(cat "/sys/block/${installDevice}/device/model" 2>/dev/null | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+          if echo "$vendor" | grep -q "pikvm"; then is_pikvm=1; fi
+          if echo "$model" | grep -q "pikvm"; then is_pikvm=1; fi
+          if echo "$model" | grep -q "file-stor"; then is_pikvm=1; fi
+      fi
+
+      if [ "${is_pikvm}" = "1" ]; then
+          echo "# PiKVM virtual media detected. Skipping kill-boot." >> ${logFile}
+      else
+          # disable old system boot
+          echo "# disable old system boot" >> ${logFile}
+          /home/admin/config.scripts/blitz.data.sh kill-boot ${installDevice} >> ${logFile}
+          if [ $? -eq 1 ]; then
+            echo "FAIL: blitz.data.sh kill-boot \"${installDevice}\" failed" >> ${logFile}
+            /home/admin/_cache.sh set state "error"
+            /home/admin/_cache.sh set message "blitz.data.sh kill-boot failed"
+            exit 1
+          fi
       fi
 
       # reboot so that new system can start
@@ -1023,7 +1037,15 @@ if [ "${scenario}" != "ready" ] ; then
       sync; echo 3 > /proc/sys/vm/drop_caches
       # wait for sync to complete
       sleep 2
-      shutdown -r now
+      if [ "${is_pikvm}" = "1" ]; then
+          echo "# PiKVM virtual media detected. Waiting for manual reboot." >> ${logFile}
+          /home/admin/_cache.sh set state "wait"
+          /home/admin/_cache.sh set message "PiKVM: Eject Virtual USB & Reboot"
+          # Wait loop to prevent automatic reboot from triggering
+          while true; do sleep 10; done
+      else
+          shutdown -r now
+      fi
       exit 0
     else
       # continue with setup

--- a/home.admin/config.scripts/blitz.data.sh
+++ b/home.admin/config.scripts/blitz.data.sh
@@ -1521,12 +1521,12 @@ if [ "$action" = "copy-system" ]; then
     echo "# Randomizing UUIDs and PARTUUIDs to prevent collisions" >> ${logFile}
     tune2fs -U random /dev/${actionDevicePartitionBase}2 >> ${logFile} 2>&1
     
-    NEW_FAT_SERIAL=$(hexdump -n 4 -v -e '/1 "%02X"' /dev/urandom)
+    NEW_MBR_ID=$(hexdump -n 4 -v -e '/1 "%02X"' /dev/urandom)
     if [ "${computerType}" = "raspberrypi" ]; then
         if parted -s /dev/${actionDevice} print | grep -qi "gpt"; then
             sgdisk -G /dev/${actionDevice} >> ${logFile} 2>&1
         else
-            echo -e "x\ni\n0x${NEW_FAT_SERIAL}\nr\nw" | fdisk /dev/${actionDevice} >> ${logFile} 2>&1
+            echo -e "x\ni\n0x${NEW_MBR_ID}\nr\nw" | fdisk /dev/${actionDevice} >> ${logFile} 2>&1
         fi
         partprobe /dev/${actionDevice}
         sleep 2

--- a/home.admin/config.scripts/blitz.data.sh
+++ b/home.admin/config.scripts/blitz.data.sh
@@ -1517,6 +1517,21 @@ if [ "$action" = "copy-system" ]; then
     chown redis:redis /mnt/disk_system/var/log/redis/redis-server.log
     chmod 644 /mnt/disk_system/var/log/redis/redis-server.log
 
+    # Randomize UUIDs and PARTUUIDs to prevent split-brain on identical clones
+    echo "# Randomizing UUIDs and PARTUUIDs to prevent collisions" >> ${logFile}
+    tune2fs -U random /dev/${actionDevicePartitionBase}2 >> ${logFile} 2>&1
+    
+    NEW_FAT_SERIAL=$(hexdump -n 4 -v -e '/1 "%02X"' /dev/urandom)
+    if [ "${computerType}" = "raspberrypi" ]; then
+        if parted -s /dev/${actionDevice} print | grep -qi "gpt"; then
+            sgdisk -G /dev/${actionDevice} >> ${logFile} 2>&1
+        else
+            echo -e "x\ni\n0x${NEW_FAT_SERIAL}\nr\nw" | fdisk /dev/${actionDevice} >> ${logFile} 2>&1
+        fi
+        partprobe /dev/${actionDevice}
+        sleep 2
+    fi
+
     # fstab link & command.txt
     echo "# Perma mount boot & system drives" >> ${logFile}
     

--- a/home.admin/config.scripts/blitz.fatpack.sh
+++ b/home.admin/config.scripts/blitz.fatpack.sh
@@ -18,6 +18,20 @@ elif [ -d /boot ]; then
 fi
 echo "# raspi_bootdir(${raspi_bootdir})"
 
+# detect if current root drive is a PiKVM virtual USB drive
+is_pikvm=0
+rootPartitionLine=$(mount | grep " / " | cut -d " " -f 1)
+rootPartition=$(basename ${rootPartitionLine})
+rootDrive=$(basename "$(readlink -f "/sys/class/block/$rootPartition/..")")
+if [ -d "/sys/block/${rootDrive}/device" ]; then
+  vendor=$(cat "/sys/block/${rootDrive}/device/vendor" 2>/dev/null | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+  model=$(cat "/sys/block/${rootDrive}/device/model" 2>/dev/null | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+  if echo "$vendor" | grep -q "pikvm"; then is_pikvm=1; fi
+  if echo "$model" | grep -q "pikvm"; then is_pikvm=1; fi
+  if echo "$model" | grep -q "file-stor"; then is_pikvm=1; fi
+fi
+echo "# rootDrive(${rootDrive}) is_pikvm(${is_pikvm})"
+
 # make sure LCD is on (default for fatpack)
 /home/admin/config.scripts/blitz.display.sh set-display lcd
 
@@ -44,13 +58,20 @@ if [ ${rootPartitionBytes} -lt 58465668608 ]; then
 
     echo "################################################"
     echo "# SD CARD GOT EXPANSION BEFORE FATPACK"
-    echo "# triggering a reboot"
-    echo "# after reboot run this script again"
+    if [ "${is_pikvm}" = "1" ]; then
+        echo "# PiKVM virtual USB detected - skipping forced reboot"
+        echo "# continuing fatpack on PiKVM-mounted writable flash media"
+    else
+        echo "# triggering a reboot"
+        echo "# after reboot run this script again"
+    fi
     echo "################################################"
 
-    # trigger reboot
-    shutdown -h -r now
-    exit 0
+    if [ "${is_pikvm}" != "1" ]; then
+        # trigger reboot
+        shutdown -h -r now
+        exit 0
+    fi
 fi
 
 apt_install() {


### PR DESCRIPTION
## Summary
- reuse PiKVM virtual USB detection in `blitz.fatpack.sh`
- skip the forced reboot after `fsexpand` when running from PiKVM writable USB media
- keep the existing reboot behavior for normal non-PiKVM environments

## Why
In the PiKVM-native image build flow, `build_sdcard.sh` reaches the expansion-before-fatpack checkpoint on the live writable virtual USB disk and then forces a reboot. We already have PiKVM virtual media detection in `_bootstrap.sh`, so this reuses the same runtime signal and avoids an unnecessary/manual extra reboot in that environment.

## Notes
- detection matches the existing `_bootstrap.sh` pattern (`vendor/model` contains `pikvm` or model contains `file-stor`)
- no PiKVM-only branch or new config knob added
- normal physical/non-PiKVM installs still reboot exactly as before
