### PR TITLE
fix: re-enable lnproxy install (fixes #4122)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ App updates, fixes and optimizations.
 - Update: JoininBox v0.8.5 [details](https://github.com/openoms/joininbox/releases/tag/v0.8.5)
 - Update: Jam v0.4.1 [details](https://github.com/joinmarket-webui/jam/releases/tag/v0.4.1)
 - Fix: Speedup data layout migration from 1.11.4 to 1.12.1 [details](https://github.com/raspiblitz/raspiblitz/issues/5194)
+- Fix: Re-enabled lnproxy install — repo URL, commit hash, and Go build fix [details](https://github.com/raspiblitz/raspiblitz/issues/4122)
 
 ## What's new in Version 1.12.0 of RaspiBlitz?
 

--- a/home.admin/00mainMenu.sh
+++ b/home.admin/00mainMenu.sh
@@ -132,9 +132,9 @@ fi
 if [ "${bos}" == "on" ]; then
   OPTIONS+=(BOS "Balance of Satoshis")
 fi
-#if [ "${lnproxy}" == "on" ]; then
-#  OPTIONS+=(LNPROXY "lnproxy server")
-#fi
+if [ "${lnproxy}" == "on" ]; then
+  OPTIONS+=(LNPROXY "lnproxy server")
+fi
 if [ "${pyblock}" == "on" ]; then
   OPTIONS+=(PYBLOCK "PyBlock")
 fi

--- a/home.admin/config.scripts/bonus.lnproxy.sh
+++ b/home.admin/config.scripts/bonus.lnproxy.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-# Deactivated - see https://github.com/raspiblitz/raspiblitz/issues/4122
-# Needs comitted maintainer or will be removed in future versions
-
-# https://github.com/lnproxy/lnproxy/commits/main
-LNPROXYVERSION="c1031bbe507623f8f196ff83aa5ea504cca05143"
+# https://github.com/lnproxy/lnproxy-relay/commits/main
+LNPROXYVERSION="f5670e7dc23f"
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
-  echo "DEACTIVATED FOR REPAIR - see #4122"
   echo "config script to install or uninstall the lnproxy server"
   echo "bonus.lnproxy.sh [on|off|menu]"
   echo "installs the version $LNPROXYVERSION by default"
@@ -81,19 +77,14 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   # download source code
   cd /home/lnproxy/ || exit 1
-  sudo -u lnproxy git clone https://github.com/lnproxy/lnproxy.git /home/lnproxy/lnproxy
+  sudo -u lnproxy git clone https://github.com/lnproxy/lnproxy-relay.git /home/lnproxy/lnproxy
   cd /home/lnproxy/lnproxy || exit 1
   sudo -u lnproxy git reset --hard ${LNPROXYVERSION} || exit 1
 
   # build
-  sudo -u lnproxy /usr/local/go/bin/go get lnproxy
-  if [ $? -ne 0 ]; then
-    echo "# FAIL -> go get lnproxy"
-    sudo userdel -rf lnproxy 2>/dev/null
-    exit 1
-  fi
-
-  sudo -u lnproxy /usr/local/go/bin/go build
+  # Change to the cloned directory for module-aware build
+  cd /home/lnproxy/lnproxy || exit 1
+  sudo -u lnproxy /usr/local/go/bin/go build -o lnproxy .
   if [ $? -ne 0 ]; then
     echo "# FAIL -> go build"
     sudo userdel -rf lnproxy 2>/dev/null
@@ -176,7 +167,7 @@ EOF
   echo "# The Tor Hidden Service address to share for using the API:"
   echo "${torAddress}/api"
   echo "# More info at:"
-  echo "https://github.com/lnproxy"
+  echo "https://github.com/lnproxy/lnproxy-relay"
 
   exit 0
 fi


### PR DESCRIPTION
## Fixes #4122 — lnproxy install broken

Two root causes identified and fixed:

### 1. Wrong clone URL
The script cloned `github.com/lnproxy/lnproxy.git` which returns 404. The actual repo is `github.com/lnproxy/lnproxy-relay.git`.

### 2. Deprecated `go get` usage
`/usr/local/go/bin/go get lnproxy` fails on Go 1.19+ because `go get` outside a module is no longer supported. The lnproxy-relay repo has a `go.mod` (module github.com/lnproxy/lnproxy-relay, go 1.20), so `go build -o lnproxy .` in the cloned directory is the correct approach.

### Additional changes:
- Updated `LNPROXYVERSION` to latest commit `f5670e7dc23f` from lnproxy-relay \`main\`
- Re-enabled the lnproxy entry in `00mainMenu.sh` (was commented out during deactivation)
- Updated `CHANGES.md`

### Verification on the fix:
- lnproxy-relay repo (github.com/lnproxy/lnproxy-relay) has a valid `go.mod` with module path `github.com/lnproxy/lnproxy-relay` and `go 1.20`
- `go build -o lnproxy .` will work because we're building in the module root directory
- The commit `f5670e7dc23f` is the latest on \`main\` (Oct 2024) with support for blinded paths
