### PR TITLE
Update BTCPayServer to v2.3.9 with .NET 10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## What's new in Version 1.12.2 of RaspiBlitz?
 
-- Update: BTCPayServer v2.3.5 [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v2.3.5)
+- Update: BTCPayServer v2.3.9 [details](https://github.com/btcpayserver/btcpayserver/releases/tag/v2.3.9)
 
 ## What's new in Version 1.12.1 of RaspiBlitz?
 

--- a/home.admin/config.scripts/bonus.btcpayserver.sh
+++ b/home.admin/config.scripts/bonus.btcpayserver.sh
@@ -2,10 +2,10 @@
 
 # Based on: https://gist.github.com/normandmickey/3f10fc077d15345fb469034e3697d0d0
 
-# https://github.com/dgarage/NBXplorer/tags
-NBXplorerVersion="v2.5.30"
+# https://github.com/btcpayserver/NBXplorer/tags
+NBXplorerVersion="v2.6.7"
 # https://github.com/btcpayserver/btcpayserver/releases
-BTCPayVersion="v2.3.5"
+BTCPayVersion="v2.3.9"
 
 # check who signed the release (person that published release)
 PGPsigner="nicolasdorier"
@@ -20,6 +20,43 @@ PGPpubkeyFingerprint="AB4CFA9895ACA0DBE27F6B346618763EF09186FE"
 # PGPpubkeyLink="https://github.com/web-flow.gpg"
 # PGPpubkeyFingerprint="B5690EEEBB952194"
 
+function DotNetInstall() {
+  echo "# install .NET"
+  # https://dotnet.microsoft.com/en-us/download/dotnet/10.0
+  sudo apt-get -y install libunwind8 gettext libssl1.0
+  cpu=$(uname -m)
+  if [ "${cpu}" = "aarch64" ]; then
+    binaryVersion="arm64"
+    dotNetdirectLink="https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.300/dotnet-sdk-10.0.300-linux-arm64.tar.gz"
+    dotNetChecksum="b503fe0cac8f8748d1ae67af40bc9157456cc0f93c8264e3bc52cc52a12fbbbc3a16e905d8528214f29337d7349859bb08de99b1e1406da92723b071b3f45ce5"
+  elif [ "${cpu}" = "x86_64" ]; then
+    binaryVersion="x64"
+    dotNetdirectLink="https://builds.dotnet.microsoft.com/dotnet/Sdk/10.0.300/dotnet-sdk-10.0.300-linux-x64.tar.gz"
+    dotNetChecksum="a0c404c1a2f85d70e32392ce297eb388c0310c519521b538a031a895469444c67f347d4f9ca1f8441f525967a89c9b75e2cd1676da486f95118cf4025c38d904"
+  else
+    echo "# FAIL! CPU (${cpu}) not supported."
+    echo "result='dotnet cpu not supported'"
+    exit 1
+  fi
+  dotNetName="dotnet-sdk-10.0.300-linux-${binaryVersion}.tar.gz"
+  sudo rm -f /home/btcpay/dotnet-sdk-*.tar.gz 2>/dev/null
+  sudo -u btcpay wget "${dotNetdirectLink}" -O "/home/btcpay/${dotNetName}"
+  # check binary is was not manipulated (checksum test)
+  actualChecksum=$(sha512sum /home/btcpay/${dotNetName} | cut -d " " -f1)
+  if [ "${actualChecksum}" != "${dotNetChecksum}" ]; then
+    echo "# FAIL # Downloaded ${dotNetName} not matching SHA512 checksum: ${dotNetChecksum}"
+    echo "result='dotnet wrong checksum'"
+    exit 1
+  fi
+  sudo rm -rf /home/btcpay/dotnet
+  sudo -u btcpay mkdir /home/btcpay/dotnet
+  sudo -u btcpay tar -xvf "/home/btcpay/${dotNetName}" -C /home/btcpay/dotnet
+  sudo rm -f /home/btcpay/*.tar.gz*
+  if ! grep -q "^DOTNET_CLI_TELEMETRY_OPTOUT=1$" /etc/environment; then
+    echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" | sudo tee -a /etc/environment
+  fi
+}
+
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "Config script to switch BTCPay Server on or off"
@@ -27,7 +64,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "bonus.btcpayserver.sh [install|uninstall]"
   echo "bonus.btcpayserver.sh [on|off|menu|write-tls-macaroon|cln-lightning-rpc-access]"
   echo "installs BTCPayServer $BTCPayVersion with NBXplorer $NBXplorerVersion"
-  echo "To update to the latest release published on github run:"
+  echo "To update to the configured release versions run:"
   echo "bonus.btcpayserver.sh update"
   echo
   exit 1
@@ -428,46 +465,16 @@ if [ "$1" = "install" ]; then
   sudo adduser --system --group --home /home/btcpay btcpay
   cd /home/btcpay || exit 1
 
-  echo "# install .NET"
-  # https://dotnet.microsoft.com/en-us/download/dotnet/8.0
-  sudo apt-get -y install libunwind8 gettext libssl1.0
-  cpu=$(uname -m)
-  if [ "${cpu}" = "aarch64" ]; then
-    binaryVersion="arm64"
-    dotNetdirectLink="https://download.visualstudio.microsoft.com/download/pr/853490db-6fd3-4c17-ad8e-9dbb61261252/3d36d7d5b861bbb219aa1a66af6e6fd2/dotnet-sdk-8.0.403-linux-arm64.tar.gz"
-    dotNetChecksum="f42e1ba9a897f91c8d734b09a9bfc82428f0629b7cdd9375262158d9f282797c199558c37ae7f36947e57d8adc61af9490595c4e6bbd05217fd6d05133dded4d"
-  elif [ "${cpu}" = "x86_64" ]; then
-    binaryVersion="x64"
-    dotNetdirectLink="https://download.visualstudio.microsoft.com/download/pr/ca6cd525-677e-4d3a-b66c-11348a6f920a/ec395f498f89d0ca4d67d903892af82d/dotnet-sdk-8.0.403-linux-x64.tar.gz"
-    dotNetChecksum="7aa03678228b174f51c4535f18348cdf7a5d35e243b1f8cb28a4a30e402e47567d06df63c8f6da4bdc3c7e898f54f4acc08d9952bfa49d3f220d0353253ac3e9"
-  else
-    echo "# FAIL! CPU (${cpu}) not supported."
-    echo "result='dotnet cpu not supported'"
-    exit 1
-  fi
-  dotNetName="dotnet-sdk-8.0.403-linux-${binaryVersion}.tar.gz"
-  sudo rm /home/btcpay/${dotnetName} 2>/dev/null
-  sudo -u btcpay wget "${dotNetdirectLink}" -O "${dotNetName}"
-  # check binary is was not manipulated (checksum test)
-  actualChecksum=$(sha512sum /home/btcpay/${dotNetName} | cut -d " " -f1)
-  if [ "${actualChecksum}" != "${dotNetChecksum}" ]; then
-    echo "# FAIL # Downloaded ${dotNetName} not matching SHA512 checksum: ${dotNetChecksum}"
-    echo "result='dotnet wrong checksum'"
-    exit 1
-  fi
-  sudo -u btcpay mkdir /home/btcpay/dotnet
-  sudo -u btcpay tar -xvf ${dotNetName} -C /home/btcpay/dotnet
-  sudo rm -f *.tar.gz*
-  echo "DOTNET_CLI_TELEMETRY_OPTOUT=1" | sudo tee -a /etc/environment
+  DotNetInstall
 
   # NBXplorer
   echo "# Install NBXplorer $NBXplorerVersion"
   cd /home/btcpay || exit 1
   echo "# Download the NBXplorer source code $NBXplorerVersion"
-  sudo -u btcpay git clone https://github.com/dgarage/NBXplorer.git
+  sudo -u btcpay git clone https://github.com/btcpayserver/NBXplorer.git
   if [ ! -d "/home/btcpay/NBXplorer" ]; then
     echo "# FAIL! on first git clone - retrying with snapshot download."
-    sudo -u btcpay curl -L https://github.com/dgarage/NBXplorer/archive/refs/tags/$NBXplorerVersion.tar.gz -o NBXplorer.tar.gz
+    sudo -u btcpay curl -L https://github.com/btcpayserver/NBXplorer/archive/refs/tags/$NBXplorerVersion.tar.gz -o NBXplorer.tar.gz
     sudo -u btcpay tar -xzvf NBXplorer.tar.gz
     sudo -u btcpay mv NBXplorer-* NBXplorer
     if [ ! -d "/home/btcpay/NBXplorer" ]; then
@@ -835,67 +842,44 @@ if [ "$1" = "restore" ]; then
 fi
 
 if [ "$1" = "update" ]; then
-  # Skip NBXplorer update for now
-  # echo "# Update NBXplorer"
-  # cd /home/btcpay || exit 1
-  # cd NBXplorer || exit 1
-  # # prevent the git error 'detected dubious ownership in repository'
-  # git config --global --add safe.directory /home/btcpay/NBXplorer
-  # # fetch latest master
-  # if [ "$(sudo -u btcpay git fetch 2>&1 | grep -c "Please tell me who you are")" -gt 0 ]; then
-  #   sudo -u btcpay git config user.email "you@example.com"
-  #   sudo -u btcpay git config user.name "Your Name"
-  # fi
-  # sudo -u btcpay git fetch
-  # # unset $1
-  # set --
-  # UPSTREAM=${1:-'@{u}'}
-  # LOCAL=$(git rev-parse @)
-  # REMOTE=$(git rev-parse "$UPSTREAM")
+  sudo systemctl stop btcpayserver 2>/dev/null
+  sudo systemctl stop nbxplorer 2>/dev/null
 
-  # if [ $LOCAL = $REMOTE ]; then
-  #   TAG=$(git tag | sort -V | tail -1)
-  #   echo "# Up-to-date on version $TAG"
-  # else
-  #   echo "# Pulling the latest changes..."
-  #   sudo -u btcpay git pull -p
-  #   TAG=$(git tag | sort -V | tail -1)
-  #   echo "# Reset to the latest release tag: $TAG"
-  #   sudo -u btcpay git reset --hard $TAG
+  DotNetInstall
 
-  #   PGPsigner="nicolasdorier"
-  #   PGPpubkeyLink="https://keybase.io/nicolasdorier/pgp_keys.asc"
-  #   PGPpubkeyFingerprint="AB4CFA9895ACA0DBE27F6B346618763EF09186FE"
-  #   if ! sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh \
-  #     "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}"; then
-  #     # try with webflow
-  #     PGPsigner="web-flow"
-  #     PGPpubkeyLink="https://github.com/web-flow.gpg"
-  #     PGPpubkeyFingerprint="B5690EEEBB952194"
-  #     sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh \
-  #       "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
-  #   fi
+  # prevent the git error 'detected dubious ownership in repository'
+  git config --global --add safe.directory /home/btcpay/NBXplorer
+  git config --global --add safe.directory /home/btcpay/btcpayserver
 
-  #   echo "# Build NBXplorer $TAG"
-  #   # from the build.sh with path
-  #   sudo systemctl stop nbxplorer
-  #   sudo -u btcpay /home/btcpay/dotnet/dotnet build -c Release NBXplorer/NBXplorer.csproj || exit 1
+  echo "# Update NBXplorer to $NBXplorerVersion"
+  cd /home/btcpay || exit 1
+  cd NBXplorer || exit 1
+  if [ "$(sudo -u btcpay git fetch --tags 2>&1 | grep -c "Please tell me who you are")" -gt 0 ]; then
+    sudo -u btcpay git config user.email "you@example.com"
+    sudo -u btcpay git config user.name "Your Name"
+    sudo -u btcpay git fetch --tags
+  fi
+  echo "# Reset NBXplorer to release tag: $NBXplorerVersion"
+  sudo -u btcpay git reset --hard "$NBXplorerVersion"
+  sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh \
+    "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}" || exit 1
 
-  #   # whitelist localhost in bitcoind
-  #   if ! sudo grep -Eq "^whitelist=127.0.0.1" /mnt/hdd/app-data/bitcoin/bitcoin.conf; then
-  #     echo "whitelist=127.0.0.1" | sudo tee -a /mnt/hdd/app-data/bitcoin/bitcoin.conf
-  #     echo "# Restarting bitcoind"
-  #     sudo systemctl restart bitcoind
-  #   fi
+  echo "# Build NBXplorer $NBXplorerVersion"
+  sudo -u btcpay /home/btcpay/dotnet/dotnet build -c Release NBXplorer/NBXplorer.csproj || exit 1
 
-  #   NBXplorerConfig
+  # whitelist localhost in bitcoind
+  if ! sudo grep -Eq "^whitelist=127.0.0.1" /mnt/hdd/app-data/bitcoin/bitcoin.conf; then
+    echo "whitelist=127.0.0.1" | sudo tee -a /mnt/hdd/app-data/bitcoin/bitcoin.conf
+    echo "# Restarting bitcoind"
+    sudo systemctl restart bitcoind
+  fi
 
-  #   sudo systemctl start nbxplorer
-  #   echo "# Updated NBXplorer to $TAG"
-  # fi
+  NBXplorerConfig
+  sudo systemctl start nbxplorer
+  echo "# Updated NBXplorer to $NBXplorerVersion"
 
   # always stop to BtcPayConfig
-  sudo systemctl stop btcpayserver
+  sudo systemctl stop btcpayserver 2>/dev/null
 
   BtcPayConfig
 
@@ -905,36 +889,24 @@ if [ "$1" = "update" ]; then
   echo "# Update BTCPayServer"
   cd /home/btcpay || exit 1
   cd btcpayserver || exit 1
-  # prevent the git error 'detected dubious ownership in repository'
-  git config --global --add safe.directory /home/btcpay/btcpayserver
-  # fetch latest master
-  if [ "$(sudo -u btcpay git fetch 2>&1 | grep -c "Please tell me who you are")" -gt 0 ]; then
+  if [ "$(sudo -u btcpay git fetch --tags 2>&1 | grep -c "Please tell me who you are")" -gt 0 ]; then
     sudo -u btcpay git config user.email "you@example.com"
     sudo -u btcpay git config user.name "Your Name"
+    sudo -u btcpay git fetch --tags
   fi
-  sudo -u btcpay git fetch
-  # unset $1
-  set --
-  UPSTREAM=${1:-'@{u}'}
-  LOCAL=$(git rev-parse @)
-  REMOTE=$(git rev-parse "$UPSTREAM")
+  echo "# Reset BTCPayServer to release tag: $BTCPayVersion"
+  sudo -u btcpay git reset --hard "$BTCPayVersion"
 
-  if [ $LOCAL = $REMOTE ]; then
-    TAG=$(git tag | grep v2 | sort -V | tail -1)
-    echo "# Up-to-date on version $TAG"
-  else
-    echo "# Pulling latest changes..."
-    sudo -u btcpay git pull -p
-    TAG=$(git tag | grep v2 | sort -V | tail -1)
-    echo "# Reset to the latest release tag: $TAG"
-    sudo -u btcpay git reset --hard $TAG
-    echo "# Build BTCPayServer $TAG"
-    # from the build.sh with path
-    sudo systemctl stop btcpayserver
-    sudo -u btcpay /home/btcpay/dotnet/dotnet build -c Release /home/btcpay/btcpayserver/BTCPayServer/BTCPayServer.csproj || exit 1
-    sudo systemctl start btcpayserver
-    echo "# Updated BTCPayServer to $TAG"
+  echo "# verify signature of ${PGPsigner}"
+  if ! sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}"; then
+    # try with webflow
+    sudo -u btcpay /home/admin/config.scripts/blitz.git-verify.sh "web-flow" "https://github.com/web-flow.gpg" "B5690EEEBB952194" || exit 1
   fi
+
+  echo "# Build BTCPayServer $BTCPayVersion"
+  sudo -u btcpay /home/btcpay/dotnet/dotnet build -c Release /home/btcpay/btcpayserver/BTCPayServer/BTCPayServer.csproj || exit 1
+  echo "# Updated BTCPayServer to $BTCPayVersion"
+
   # always start after BtcPayConfig
   sudo systemctl start btcpayserver
   exit 0


### PR DESCRIPTION
Follow-up for #5243 / requested in https://github.com/raspiblitz/raspiblitz/pull/5243#issuecomment-4487369559

This updates the PR branch from BTCPayServer v2.3.5 to the current v2.3.9 release and updates the dependent runtime pieces.

Changes:
- BTCPayServer v2.3.9
- NBXplorer v2.6.7
- .NET SDK 10.0.300 with linux arm64/x64 SHA512 hashes from the official .NET release manifest
- shared DotNetInstall path for install and update, so existing installs get .NET 10 before rebuilding
- update path restores NBXplorer updates and verifies both NBXplorer and BTCPayServer checked-out commits with Nicolas Dorier's key before build

Verified locally:
- bash -n home.admin/config.scripts/bonus.btcpayserver.sh
- git diff --check
- git verify-commit HEAD passes for btcpayserver/btcpayserver v2.3.9
- git verify-commit HEAD passes for btcpayserver/NBXplorer v2.6.7