### PR TITLE
Add Wasabi Wallet: client daemon (Services menu) + WabiSabi coordinator (bonus)

### DIFF
--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -17,6 +17,7 @@ if [ ${#fulcrum} -eq 0 ]; then fulcrum="off"; fi
 if [ ${#lndmanage} -eq 0 ]; then lndmanage="off"; fi
 if [ ${#joinmarket} -eq 0 ]; then joinmarket="off"; fi
 if [ ${#jam} -eq 0 ]; then jam="off"; fi
+if [ ${#wasabid} -eq 0 ]; then wasabid="off"; fi
 if [ ${#LNBits} -eq 0 ]; then LNBits="off"; fi
 if [ ${#mempoolExplorer} -eq 0 ]; then mempoolExplorer="off"; fi
 if [ ${#bos} -eq 0 ]; then bos="off"; fi
@@ -51,6 +52,7 @@ if [ "${network}" == "bitcoin" ]; then
   OPTIONS+=(aa 'BTC Mempool Space' ${mempoolExplorer})
   OPTIONS+=(ja 'BTC JoinMarket+JoininBox menu' ${joinmarket})
   OPTIONS+=(za 'BTC Jam (JoinMarket WebUI)' ${jam})
+  OPTIONS+=(wd 'BTC Wasabi Wallet (daemon + JSON-RPC)' ${wasabid})
   OPTIONS+=(wa 'BTC Download Bitcoin Whitepaper' ${whitepaper})
   OPTIONS+=(ls 'BTC Labelbase' ${labelbase})
   OPTIONS+=(pp 'BTC Publicpool (Solo Mining)' ${publicpool})  
@@ -605,6 +607,25 @@ Then try activating Jam again in SERVICES.\n
   fi
 else
   echo "Jam not changed."
+fi
+
+# Wasabi daemon (client wallet) process choice
+choice="off"; check=$(echo "${CHOICES}" | grep -c "wd")
+if [ ${check} -eq 1 ]; then choice="on"; fi
+if [ "${wasabid}" != "${choice}" ]; then
+  echo "Wasabi daemon setting changed .."
+  anychange=1
+  sudo /home/admin/config.scripts/bonus.wasabid.sh ${choice}
+  errorOnInstall=$?
+  if [ "${choice}" = "on" ]; then
+    if [ ${errorOnInstall} -eq 0 ]; then
+      sudo /home/admin/config.scripts/bonus.wasabid.sh menu
+    else
+      whiptail --title 'FAIL' --msgbox "Wasabi daemon installation is cancelled\nTry again from the menu or install from the terminal with:\nsudo /home/admin/config.scripts/bonus.wasabid.sh on" 9 65
+    fi
+  fi
+else
+  echo "Wasabi daemon not changed."
 fi
 
 # Mempool process choice

--- a/home.admin/00settingsMenuServices.sh
+++ b/home.admin/00settingsMenuServices.sh
@@ -610,7 +610,7 @@ else
 fi
 
 # Wasabi daemon (client wallet) process choice
-choice="off"; check=$(echo "${CHOICES}" | grep -c "wd")
+choice="off"; check=$(echo "${CHOICES}" | grep -cw "wd")
 if [ ${check} -eq 1 ]; then choice="on"; fi
 if [ "${wasabid}" != "${choice}" ]; then
   echo "Wasabi daemon setting changed .."

--- a/home.admin/_provision_.sh
+++ b/home.admin/_provision_.sh
@@ -569,6 +569,24 @@ else
   echo "Provisioning Specter - keep default" >> ${logFile}
 fi
 
+# Wasabi Wallet daemon (client)
+if [ "${wasabid}" = "on" ]; then
+  echo "Provisioning Wasabi daemon - run config script" >> ${logFile}
+  /home/admin/_cache.sh set message "Setup Wasabi daemon"
+  sudo /home/admin/config.scripts/bonus.wasabid.sh on >> ${logFile} 2>&1
+else
+  echo "Provisioning Wasabi daemon - keep default" >> ${logFile}
+fi
+
+# Wasabi (WabiSabi) coinjoin coordinator (advanced bonus, not in services menu)
+if [ "${wasabi}" = "on" ]; then
+  echo "Provisioning Wasabi coordinator - run config script" >> ${logFile}
+  /home/admin/_cache.sh set message "Setup Wasabi coordinator"
+  sudo /home/admin/config.scripts/bonus.wasabi.sh on >> ${logFile} 2>&1
+else
+  echo "Provisioning Wasabi coordinator - keep default" >> ${logFile}
+fi
+
 # BOS
 if [ "${bos}" = "on" ]; then
   echo "Provisioning Balance of Satoshis - run config script" >> ${logFile}

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -8,6 +8,9 @@
 # REQUIRES bitcoind with: txindex=1, blockfilterindex=1, peerblockfilters=1,
 # server=1. The 'on' step ensures these in bitcoin.conf and restarts bitcoind
 # (first-time block-filter indexing can take hours).
+#
+# The .NET SDK channel is read from the project's global.json, so this auto-installs
+# the right SDK as the project moves on (8.0 for v2.7.2, 10.0 for the next release).
 
 # Pin the source to the latest official release.
 VERSION="v2.7.2"
@@ -19,12 +22,14 @@ HOME_DIR="/home/${USERNAME}"
 # with uncommitted changes. A fresh path means install/update can never
 # git-reset/checkout over hand-modified source.
 SOURCE_DIR="${HOME_DIR}/wabisabi-coordinator"
+PUBLISH_DIR="${SOURCE_DIR}/publish"
 CSPROJ="WalletWasabi.Coordinator/WalletWasabi.Coordinator.csproj"
+DLL="WalletWasabi.Coordinator.dll"
 DATADIR="${HOME_DIR}/.walletwasabi/coordinator"
 DOTNET_DIR="${HOME_DIR}/.dotnet"
 DOTNET="${DOTNET_DIR}/dotnet"
-# .NET SDK channel; the project's global.json pins the exact feature band.
-DOTNET_CHANNEL="8.0"
+# fallback .NET channel if global.json cannot be read (real value derived at install)
+DOTNET_CHANNEL_FALLBACK="8.0"
 # coordinator public API port (Wasabi clients connect here); 5000 is the local-only port
 PUBLIC_PORT="37126"
 LOCAL_PORT="5000"
@@ -32,7 +37,6 @@ SERVICE="wasabicoordinator"
 
 RASPIBLITZ_INFO=/home/admin/raspiblitz.info
 RASPIBLITZ_CONF=/mnt/hdd/app-data/raspiblitz.conf
-BITCOIN_CONF=/mnt/hdd/app-data/bitcoin/bitcoin.conf
 
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
@@ -43,14 +47,44 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   exit 1
 fi
 
-# load raspiblitz config to know network state & Tor setting
+# load raspiblitz config to know network/chain, state & Tor setting
 source $RASPIBLITZ_INFO 2>/dev/null
 source $RASPIBLITZ_CONF 2>/dev/null
+
+# network awareness (RaspiBlitz: network=bitcoin, chain=main|test|sig|reg)
+network="${network:-bitcoin}"
+chain="${chain:-main}"
+BITCOIN_CONF="/mnt/hdd/app-data/${network}/${network}.conf"
+BITCOIND_SERVICE="${network}d"
+case "${chain}" in
+  main) WASABI_NET="Main" ;;
+  test) WASABI_NET="TestNet" ;;
+  reg)  WASABI_NET="RegTest" ;;
+  *)    WASABI_NET="Main" ;;
+esac
 
 # detect install/active state
 isInstalled=$(compgen -u | grep -c "^${USERNAME}$")
 isActive=$(sudo ls /etc/systemd/system/${SERVICE}.service 2>/dev/null | grep -c "${SERVICE}.service")
 localip=$(hostname -I | awk '{print $1}')
+
+# helper: derive + ensure the .NET SDK the project's global.json asks for
+ensure_dotnet_sdk() {
+  local channel
+  channel=$(grep -oE '"version"[^"]*"[0-9]+\.[0-9]+' "${SOURCE_DIR}/global.json" 2>/dev/null \
+            | grep -oE '[0-9]+\.[0-9]+$' | head -1)
+  [ -z "${channel}" ] && channel="${DOTNET_CHANNEL_FALLBACK}"
+  echo "# project needs .NET SDK channel ${channel} (from global.json)"
+  if ! sudo -u ${USERNAME} bash -c "DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} --list-sdks 2>/dev/null" \
+       | grep -q "^${channel}\."; then
+    echo "# installing .NET SDK ${channel} into ${DOTNET_DIR}"
+    sudo -u ${USERNAME} bash -c "curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh" || return 1
+    sudo -u ${USERNAME} bash /tmp/dotnet-install.sh --channel ${channel} --install-dir ${DOTNET_DIR} || return 1
+    rm -f /tmp/dotnet-install.sh
+  else
+    echo "# .NET SDK ${channel} already present"
+  fi
+}
 
 ###################
 # STATUS
@@ -61,6 +95,7 @@ if [ "$1" = "status" ]; then
   echo "version='${VERSION}'"
   echo "installed='${isActive}'"
   echo "running='${running}'"
+  echo "network='${WASABI_NET}'"
   echo "localIP='${localip}'"
   echo "publicPort='${PUBLIC_PORT}'"
   echo "localPort='${LOCAL_PORT}'"
@@ -89,16 +124,16 @@ Config & logs: ${DATADIR}"
 fi
 
 ###################
-# INSTALL (user + .NET + source + build)
+# INSTALL (user + source + .NET + publish)
 ###################
 if [ "$1" = "install" ]; then
 
-  if [ ${isInstalled} -gt 0 ] && [ -d "${SOURCE_DIR}" ]; then
+  if [ ${isInstalled} -gt 0 ] && [ -d "${PUBLISH_DIR}" ]; then
     echo "result='already installed'"
     exit 0
   fi
 
-  echo "# *** INSTALL WASABI COORDINATOR (user, .NET, source) ***"
+  echo "# *** INSTALL WASABI COORDINATOR (user, source, .NET, publish) ***"
 
   # dedicated user
   if [ ${isInstalled} -eq 0 ]; then
@@ -107,15 +142,8 @@ if [ "$1" = "install" ]; then
   fi
 
   # build dependencies (.NET needs libicu at runtime on ARM)
+  sudo apt-get update
   sudo apt-get install -y git curl libicu-dev || exit 1
-
-  # install the .NET SDK into the user's home (per-user, RaspiBlitz style)
-  if ! sudo -u ${USERNAME} ${DOTNET} --version 2>/dev/null | grep -q .; then
-    echo "# installing .NET SDK ${DOTNET_CHANNEL} into ${DOTNET_DIR}"
-    sudo -u ${USERNAME} bash -c "curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh"
-    sudo -u ${USERNAME} bash /tmp/dotnet-install.sh --channel ${DOTNET_CHANNEL} --install-dir ${DOTNET_DIR} || exit 1
-    rm -f /tmp/dotnet-install.sh
-  fi
 
   # source code
   if [ ! -d "${SOURCE_DIR}" ]; then
@@ -126,14 +154,18 @@ if [ "$1" = "install" ]; then
   sudo -u ${USERNAME} git fetch --tags --force 1>&2
   sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
 
-  # build the coordinator
-  echo "# building the coordinator (this can take a while on a Pi)"
-  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || {
-    echo "result='fail - dotnet build failed'"
+  # .NET SDK matching the project's global.json (auto-tracks the .NET 10 release)
+  ensure_dotnet_sdk || { echo "result='fail - dotnet sdk install failed'"; exit 1; }
+
+  # publish a self-contained-of-framework build (no rebuild/restore at service start)
+  echo "# publishing the coordinator (this can take a while on a Pi)"
+  sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} publish -c Release -o ${PUBLISH_DIR} ${CSPROJ}" || {
+    echo "result='fail - dotnet publish failed'"
     exit 1
   }
 
-  echo "# OK - Wasabi coordinator user, .NET and source installed"
+  echo "# OK - Wasabi coordinator user, source, .NET and publish installed"
   exit 0
 fi
 
@@ -177,7 +209,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   fi
 
   # make sure it is installed
-  if [ ${isInstalled} -eq 0 ] || [ ! -d "${SOURCE_DIR}" ]; then
+  if [ ${isInstalled} -eq 0 ] || [ ! -d "${PUBLISH_DIR}" ]; then
     sudo /home/admin/config.scripts/bonus.wasabi.sh install 1>&2 || exit 1
   fi
 
@@ -189,10 +221,9 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # --- ensure bitcoind has the indexes/filters the coordinator REQUIRES ---
   # Without these the coordinator cannot function: txindex (look up any tx) and
   # BIP158 compact block filters served to clients (blockfilterindex +
-  # peerblockfilters), plus the RPC server.
-  echo "# ensuring required bitcoin.conf settings"
-  # txindex via the dedicated RaspiBlitz helper (handles the reindex)
-  /home/admin/config.scripts/network.txindex.sh on 1>&2
+  # peerblockfilters), plus the RPC server. Edit the filter keys first, then let
+  # the txindex helper run; restart bitcoind only once.
+  echo "# ensuring required ${network}.conf settings"
   btcRestart=0
   for key in server blockfilterindex peerblockfilters; do
     if grep -Eq "^${key}=1" "${BITCOIN_CONF}"; then
@@ -202,30 +233,41 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     else
       echo "${key}=1" | sudo tee -a "${BITCOIN_CONF}" >/dev/null
     fi
-    echo "# set ${key}=1 in bitcoin.conf"
+    echo "# set ${key}=1 in ${network}.conf"
     btcRestart=1
   done
-  if [ ${btcRestart} -eq 1 ] && systemctl is-active bitcoind | grep -q "^active"; then
-    echo "# restarting bitcoind to apply block-filter settings"
+  # txindex via the dedicated helper - it restarts/reindexes itself if it changes
+  txindexBefore=$(grep -Eq "^txindex=1" "${BITCOIN_CONF}" && echo 1 || echo 0)
+  /home/admin/config.scripts/network.txindex.sh on 1>&2
+  # restart bitcoind for the filter changes only if the txindex helper did not already
+  if [ ${btcRestart} -eq 1 ] && [ "${txindexBefore}" = "1" ] && systemctl is-active ${BITCOIND_SERVICE} | grep -q "^active"; then
+    echo "# restarting ${BITCOIND_SERVICE} to apply block-filter settings"
     echo "# NOTE: first-time block-filter indexing can take hours; the coordinator"
     echo "#       will only serve clients once it has finished."
-    sudo systemctl restart bitcoind 1>&2
+    sudo systemctl restart ${BITCOIND_SERVICE} 1>&2
   fi
 
   # generate Config.json on first run, then patch in the bitcoind RPC details.
   # The coordinator writes a default Config.json (incl. a freshly generated
-  # CoordinatorExtPubKey) the first time it starts, so let it do that, then patch.
+  # CoordinatorExtPubKey) on first start. Run it (bound to localhost only),
+  # poll until the file appears, then stop it - no fragile fixed timeout.
   if [ ! -f "${DATADIR}/Config.json" ]; then
     echo "# first run: generating default Config.json ..."
-    sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ASPNETCORE_URLS='http://127.0.0.1:${LOCAL_PORT}' timeout 40 ${DOTNET} run -c Release --project ${CSPROJ}" 1>&2 2>/dev/null
+    sudo -u ${USERNAME} bash -c "HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ASPNETCORE_URLS='http://127.0.0.1:${LOCAL_PORT}' ${DOTNET} ${PUBLISH_DIR}/${DLL}" >/dev/null 2>&1 &
+    for i in $(seq 1 90); do
+      [ -f "${DATADIR}/Config.json" ] && break
+      sleep 2
+    done
+    sudo pkill -u ${USERNAME} -f "${DLL}" 2>/dev/null
+    sleep 1
   fi
 
   # read bitcoind RPC creds from bitcoin.conf and patch Config.json (Python, stdlib)
   if [ -f "${DATADIR}/Config.json" ] && [ -f "${BITCOIN_CONF}" ]; then
     echo "# wiring coordinator to bitcoind RPC"
-    sudo python3 - "${DATADIR}/Config.json" "${BITCOIN_CONF}" <<'PY'
+    sudo python3 - "${DATADIR}/Config.json" "${BITCOIN_CONF}" "${WASABI_NET}" <<'PY'
 import json, sys
-cfg_path, btc_path = sys.argv[1], sys.argv[2]
+cfg_path, btc_path, wnet = sys.argv[1], sys.argv[2], sys.argv[3]
 conf = {}
 for line in open(btc_path, encoding="utf-8", errors="replace"):
     line = line.strip()
@@ -237,8 +279,10 @@ pw = conf.get("rpcpassword", "")
 port = conf.get("rpcport", "8332")
 with open(cfg_path, encoding="utf-8-sig") as f:
     cfg = json.load(f)
-cfg["Network"] = "Main"
-cfg["MainNetBitcoinRpcUri"] = f"http://127.0.0.1:{port}"
+cfg["Network"] = wnet
+# URI key prefix: Main->MainNet, TestNet->TestNet, RegTest->RegTest
+prefix = "MainNet" if wnet == "Main" else wnet
+cfg[f"{prefix}BitcoinRpcUri"] = f"http://127.0.0.1:{port}"
 if user and pw:
     cfg["BitcoinRpcConnectionString"] = f"{user}:{pw}"
 with open(cfg_path, "w", encoding="utf-8") as f:
@@ -251,16 +295,16 @@ PY
     echo "# WARN: could not patch Config.json automatically - set BitcoinRpcConnectionString manually" 1>&2
   fi
 
-  # systemd service (mirrors the proven manual unit; builds on first start via 'dotnet run')
+  # systemd service - runs the published DLL directly (no build/restore at start)
   echo "# installing systemd service ${SERVICE}"
   echo "\
 [Unit]
 Description=Wasabi Coordinator daemon
-Requires=bitcoind.service
-After=bitcoind.service
+Requires=${BITCOIND_SERVICE}.service
+After=${BITCOIND_SERVICE}.service
 
 [Service]
-ExecStart=${DOTNET} run -c Release --project ${SOURCE_DIR}/${CSPROJ}
+ExecStart=${DOTNET} ${PUBLISH_DIR}/${DLL}
 Environment=HOME=${HOME_DIR}
 Environment=DOTNET_ROOT=${DOTNET_DIR}
 Environment=\"ASPNETCORE_URLS=http://0.0.0.0:${PUBLIC_PORT};http://127.0.0.1:${LOCAL_PORT}\"
@@ -297,7 +341,7 @@ WantedBy=multi-user.target
   # start if the system is ready
   source $RASPIBLITZ_INFO 2>/dev/null
   if [ "${state}" = "ready" ]; then
-    echo "# starting ${SERVICE} (first start compiles, may take minutes)"
+    echo "# starting ${SERVICE}"
     sudo systemctl start ${SERVICE} 1>&2
   else
     echo "# enabled; start manually with: sudo systemctl start ${SERVICE}"
@@ -361,11 +405,14 @@ if [ "$1" = "update" ]; then
   else
     sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
   fi
-  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || exit 1
+  # the new checkout may require a newer .NET SDK (e.g. 10.0) - ensure it
+  ensure_dotnet_sdk || exit 1
+  sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} publish -c Release -o ${PUBLISH_DIR} ${CSPROJ}" || exit 1
   if [ ${isActive} -gt 0 ]; then
     sudo systemctl restart ${SERVICE} 1>&2
   fi
-  echo "# OK - updated and rebuilt"
+  echo "# OK - updated and re-published"
   exit 0
 fi
 

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+
+# https://github.com/WalletWasabi/WalletWasabi  (WabiSabi coinjoin coordinator backend)
+#
+# The coinjoin.nl coordinator-specific changes are merged upstream (master/dev) and
+# ship in the next release. Until then, pull master with: bonus.wasabi.sh update commit
+
+# Pin the source to the latest official release.
+VERSION="v2.7.2"
+REPO="WalletWasabi/WalletWasabi"
+USERNAME="wasabi"
+HOME_DIR="/home/${USERNAME}"
+# dedicated clone path - deliberately NOT ${HOME_DIR}/WalletWasabi or
+# WalletWasabi-<ver>, which on an existing manual deployment may be a dev tree
+# with uncommitted changes. A fresh path means install/update can never
+# git-reset/checkout over hand-modified source.
+SOURCE_DIR="${HOME_DIR}/wabisabi-coordinator"
+CSPROJ="WalletWasabi.Coordinator/WalletWasabi.Coordinator.csproj"
+DATADIR="${HOME_DIR}/.walletwasabi/coordinator"
+DOTNET_DIR="${HOME_DIR}/.dotnet"
+DOTNET="${DOTNET_DIR}/dotnet"
+# .NET SDK channel; the project's global.json pins the exact feature band.
+DOTNET_CHANNEL="8.0"
+# coordinator public API port (Wasabi clients connect here); 5000 is the local-only port
+PUBLIC_PORT="37126"
+LOCAL_PORT="5000"
+SERVICE="wasabicoordinator"
+
+RASPIBLITZ_INFO=/home/admin/raspiblitz.info
+RASPIBLITZ_CONF=/mnt/hdd/app-data/raspiblitz.conf
+BITCOIN_CONF=/mnt/hdd/app-data/bitcoin/bitcoin.conf
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+  echo "config script to switch the Wasabi (WabiSabi) coinjoin coordinator on or off"
+  echo "bonus.wasabi.sh [install|uninstall]"
+  echo "bonus.wasabi.sh [on|off|status|menu]"
+  echo "bonus.wasabi.sh [update|update commit]"
+  exit 1
+fi
+
+# load raspiblitz config to know network state & Tor setting
+source $RASPIBLITZ_INFO 2>/dev/null
+source $RASPIBLITZ_CONF 2>/dev/null
+
+# detect install/active state
+isInstalled=$(compgen -u | grep -c "^${USERNAME}$")
+isActive=$(sudo ls /etc/systemd/system/${SERVICE}.service 2>/dev/null | grep -c "${SERVICE}.service")
+localip=$(hostname -I | awk '{print $1}')
+
+###################
+# STATUS
+###################
+if [ "$1" = "status" ]; then
+  toraddress=$(sudo cat /mnt/hdd/app-data/tor/${SERVICE}/hostname 2>/dev/null)
+  running=$(systemctl is-active ${SERVICE} 2>/dev/null | grep -c "^active$")
+  echo "version='${VERSION}'"
+  echo "installed='${isActive}'"
+  echo "running='${running}'"
+  echo "localIP='${localip}'"
+  echo "publicPort='${PUBLIC_PORT}'"
+  echo "localPort='${LOCAL_PORT}'"
+  echo "toraddress='${toraddress}'"
+  exit 0
+fi
+
+###################
+# MENU
+###################
+if [ "$1" = "menu" ]; then
+  if [ ${isActive} -eq 0 ]; then
+    echo "# *** WASABI COORDINATOR NOT INSTALLED ***"
+    exit 0
+  fi
+  toraddress=$(sudo cat /mnt/hdd/app-data/tor/${SERVICE}/hostname 2>/dev/null)
+  text="Wasabi (WabiSabi) coinjoin coordinator backend.\n
+Clients connect to the coordinator API on:
+http://${localip}:${PUBLIC_PORT}\n
+Config & logs: ${DATADIR}"
+  if [ "${runBehindTor}" = "on" ] && [ ${#toraddress} -gt 0 ]; then
+    text="${text}\n\nTor Hidden Service address:\n${toraddress}"
+  fi
+  whiptail --title " Wasabi Coordinator " --msgbox "${text}" 16 70
+  exit 0
+fi
+
+###################
+# INSTALL (user + .NET + source + build)
+###################
+if [ "$1" = "install" ]; then
+
+  if [ ${isInstalled} -gt 0 ] && [ -d "${SOURCE_DIR}" ]; then
+    echo "result='already installed'"
+    exit 0
+  fi
+
+  echo "# *** INSTALL WASABI COORDINATOR (user, .NET, source) ***"
+
+  # dedicated user
+  if [ ${isInstalled} -eq 0 ]; then
+    echo "# creating the ${USERNAME} user"
+    sudo adduser --system --group --home ${HOME_DIR} ${USERNAME} || exit 1
+  fi
+
+  # build dependencies (.NET needs libicu at runtime on ARM)
+  sudo apt-get install -y git curl libicu-dev || exit 1
+
+  # install the .NET SDK into the user's home (per-user, RaspiBlitz style)
+  if ! sudo -u ${USERNAME} ${DOTNET} --version 2>/dev/null | grep -q .; then
+    echo "# installing .NET SDK ${DOTNET_CHANNEL} into ${DOTNET_DIR}"
+    sudo -u ${USERNAME} bash -c "curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh"
+    sudo -u ${USERNAME} bash /tmp/dotnet-install.sh --channel ${DOTNET_CHANNEL} --install-dir ${DOTNET_DIR} || exit 1
+    rm -f /tmp/dotnet-install.sh
+  fi
+
+  # source code
+  if [ ! -d "${SOURCE_DIR}" ]; then
+    echo "# cloning ${REPO} @ ${VERSION}"
+    sudo -u ${USERNAME} git clone https://github.com/${REPO}.git ${SOURCE_DIR} || exit 1
+  fi
+  cd ${SOURCE_DIR} || exit 1
+  sudo -u ${USERNAME} git fetch --tags --force 1>&2
+  sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
+
+  # build the coordinator
+  echo "# building the coordinator (this can take a while on a Pi)"
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || {
+    echo "result='fail - dotnet build failed'"
+    exit 1
+  }
+
+  echo "# OK - Wasabi coordinator user, .NET and source installed"
+  exit 0
+fi
+
+###################
+# UNINSTALL
+###################
+if [ "$1" = "uninstall" ]; then
+  if [ ${isActive} -gt 0 ]; then
+    echo "result='still in use - switch off first'"
+    exit 1
+  fi
+  echo "# *** UNINSTALL WASABI COORDINATOR ***"
+  echo "# NOTE: keeping ${DATADIR} (holds the coordinator wallet xpub & keys)."
+  echo "#       Delete it manually only if you are sure you no longer need it."
+  # remove source + .NET, keep the data dir (it has the keys)
+  sudo rm -rf ${SOURCE_DIR} ${DOTNET_DIR}
+  exit 0
+fi
+
+###################
+# ON
+###################
+if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+
+  if [ ${isActive} -gt 0 ]; then
+    echo "# Wasabi coordinator already activated."
+    echo "result='OK'"
+    exit 0
+  fi
+
+  # SAFETY GUARD (first, before any install/build/mutation): do not clobber a
+  # pre-existing manual deployment. If a wasabicoordinator.service already exists
+  # but does NOT run from our dedicated SOURCE_DIR, abort - it was set up by hand
+  # and 'on' would overwrite the unit and patch its live Config.json.
+  if [ -f /etc/systemd/system/${SERVICE}.service ] && \
+     ! grep -q "${SOURCE_DIR}" /etc/systemd/system/${SERVICE}.service; then
+    echo "# ABORT: an existing ${SERVICE}.service was found that does not use ${SOURCE_DIR}." 1>&2
+    echo "# This looks like a manual deployment. Refusing to overwrite it." 1>&2
+    echo "result='fail - existing manual deployment detected'"
+    exit 1
+  fi
+
+  # make sure it is installed
+  if [ ${isInstalled} -eq 0 ] || [ ! -d "${SOURCE_DIR}" ]; then
+    sudo /home/admin/config.scripts/bonus.wasabi.sh install 1>&2 || exit 1
+  fi
+
+  echo "# *** ACTIVATING WASABI COORDINATOR ***"
+
+  # data dir
+  sudo -u ${USERNAME} mkdir -p ${DATADIR}
+
+  # generate Config.json on first run, then patch in the bitcoind RPC details.
+  # The coordinator writes a default Config.json (incl. a freshly generated
+  # CoordinatorExtPubKey) the first time it starts, so let it do that, then patch.
+  if [ ! -f "${DATADIR}/Config.json" ]; then
+    echo "# first run: generating default Config.json ..."
+    sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ASPNETCORE_URLS='http://127.0.0.1:${LOCAL_PORT}' timeout 40 ${DOTNET} run -c Release --project ${CSPROJ}" 1>&2 2>/dev/null
+  fi
+
+  # read bitcoind RPC creds from bitcoin.conf and patch Config.json (Python, stdlib)
+  if [ -f "${DATADIR}/Config.json" ] && [ -f "${BITCOIN_CONF}" ]; then
+    echo "# wiring coordinator to bitcoind RPC"
+    sudo python3 - "${DATADIR}/Config.json" "${BITCOIN_CONF}" <<'PY'
+import json, sys
+cfg_path, btc_path = sys.argv[1], sys.argv[2]
+conf = {}
+for line in open(btc_path, encoding="utf-8", errors="replace"):
+    line = line.strip()
+    if "=" in line and not line.startswith("#"):
+        k, _, v = line.partition("=")
+        conf[k.strip().split(".")[-1]] = v.strip()  # drop main./test. prefixes
+user = conf.get("rpcuser", "")
+pw = conf.get("rpcpassword", "")
+port = conf.get("rpcport", "8332")
+with open(cfg_path, encoding="utf-8-sig") as f:
+    cfg = json.load(f)
+cfg["Network"] = "Main"
+cfg["MainNetBitcoinRpcUri"] = f"http://127.0.0.1:{port}"
+if user and pw:
+    cfg["BitcoinRpcConnectionString"] = f"{user}:{pw}"
+with open(cfg_path, "w", encoding="utf-8") as f:
+    json.dump(cfg, f, indent=2)
+print("# Config.json patched (RPC URI + connection string)")
+PY
+    sudo chown ${USERNAME}:${USERNAME} "${DATADIR}/Config.json"
+    sudo chmod 600 "${DATADIR}/Config.json"
+  else
+    echo "# WARN: could not patch Config.json automatically - set BitcoinRpcConnectionString manually" 1>&2
+  fi
+
+  # systemd service (mirrors the proven manual unit; builds on first start via 'dotnet run')
+  echo "# installing systemd service ${SERVICE}"
+  echo "\
+[Unit]
+Description=Wasabi Coordinator daemon
+Requires=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=${DOTNET} run -c Release --project ${SOURCE_DIR}/${CSPROJ}
+Environment=HOME=${HOME_DIR}
+Environment=DOTNET_ROOT=${DOTNET_DIR}
+Environment=\"ASPNETCORE_URLS=http://0.0.0.0:${PUBLIC_PORT};http://127.0.0.1:${LOCAL_PORT}\"
+User=${USERNAME}
+Group=${USERNAME}
+Type=simple
+Restart=always
+RestartSec=10
+
+# Hardening measures
+PrivateTmp=true
+ProtectSystem=full
+NoNewPrivileges=true
+PrivateDevices=true
+
+[Install]
+WantedBy=multi-user.target
+" | sudo tee /etc/systemd/system/${SERVICE}.service 1>&2
+  sudo systemctl daemon-reload 1>&2
+  sudo systemctl enable ${SERVICE} 1>&2
+
+  # firewall: open the public coordinator port (5000 stays local-only)
+  echo "# *** updating firewall ***" 1>&2
+  sudo ufw allow from any to any port ${PUBLIC_PORT} comment 'allow Wasabi coordinator' 1>&2
+
+  # raspiblitz config flag
+  /home/admin/config.scripts/blitz.conf.sh set wasabi "on" ${RASPIBLITZ_CONF} 1>&2
+
+  # Tor hidden service (maps onion:80 -> coordinator public port)
+  if [ "${runBehindTor}" = "on" ]; then
+    /home/admin/config.scripts/tor.onion-service.sh ${SERVICE} 80 ${PUBLIC_PORT} 1>&2
+  fi
+
+  # start if the system is ready
+  source $RASPIBLITZ_INFO 2>/dev/null
+  if [ "${state}" = "ready" ]; then
+    echo "# starting ${SERVICE} (first start compiles, may take minutes)"
+    sudo systemctl start ${SERVICE} 1>&2
+  else
+    echo "# enabled; start manually with: sudo systemctl start ${SERVICE}"
+  fi
+
+  echo "result='OK'"
+  exit 0
+fi
+
+###################
+# OFF
+###################
+if [ "$1" = "0" ] || [ "$1" = "off" ]; then
+  # SAFETY GUARD: only touch a service that this script created (runs from SOURCE_DIR).
+  if [ -f /etc/systemd/system/${SERVICE}.service ] && \
+     ! grep -q "${SOURCE_DIR}" /etc/systemd/system/${SERVICE}.service; then
+    echo "# ABORT: ${SERVICE}.service does not use ${SOURCE_DIR} (manual deployment)." 1>&2
+    echo "# Refusing to stop/remove a service this script did not create." 1>&2
+    echo "result='fail - existing manual deployment detected'"
+    exit 1
+  fi
+
+  echo "# *** DEACTIVATE WASABI COORDINATOR ***"
+
+  sudo systemctl stop ${SERVICE} 2>/dev/null
+  sudo systemctl disable ${SERVICE} 2>/dev/null
+  sudo rm -f /etc/systemd/system/${SERVICE}.service
+  sudo systemctl daemon-reload 2>/dev/null
+
+  # close firewall port
+  sudo ufw delete allow from any to any port ${PUBLIC_PORT} 1>&2
+
+  # remove Tor hidden service
+  if [ "${runBehindTor}" = "on" ]; then
+    /home/admin/config.scripts/tor.onion-service.sh off ${SERVICE} 1>&2
+  fi
+
+  # raspiblitz config flag
+  /home/admin/config.scripts/blitz.conf.sh set wasabi "off" ${RASPIBLITZ_CONF} 1>&2
+
+  echo "# OK - Wasabi coordinator deactivated (source & data kept)"
+  echo "result='OK'"
+  exit 0
+fi
+
+###################
+# UPDATE
+###################
+if [ "$1" = "update" ]; then
+  if [ ! -d "${SOURCE_DIR}" ]; then
+    echo "# *** WASABI COORDINATOR IS NOT INSTALLED ***"
+    exit 1
+  fi
+  echo "# *** UPDATE WASABI COORDINATOR ***"
+  cd ${SOURCE_DIR} || exit 1
+  sudo -u ${USERNAME} git fetch --tags --force 1>&2
+  if [ "$2" = "commit" ]; then
+    # track the default branch (master) - has the upstreamed changes before release
+    sudo -u ${USERNAME} git checkout --force master 1>&2
+    sudo -u ${USERNAME} git pull 1>&2
+  else
+    sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
+  fi
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || exit 1
+  if [ ${isActive} -gt 0 ]; then
+    sudo systemctl restart ${SERVICE} 1>&2
+  fi
+  echo "# OK - updated and rebuilt"
+  exit 0
+fi
+
+echo "FAIL - Unknown Parameter $1"
+exit 1

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -30,9 +30,11 @@ DOTNET_DIR="${HOME_DIR}/.dotnet"
 DOTNET="${DOTNET_DIR}/dotnet"
 # fallback .NET channel if global.json cannot be read (real value derived at install)
 DOTNET_CHANNEL_FALLBACK="8.0"
-# coordinator public API port (Wasabi clients connect here); 5000 is the local-only port
+# coordinator API port. Bound to 127.0.0.1 only and reached over a Tor onion
+# service (default) - no clearnet bind, no domain or port-forwarding needed, and
+# the operator's IP stays hidden. (A single localhost endpoint; no extra local
+# port - 5000 collided with common services like LNBits.)
 PUBLIC_PORT="37126"
-LOCAL_PORT="5000"
 SERVICE="wasabicoordinator"
 
 RASPIBLITZ_INFO=/home/admin/raspiblitz.info
@@ -97,8 +99,7 @@ if [ "$1" = "status" ]; then
   echo "running='${running}'"
   echo "network='${WASABI_NET}'"
   echo "localIP='${localip}'"
-  echo "publicPort='${PUBLIC_PORT}'"
-  echo "localPort='${LOCAL_PORT}'"
+  echo "localPort='${PUBLIC_PORT}'"
   echo "toraddress='${toraddress}'"
   exit 0
 fi
@@ -113,12 +114,9 @@ if [ "$1" = "menu" ]; then
   fi
   toraddress=$(sudo cat /mnt/hdd/app-data/tor/${SERVICE}/hostname 2>/dev/null)
   text="Wasabi (WabiSabi) coinjoin coordinator backend.\n
-Clients connect to the coordinator API on:
-http://${localip}:${PUBLIC_PORT}\n
+Clients connect over Tor - share this onion address with them:
+${toraddress:-<creating - check again in a moment>}\n
 Config & logs: ${DATADIR}"
-  if [ "${runBehindTor}" = "on" ] && [ ${#toraddress} -gt 0 ]; then
-    text="${text}\n\nTor Hidden Service address:\n${toraddress}"
-  fi
   whiptail --title " Wasabi Coordinator " --msgbox "${text}" 16 70
   exit 0
 fi
@@ -257,7 +255,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
   # poll until the file appears, then stop it - no fragile fixed timeout.
   if [ ! -f "${DATADIR}/Config.json" ]; then
     echo "# first run: generating default Config.json ..."
-    sudo -u ${USERNAME} bash -c "HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ASPNETCORE_URLS='http://127.0.0.1:${LOCAL_PORT}' ${DOTNET} ${PUBLISH_DIR}/${DLL}" >/dev/null 2>&1 &
+    sudo -u ${USERNAME} bash -c "HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ASPNETCORE_URLS='http://127.0.0.1:${PUBLIC_PORT}' ${DOTNET} ${PUBLISH_DIR}/${DLL}" >/dev/null 2>&1 &
     for i in $(seq 1 90); do
       [ -f "${DATADIR}/Config.json" ] && break
       sleep 2
@@ -324,7 +322,7 @@ After=${BITCOIND_SERVICE}.service
 ExecStart=${DOTNET} ${PUBLISH_DIR}/${DLL}
 Environment=HOME=${HOME_DIR}
 Environment=DOTNET_ROOT=${DOTNET_DIR}
-Environment=\"ASPNETCORE_URLS=http://0.0.0.0:${PUBLIC_PORT};http://127.0.0.1:${LOCAL_PORT}\"
+Environment=\"ASPNETCORE_URLS=http://127.0.0.1:${PUBLIC_PORT}\"
 User=${USERNAME}
 Group=${USERNAME}
 Type=simple
@@ -343,17 +341,21 @@ WantedBy=multi-user.target
   sudo systemctl daemon-reload 1>&2
   sudo systemctl enable ${SERVICE} 1>&2
 
-  # firewall: open the public coordinator port (5000 stays local-only)
-  echo "# *** updating firewall ***" 1>&2
-  sudo ufw allow from any to any port ${PUBLIC_PORT} comment 'allow Wasabi coordinator' 1>&2
+  # No clearnet firewall port: the coordinator binds 127.0.0.1 only and is reached
+  # over Tor (below). Operators who want a clearnet endpoint can add their own
+  # reverse proxy / firewall rule.
 
   # raspiblitz config flag
   /home/admin/config.scripts/blitz.conf.sh set wasabi "on" ${RASPIBLITZ_CONF} 1>&2
 
-  # Tor hidden service (maps onion:80 -> coordinator public port)
-  if [ "${runBehindTor}" = "on" ]; then
-    /home/admin/config.scripts/tor.onion-service.sh ${SERVICE} 80 ${PUBLIC_PORT} 1>&2
+  # Tor onion is the default (and only) access path - publish it unconditionally.
+  # Ensure Tor is installed first (the node may not be routed through Tor), then
+  # map onion:80 -> 127.0.0.1:${PUBLIC_PORT}.
+  if ! systemctl is-active --quiet tor@default; then
+    echo "# Tor not active - installing it for the coordinator onion service" 1>&2
+    /home/admin/config.scripts/tor.install.sh install 1>&2
   fi
+  /home/admin/config.scripts/tor.onion-service.sh ${SERVICE} 80 ${PUBLIC_PORT} 1>&2
 
   # start if the system is ready
   source $RASPIBLITZ_INFO 2>/dev/null
@@ -388,13 +390,10 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo rm -f /etc/systemd/system/${SERVICE}.service
   sudo systemctl daemon-reload 2>/dev/null
 
-  # close firewall port
-  sudo ufw delete allow from any to any port ${PUBLIC_PORT} 1>&2
+  # no clearnet firewall rule was added (localhost-only bind), nothing to close
 
   # remove Tor hidden service
-  if [ "${runBehindTor}" = "on" ]; then
-    /home/admin/config.scripts/tor.onion-service.sh off ${SERVICE} 1>&2
-  fi
+  /home/admin/config.scripts/tor.onion-service.sh off ${SERVICE} 1>&2
 
   # raspiblitz config flag
   /home/admin/config.scripts/blitz.conf.sh set wasabi "off" ${RASPIBLITZ_CONF} 1>&2

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -2,18 +2,18 @@
 
 # https://github.com/WalletWasabi/WalletWasabi  (WabiSabi coinjoin coordinator backend)
 #
-# The coinjoin.nl coordinator-specific changes are merged upstream (master/dev) and
-# ship in the next release. Until then, pull master with: bonus.wasabi.sh update commit
+# The coordinator-specific changes are merged upstream (master/dev) and ship in the
+# next release. Until then, pull master with: bonus.wasabi.sh update commit
 #
 # REQUIRES bitcoind with: txindex=1, blockfilterindex=1, peerblockfilters=1,
 # server=1. The 'on' step ensures these in bitcoin.conf and restarts bitcoind
 # (first-time block-filter indexing can take hours).
 #
 # The .NET SDK channel is read from the project's global.json, so this auto-installs
-# the right SDK as the project moves on (8.0 for v2.7.2, 10.0 for the next release).
+# the right SDK as the project moves on (8.0 for v2.7.2, 10.0 for v2.8.0).
 
 # Pin the source to the latest official release.
-VERSION="v2.7.2"
+VERSION="v2.8.0"
 REPO="WalletWasabi/WalletWasabi"
 USERNAME="wasabi"
 HOME_DIR="/home/${USERNAME}"

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -4,6 +4,10 @@
 #
 # The coinjoin.nl coordinator-specific changes are merged upstream (master/dev) and
 # ship in the next release. Until then, pull master with: bonus.wasabi.sh update commit
+#
+# REQUIRES bitcoind with: txindex=1, blockfilterindex=1, peerblockfilters=1,
+# server=1. The 'on' step ensures these in bitcoin.conf and restarts bitcoind
+# (first-time block-filter indexing can take hours).
 
 # Pin the source to the latest official release.
 VERSION="v2.7.2"
@@ -181,6 +185,32 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   # data dir
   sudo -u ${USERNAME} mkdir -p ${DATADIR}
+
+  # --- ensure bitcoind has the indexes/filters the coordinator REQUIRES ---
+  # Without these the coordinator cannot function: txindex (look up any tx) and
+  # BIP158 compact block filters served to clients (blockfilterindex +
+  # peerblockfilters), plus the RPC server.
+  echo "# ensuring required bitcoin.conf settings"
+  # txindex via the dedicated RaspiBlitz helper (handles the reindex)
+  /home/admin/config.scripts/network.txindex.sh on 1>&2
+  btcRestart=0
+  for key in server blockfilterindex peerblockfilters; do
+    if grep -Eq "^${key}=1" "${BITCOIN_CONF}"; then
+      continue
+    elif grep -Eq "^${key}=" "${BITCOIN_CONF}"; then
+      sudo sed -i "s/^${key}=.*/${key}=1/g" "${BITCOIN_CONF}"
+    else
+      echo "${key}=1" | sudo tee -a "${BITCOIN_CONF}" >/dev/null
+    fi
+    echo "# set ${key}=1 in bitcoin.conf"
+    btcRestart=1
+  done
+  if [ ${btcRestart} -eq 1 ] && systemctl is-active bitcoind | grep -q "^active"; then
+    echo "# restarting bitcoind to apply block-filter settings"
+    echo "# NOTE: first-time block-filter indexing can take hours; the coordinator"
+    echo "#       will only serve clients once it has finished."
+    sudo systemctl restart bitcoind 1>&2
+  fi
 
   # generate Config.json on first run, then patch in the bitcoind RPC details.
   # The coordinator writes a default Config.json (incl. a freshly generated

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -165,6 +165,10 @@ if [ "$1" = "install" ]; then
     exit 1
   }
 
+  # dotnet publish drops the execute bit on any bundled native binaries (Tor, hwi);
+  # restore it so they can be launched at runtime (no-op if none are bundled).
+  sudo find ${PUBLISH_DIR}/BundledApps/Binaries -type f \( -name tor -o -name hwi \) -exec chmod +x {} \; 2>/dev/null
+
   echo "# OK - Wasabi coordinator user, source, .NET and publish installed"
   exit 0
 fi

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -272,15 +272,28 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     sudo python3 - "${DATADIR}/Config.json" "${BITCOIN_CONF}" "${WASABI_NET}" <<'PY'
 import json, sys
 cfg_path, btc_path, wnet = sys.argv[1], sys.argv[2], sys.argv[3]
-conf = {}
-for line in open(btc_path, encoding="utf-8", errors="replace"):
-    line = line.strip()
-    if "=" in line and not line.startswith("#"):
+# bitcoin.conf is network-scoped (main.rpcport=8332, test.rpcport=18332, ...), so
+# read the value for THIS network's prefix - never collapse them (a mainnet node
+# must not pick up test.rpcport=18332).
+NETMAP = {"Main": ("main", "8332"), "TestNet": ("test", "18332"),
+          "RegTest": ("regtest", "18443"), "Signet": ("signet", "38332")}
+cprefix, default_port = NETMAP.get(wnet, ("main", "8332"))
+def conf_get(key):
+    scoped = glob = None
+    for line in open(btc_path, encoding="utf-8", errors="replace"):
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
         k, _, v = line.partition("=")
-        conf[k.strip().split(".")[-1]] = v.strip()  # drop main./test. prefixes
-user = conf.get("rpcuser", "")
-pw = conf.get("rpcpassword", "")
-port = conf.get("rpcport", "8332")
+        k, v = k.strip(), v.strip()
+        if k == f"{cprefix}.{key}":
+            scoped = v
+        elif k == key:
+            glob = v
+    return scoped if scoped is not None else glob
+user = conf_get("rpcuser") or ""
+pw = conf_get("rpcpassword") or ""
+port = conf_get("rpcport") or default_port
 with open(cfg_path, encoding="utf-8-sig") as f:
     cfg = json.load(f)
 cfg["Network"] = wnet

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -44,7 +44,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "config script to switch the Wasabi (WabiSabi) coinjoin coordinator on or off"
   echo "bonus.wasabi.sh [install|uninstall]"
   echo "bonus.wasabi.sh [on|off|status|menu]"
-  echo "bonus.wasabi.sh [update]"
+  echo "bonus.wasabi.sh [update|update <tag>]"
   exit 1
 fi
 
@@ -411,9 +411,14 @@ if [ "$1" = "update" ]; then
     exit 1
   fi
   echo "# *** UPDATE WASABI COORDINATOR ***"
+  # 'update' rebuilds the pinned VERSION; 'update <tag>' targets a specific upstream
+  # release tag (e.g. v2.8.1) for operators who want a newer build before the script
+  # pin is bumped. Only build a version you trust - it compiles upstream source as-is.
+  TARGET="${2:-$VERSION}"
+  [ "${TARGET}" != "${VERSION}" ] && echo "# NOTE: building ${TARGET}, not the pinned ${VERSION}" 1>&2
   cd ${SOURCE_DIR} || exit 1
   sudo -u ${USERNAME} git fetch --tags --force 1>&2
-  sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
+  sudo -u ${USERNAME} git checkout --force "${TARGET}" || exit 1
   # the new checkout may require a newer .NET SDK (e.g. 10.0) - ensure it
   ensure_dotnet_sdk || exit 1
   sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -108,15 +108,28 @@ fi
 ###################
 if [ "$1" = "menu" ]; then
   if [ ${isActive} -eq 0 ]; then
-    echo "# *** WASABI COORDINATOR NOT INSTALLED ***"
+    whiptail --title " Wasabi Coordinator " --msgbox "\
+Wasabi coordinator is not activated.\n
+Activate it with:
+  sudo /home/admin/config.scripts/bonus.wasabi.sh on" 11 72
     exit 0
   fi
   toraddress=$(sudo cat /mnt/hdd/app-data/tor/${SERVICE}/hostname 2>/dev/null)
-  text="Wasabi (WabiSabi) coinjoin coordinator backend.\n
-Clients connect over Tor - share this onion address with them:
-${toraddress:-<creating - check again in a moment>}\n
-Config & logs: ${DATADIR}"
-  whiptail --title " Wasabi Coordinator " --msgbox "${text}" 16 70
+  if [ "$(systemctl is-active ${SERVICE} 2>/dev/null)" = "active" ]; then
+    status="running"
+  else
+    status="STOPPED - start: sudo systemctl start ${SERVICE}"
+  fi
+  whiptail --title " Wasabi Coordinator " --msgbox "\
+WabiSabi coinjoin coordinator backend.\n
+Status: ${status}\n
+To use this coordinator, in Wasabi Wallet:
+  Settings  ->  Coordinator  ->  Coordinator URI:
+  http://${toraddress:-<creating - reopen this menu shortly>}\n
+Rounds begin only after bitcoind finishes block-filter indexing
+(first run can take a while). Check with:  bitcoin-cli getindexinfo\n
+Config & data:  ${DATADIR}
+Logs:           sudo journalctl -u ${SERVICE} -f" 20 76
   exit 0
 fi
 

--- a/home.admin/config.scripts/bonus.wasabi.sh
+++ b/home.admin/config.scripts/bonus.wasabi.sh
@@ -2,8 +2,7 @@
 
 # https://github.com/WalletWasabi/WalletWasabi  (WabiSabi coinjoin coordinator backend)
 #
-# The coordinator-specific changes are merged upstream (master/dev) and ship in the
-# next release. Until then, pull master with: bonus.wasabi.sh update commit
+# The coordinator-specific changes are released upstream as of v2.8.0.
 #
 # REQUIRES bitcoind with: txindex=1, blockfilterindex=1, peerblockfilters=1,
 # server=1. The 'on' step ensures these in bitcoin.conf and restarts bitcoind
@@ -45,7 +44,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "config script to switch the Wasabi (WabiSabi) coinjoin coordinator on or off"
   echo "bonus.wasabi.sh [install|uninstall]"
   echo "bonus.wasabi.sh [on|off|status|menu]"
-  echo "bonus.wasabi.sh [update|update commit]"
+  echo "bonus.wasabi.sh [update]"
   exit 1
 fi
 
@@ -414,13 +413,7 @@ if [ "$1" = "update" ]; then
   echo "# *** UPDATE WASABI COORDINATOR ***"
   cd ${SOURCE_DIR} || exit 1
   sudo -u ${USERNAME} git fetch --tags --force 1>&2
-  if [ "$2" = "commit" ]; then
-    # track the default branch (master) - has the upstreamed changes before release
-    sudo -u ${USERNAME} git checkout --force master 1>&2
-    sudo -u ${USERNAME} git pull 1>&2
-  else
-    sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
-  fi
+  sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
   # the new checkout may require a newer .NET SDK (e.g. 10.0) - ensure it
   ensure_dotnet_sdk || exit 1
   sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -6,6 +6,9 @@
 # from the command line via the wcli script or any RPC client. This is the
 # client wallet (for end users) - NOT the coinjoin coordinator (that is the
 # advanced-only bonus.wasabi.sh).
+#
+# The .NET SDK channel is read from the project's global.json, so this auto-installs
+# the right SDK as the project moves on (8.0 for v2.7.2, 10.0 for the next release).
 
 VERSION="v2.7.2"
 REPO="WalletWasabi/WalletWasabi"
@@ -13,11 +16,13 @@ USERNAME="wasabid"
 HOME_DIR="/home/${USERNAME}"
 # dedicated clone path (isolated from any manual deployment / dev tree)
 SOURCE_DIR="${HOME_DIR}/wabisabi-client"
+PUBLISH_DIR="${SOURCE_DIR}/publish"
 CSPROJ="WalletWasabi.Daemon/WalletWasabi.Daemon.csproj"
+DLL="WalletWasabi.Daemon.dll"
 DATADIR="${HOME_DIR}/.walletwasabi/client"
 DOTNET_DIR="${HOME_DIR}/.dotnet"
 DOTNET="${DOTNET_DIR}/dotnet"
-DOTNET_CHANNEL="8.0"
+DOTNET_CHANNEL_FALLBACK="8.0"
 # local-only JSON-RPC (Wasabi default port); never exposed to the network
 RPC_PORT="37128"
 SERVICE="wasabid"
@@ -38,9 +43,39 @@ fi
 source $RASPIBLITZ_INFO 2>/dev/null
 source $RASPIBLITZ_CONF 2>/dev/null
 
+# network awareness (RaspiBlitz: network=bitcoin, chain=main|test|sig|reg)
+network="${network:-bitcoin}"
+chain="${chain:-main}"
+BITCOIN_CONF="/mnt/hdd/app-data/${network}/${network}.conf"
+BITCOIND_SERVICE="${network}d"
+case "${chain}" in
+  main) WASABI_NET="Main" ;;
+  test) WASABI_NET="TestNet" ;;
+  reg)  WASABI_NET="RegTest" ;;
+  *)    WASABI_NET="Main" ;;
+esac
+
 isInstalled=$(compgen -u | grep -c "^${USERNAME}$")
 isActive=$(sudo ls /etc/systemd/system/${SERVICE}.service 2>/dev/null | grep -c "${SERVICE}.service")
 localip=$(hostname -I | awk '{print $1}')
+
+# helper: derive + ensure the .NET SDK the project's global.json asks for
+ensure_dotnet_sdk() {
+  local channel
+  channel=$(grep -oE '"version"[^"]*"[0-9]+\.[0-9]+' "${SOURCE_DIR}/global.json" 2>/dev/null \
+            | grep -oE '[0-9]+\.[0-9]+$' | head -1)
+  [ -z "${channel}" ] && channel="${DOTNET_CHANNEL_FALLBACK}"
+  echo "# project needs .NET SDK channel ${channel} (from global.json)"
+  if ! sudo -u ${USERNAME} bash -c "DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} --list-sdks 2>/dev/null" \
+       | grep -q "^${channel}\."; then
+    echo "# installing .NET SDK ${channel} into ${DOTNET_DIR}"
+    sudo -u ${USERNAME} bash -c "curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh" || return 1
+    sudo -u ${USERNAME} bash /tmp/dotnet-install.sh --channel ${channel} --install-dir ${DOTNET_DIR} || return 1
+    rm -f /tmp/dotnet-install.sh
+  else
+    echo "# .NET SDK ${channel} already present"
+  fi
+}
 
 ###################
 # STATUS
@@ -50,6 +85,7 @@ if [ "$1" = "status" ]; then
   echo "version='${VERSION}'"
   echo "installed='${isActive}'"
   echo "running='${running}'"
+  echo "network='${WASABI_NET}'"
   echo "localIP='${localip}'"
   echo "rpcPort='${RPC_PORT}'"
   echo "rpcBind='127.0.0.1'"
@@ -141,26 +177,20 @@ fi
 ###################
 if [ "$1" = "install" ]; then
 
-  if [ ${isInstalled} -gt 0 ] && [ -d "${SOURCE_DIR}" ]; then
+  if [ ${isInstalled} -gt 0 ] && [ -d "${PUBLISH_DIR}" ]; then
     echo "result='already installed'"
     exit 0
   fi
 
-  echo "# *** INSTALL WASABI DAEMON (user, .NET, source) ***"
+  echo "# *** INSTALL WASABI DAEMON (user, source, .NET, publish) ***"
 
   if [ ${isInstalled} -eq 0 ]; then
     echo "# creating the ${USERNAME} user"
     sudo adduser --system --group --home ${HOME_DIR} ${USERNAME} || exit 1
   fi
 
+  sudo apt-get update
   sudo apt-get install -y git curl libicu-dev jq || exit 1
-
-  if ! sudo -u ${USERNAME} ${DOTNET} --version 2>/dev/null | grep -q .; then
-    echo "# installing .NET SDK ${DOTNET_CHANNEL} into ${DOTNET_DIR}"
-    sudo -u ${USERNAME} bash -c "curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh"
-    sudo -u ${USERNAME} bash /tmp/dotnet-install.sh --channel ${DOTNET_CHANNEL} --install-dir ${DOTNET_DIR} || exit 1
-    rm -f /tmp/dotnet-install.sh
-  fi
 
   if [ ! -d "${SOURCE_DIR}" ]; then
     echo "# cloning ${REPO} @ ${VERSION}"
@@ -170,13 +200,17 @@ if [ "$1" = "install" ]; then
   sudo -u ${USERNAME} git fetch --tags --force 1>&2
   sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
 
-  echo "# building the daemon (this can take a while on a Pi)"
-  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || {
-    echo "result='fail - dotnet build failed'"
+  # .NET SDK matching the project's global.json (auto-tracks the .NET 10 release)
+  ensure_dotnet_sdk || { echo "result='fail - dotnet sdk install failed'"; exit 1; }
+
+  echo "# publishing the daemon (this can take a while on a Pi)"
+  sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} publish -c Release -o ${PUBLISH_DIR} ${CSPROJ}" || {
+    echo "result='fail - dotnet publish failed'"
     exit 1
   }
 
-  echo "# OK - Wasabi daemon user, .NET and source installed"
+  echo "# OK - Wasabi daemon user, source, .NET and publish installed"
   exit 0
 fi
 
@@ -205,7 +239,7 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
     exit 0
   fi
 
-  if [ ${isInstalled} -eq 0 ] || [ ! -d "${SOURCE_DIR}" ]; then
+  if [ ${isInstalled} -eq 0 ] || [ ! -d "${PUBLISH_DIR}" ]; then
     sudo /home/admin/config.scripts/bonus.wasabid.sh install 1>&2 || exit 1
   fi
 
@@ -213,26 +247,37 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   sudo -u ${USERNAME} mkdir -p ${DATADIR}
 
-  # write Config.json with JSON-RPC enabled (local only) on first run.
+  # write Config.json on first run: local JSON-RPC + wire to the local bitcoind.
   # The daemon fills any missing keys with its own defaults on start.
   if [ ! -f "${DATADIR}/Config.json" ]; then
-    echo "# generating Config.json with a local JSON-RPC server"
+    echo "# generating Config.json (local JSON-RPC + local bitcoind RPC)"
     RPCPASS=$(openssl rand -hex 24)
-    sudo python3 - "${DATADIR}/Config.json" "${RPC_PORT}" "${RPCPASS}" <<'PY'
-import json, sys
-path, port, pw = sys.argv[1], sys.argv[2], sys.argv[3]
+    sudo python3 - "${DATADIR}/Config.json" "${RPC_PORT}" "${RPCPASS}" "${WASABI_NET}" "${BITCOIN_CONF}" <<'PY'
+import json, sys, os
+path, port, pw, wnet, btc_path = sys.argv[1:6]
 cfg = {
-    "Network": "Main",
+    "Network": wnet,
     "UseTor": "Enabled",
     "JsonRpcServerEnabled": True,
     "JsonRpcUser": "wasabi",
     "JsonRpcPassword": pw,
     "JsonRpcServerPrefixes": [f"http://127.0.0.1:{port}/"],
 }
-# NOTE (review): to fetch blocks from the local bitcoind instead of Wasabi's
-# default node, also set the RPC keys - the exact names are version-dependent
-# (e.g. BitcoinRpcUri + BitcoinRpcConnectionString). Left out so we don't ship
-# a key the daemon would silently ignore. The daemon works on defaults without it.
+# wire the client to the local bitcoind via RPC (trustless, uses the user's node)
+if os.path.exists(btc_path):
+    conf = {}
+    for line in open(btc_path, encoding="utf-8", errors="replace"):
+        line = line.strip()
+        if "=" in line and not line.startswith("#"):
+            k, _, v = line.partition("=")
+            conf[k.strip().split(".")[-1]] = v.strip()  # drop main./test. prefixes
+    user = conf.get("rpcuser", "")
+    pwd = conf.get("rpcpassword", "")
+    rpcport = conf.get("rpcport", "8332")
+    if user and pwd:
+        cfg["UseBitcoinRpc"] = True
+        cfg["BitcoinRpcCredentialString"] = f"{user}:{pwd}"
+        cfg["BitcoinRpcUri"] = f"http://127.0.0.1:{rpcport}"
 with open(path, "w", encoding="utf-8") as f:
     json.dump(cfg, f, indent=2)
 PY
@@ -244,11 +289,11 @@ PY
   echo "\
 [Unit]
 Description=Wasabi Wallet daemon (headless client + JSON-RPC)
-Wants=bitcoind.service
-After=bitcoind.service
+Wants=${BITCOIND_SERVICE}.service
+After=${BITCOIND_SERVICE}.service
 
 [Service]
-ExecStart=${DOTNET} run -c Release --project ${SOURCE_DIR}/${CSPROJ} -- --datadir=${DATADIR}
+ExecStart=${DOTNET} ${PUBLISH_DIR}/${DLL} --datadir=${DATADIR}
 Environment=HOME=${HOME_DIR}
 Environment=DOTNET_ROOT=${DOTNET_DIR}
 User=${USERNAME}
@@ -282,7 +327,7 @@ WantedBy=multi-user.target
 
   source $RASPIBLITZ_INFO 2>/dev/null
   if [ "${state}" = "ready" ]; then
-    echo "# starting ${SERVICE} (first start compiles, may take minutes)"
+    echo "# starting ${SERVICE}"
     sudo systemctl start ${SERVICE} 1>&2
   else
     echo "# enabled; start manually with: sudo systemctl start ${SERVICE}"
@@ -330,11 +375,14 @@ if [ "$1" = "update" ]; then
   else
     sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
   fi
-  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || exit 1
+  # the new checkout may require a newer .NET SDK (e.g. 10.0) - ensure it
+  ensure_dotnet_sdk || exit 1
+  sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} publish -c Release -o ${PUBLISH_DIR} ${CSPROJ}" || exit 1
   if [ ${isActive} -gt 0 ]; then
     sudo systemctl restart ${SERVICE} 1>&2
   fi
-  echo "# OK - updated and rebuilt"
+  echo "# OK - updated and re-published"
   exit 0
 fi
 

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -294,10 +294,12 @@ if os.path.exists(btc_path):
     pwd = conf_get("rpcpassword") or ""
     rpcport = conf_get("rpcport") or default_port
     if user and pwd:
+        # the daemon decides "RPC configured" solely on BitcoinRpcUri being set,
+        # and that property is fed by the switch named BitcoinRpcEndPoint (there is
+        # no UseBitcoinRpc switch). A loopback URI is used directly (not via Tor).
         lines += [
-            "WASABI_USEBITCOINRPC=true",
             f"WASABI_BITCOINRPCCREDENTIALSTRING={user}:{pwd}",
-            f"WASABI_BITCOINRPCURI=http://127.0.0.1:{rpcport}",
+            f"WASABI_BITCOINRPCENDPOINT=http://127.0.0.1:{rpcport}",
         ]
 with open(env_path, "w", encoding="utf-8") as f:
     f.write("\n".join(lines) + "\n")

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -26,6 +26,9 @@ DOTNET_CHANNEL_FALLBACK="8.0"
 # local-only JSON-RPC (Wasabi default port); never exposed to the network
 RPC_PORT="37128"
 SERVICE="wasabid"
+# v2.8.0 resets hand-written Config.json keys on load, so behavioral settings are
+# passed as WASABI_* env vars (higher precedence) from this root-owned 600 file.
+ENV_FILE="/etc/${SERVICE}.env"
 
 RASPIBLITZ_INFO=/home/admin/raspiblitz.info
 RASPIBLITZ_CONF=/mnt/hdd/app-data/raspiblitz.conf
@@ -107,14 +110,14 @@ JSON-RPC endpoint (localhost only):
   http://127.0.0.1:${RPC_PORT}/           (global)
   http://127.0.0.1:${RPC_PORT}/WalletName (per wallet)\n
 Easiest interaction is the dev-maintained 'wcli' command (installed):
-  wcli help                         list all methods
+  wcli getstatus                    sync / Tor / node status
   wcli createwallet MyWallet '\"pass\"'
   wcli -wallet=MyWallet getnewaddress \"label\" false
   wcli -wallet=MyWallet startcoinjoin pass true true
-It auto-loads the RPC endpoint + credentials from Config.json.\n
+It auto-loads the RPC endpoint from Config.json (local RPC is auth-less).\n
 For a fuller cheat sheet (incl. raw curl):
   sudo /home/admin/config.scripts/bonus.wasabid.sh examples\n
-RPC creds live in: ${DATADIR}/Config.json
+Settings (RPC/network/bitcoind): ${ENV_FILE}
 Docs: https://docs.wasabiwallet.io/using-wasabi/RPC.html
 " 22 76
   exit 0
@@ -129,13 +132,13 @@ if [ "$1" = "examples" ] || [ "$1" = "rpc" ]; then
     exit 1
   fi
   # The 'wcli' wrapper (installed by 'on') is the dev-maintained CLI. It reads the
-  # RPC endpoint + credentials from Config.json itself, so you never type them.
+  # RPC endpoint from Config.json itself, so you never type the port.
   cat <<EOF
 # ===== Wasabi wallet via wcli (recommended) =====
-# wcli is the dev-maintained CLI wrapper. It auto-loads the endpoint and the RPC
-# credentials from ${DATADIR}/Config.json - no need to pass a port or password.
+# wcli is the dev-maintained CLI wrapper. It auto-loads the endpoint from
+# ${DATADIR}/Config.json - no need to pass a port (local RPC is auth-less).
 #
-#   wcli help                       # authoritative list of all methods
+#   wcli getstatus                  # sync / Tor / node status
 #   wcli <method> [params...]       # global call
 #   wcli -wallet=<name> <method> ..  # call against a specific wallet
 #
@@ -162,8 +165,8 @@ wcli listwallets
 wcli -wallet=MyWallet getwalletinfo
 
 # ----- raw curl equivalent (if you prefer) -----
-# Add basic auth from Config.json: -u <JsonRpcUser>:<JsonRpcPassword>
-#   curl -s -u USER:PASS --data-binary \\
+# Local RPC is auth-less (127.0.0.1 only), so no credentials are needed:
+#   curl -s --data-binary \\
 #     '{"jsonrpc":"2.0","id":"1","method":"getnewaddress","params":["label",false]}' \\
 #     http://127.0.0.1:${RPC_PORT}/MyWallet | jq
 #
@@ -253,22 +256,19 @@ if [ "$1" = "1" ] || [ "$1" = "on" ]; then
 
   sudo -u ${USERNAME} mkdir -p ${DATADIR}
 
-  # write Config.json on first run: local JSON-RPC + wire to the local bitcoind.
-  # The daemon fills any missing keys with its own defaults on start.
-  if [ ! -f "${DATADIR}/Config.json" ]; then
-    echo "# generating Config.json (local JSON-RPC + local bitcoind RPC)"
-    RPCPASS=$(openssl rand -hex 24)
-    sudo python3 - "${DATADIR}/Config.json" "${RPC_PORT}" "${RPCPASS}" "${WASABI_NET}" "${BITCOIN_CONF}" <<'PY'
-import json, sys, os
-path, port, pw, wnet, btc_path = sys.argv[1:6]
-cfg = {
-    "Network": wnet,
-    "UseTor": "Enabled",
-    "JsonRpcServerEnabled": True,
-    "JsonRpcUser": "wasabi",
-    "JsonRpcPassword": pw,
-    "JsonRpcServerPrefixes": [f"http://127.0.0.1:{port}/"],
-}
+  # Behavioral settings go through WASABI_* env vars, NOT Config.json: v2.8.0 runs
+  # a config migration on load that resets hand-written keys (JsonRpcServerEnabled,
+  # UseBitcoinRpc, Network, ...) back to defaults. Env vars outrank the config file
+  # and survive that rewrite. Local JSON-RPC stays auth-less (127.0.0.1 only, no
+  # firewall port) - that is upstream's own localhost RPC model.
+  echo "# writing ${ENV_FILE} (RPC enable + network + local bitcoind wiring)"
+  sudo python3 - "${ENV_FILE}" "${WASABI_NET}" "${BITCOIN_CONF}" <<'PY'
+import sys, os
+env_path, wnet, btc_path = sys.argv[1:4]
+lines = [
+    "WASABI_JSONRPCSERVERENABLED=true",
+    f"WASABI_NETWORK={wnet}",
+]
 # wire the client to the local bitcoind via RPC (trustless, uses the user's node)
 if os.path.exists(btc_path):
     conf = {}
@@ -281,13 +281,23 @@ if os.path.exists(btc_path):
     pwd = conf.get("rpcpassword", "")
     rpcport = conf.get("rpcport", "8332")
     if user and pwd:
-        cfg["UseBitcoinRpc"] = True
-        cfg["BitcoinRpcCredentialString"] = f"{user}:{pwd}"
-        cfg["BitcoinRpcUri"] = f"http://127.0.0.1:{rpcport}"
-with open(path, "w", encoding="utf-8") as f:
-    json.dump(cfg, f, indent=2)
+        lines += [
+            "WASABI_USEBITCOINRPC=true",
+            f"WASABI_BITCOINRPCCREDENTIALSTRING={user}:{pwd}",
+            f"WASABI_BITCOINRPCURI=http://127.0.0.1:{rpcport}",
+        ]
+with open(env_path, "w", encoding="utf-8") as f:
+    f.write("\n".join(lines) + "\n")
 PY
-    sudo chown -R ${USERNAME}:${USERNAME} "${HOME_DIR}/.walletwasabi"
+  sudo chown root:root "${ENV_FILE}"
+  sudo chmod 600 "${ENV_FILE}"
+
+  # The daemon writes its own Config.json (default port ${RPC_PORT}) on first run;
+  # pre-seed a minimal one so 'wcli' has an endpoint to read immediately. The daemon
+  # preserves the prefix and fills the rest; auth stays empty so wcli needs no creds.
+  if [ ! -f "${DATADIR}/Config.json" ]; then
+    echo "{\"JsonRpcServerPrefixes\": [\"http://127.0.0.1:${RPC_PORT}/\"]}" \
+      | sudo -u ${USERNAME} tee "${DATADIR}/Config.json" >/dev/null
     sudo chmod 600 "${DATADIR}/Config.json"
   fi
 
@@ -302,6 +312,7 @@ After=${BITCOIND_SERVICE}.service
 ExecStart=${DOTNET} ${PUBLISH_DIR}/${DLL} --datadir=${DATADIR}
 Environment=HOME=${HOME_DIR}
 Environment=DOTNET_ROOT=${DOTNET_DIR}
+EnvironmentFile=${ENV_FILE}
 User=${USERNAME}
 Group=${USERNAME}
 Type=simple
@@ -321,7 +332,7 @@ WantedBy=multi-user.target
   sudo systemctl enable ${SERVICE} 1>&2
 
   # install the dev-maintained 'wcli' as a system command (runs as the daemon
-  # user so it reads that user's Config.json for endpoint + credentials)
+  # user so it reads that user's Config.json for the endpoint; RPC is auth-less)
   echo "# installing the wcli command"
   printf '#!/bin/bash\nsudo -u %s HOME=%s bash %s/Contrib/CLI/wcli.sh "$@"\n' \
     "${USERNAME}" "${HOME_DIR}" "${SOURCE_DIR}" | sudo tee /usr/local/bin/wcli >/dev/null
@@ -352,6 +363,7 @@ if [ "$1" = "0" ] || [ "$1" = "off" ]; then
   sudo systemctl stop ${SERVICE} 2>/dev/null
   sudo systemctl disable ${SERVICE} 2>/dev/null
   sudo rm -f /etc/systemd/system/${SERVICE}.service
+  sudo rm -f ${ENV_FILE}
   sudo systemctl daemon-reload 2>/dev/null
 
   # remove the wcli command
@@ -385,6 +397,8 @@ if [ "$1" = "update" ]; then
   ensure_dotnet_sdk || exit 1
   sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}
   sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} publish -c Release -o ${PUBLISH_DIR} ${CSPROJ}" || exit 1
+  # publish drops the execute bit on bundled native binaries (Tor, hwi) - restore it
+  sudo find ${PUBLISH_DIR}/BundledApps/Binaries -type f \( -name tor -o -name hwi \) -exec chmod +x {} \;
   if [ ${isActive} -gt 0 ]; then
     sudo systemctl restart ${SERVICE} 1>&2
   fi

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -101,25 +101,49 @@ fi
 ###################
 if [ "$1" = "menu" ]; then
   if [ ${isActive} -eq 0 ]; then
-    echo "# *** WASABI DAEMON NOT INSTALLED ***"
+    whiptail --title " Wasabi Wallet Daemon " --msgbox "\
+Wasabi daemon is not activated.\n
+Enable it from the SERVICES menu, or run:
+  sudo /home/admin/config.scripts/bonus.wasabid.sh on" 11 72
     exit 0
   fi
+
+  # Live status, guarded with a timeout so the menu never hangs while the daemon
+  # is still starting. Query the loopback JSON-RPC directly (auth-less) for clean,
+  # parseable output instead of wcli's table formatting.
+  _rpc() { timeout 6 curl -s --data-binary "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"$1\",\"params\":[]}" "http://127.0.0.1:${RPC_PORT}/" 2>/dev/null; }
+  if [ "$(systemctl is-active ${SERVICE} 2>/dev/null)" = "active" ]; then
+    st=$(_rpc getstatus)
+    if echo "${st}" | jq -e '.result' >/dev/null 2>&1; then
+      tor=$(echo "${st}" | jq -r '.result.torStatus // "?"')
+      net=$(echo "${st}" | jq -r '.result.network // "?"')
+      left=$(echo "${st}" | jq -r '.result.filtersLeft // empty')
+      [ "${left}" = "0" ] && synced="yes" || synced="syncing"
+      statusLine="running | Tor: ${tor} | ${net} | synced: ${synced}"
+      cnt=$(_rpc listwallets | jq -r '.result | length' 2>/dev/null)
+      case "${cnt}" in ""|null) wallets="?";; 0) wallets="none yet (create one below)";; *) wallets="${cnt}";; esac
+    else
+      statusLine="running | RPC starting (Tor bootstrapping) - reopen shortly"
+      wallets="?"
+    fi
+  else
+    statusLine="STOPPED | start: sudo systemctl start ${SERVICE}"
+    wallets="-"
+  fi
+
   whiptail --title " Wasabi Wallet Daemon " --msgbox "\
-Headless Wasabi wallet with a local JSON-RPC interface.\n
-JSON-RPC endpoint (localhost only):
-  http://127.0.0.1:${RPC_PORT}/           (global)
-  http://127.0.0.1:${RPC_PORT}/WalletName (per wallet)\n
-Easiest interaction is the dev-maintained 'wcli' command (installed):
-  wcli getstatus                    sync / Tor / node status
+Status:  ${statusLine}
+Wallets: ${wallets}\n
+Headless Wasabi wallet, local JSON-RPC on 127.0.0.1:${RPC_PORT} (auth-less).\n
+Manage it with the 'wcli' command:
+  wcli getstatus                       sync / Tor / node status
   wcli createwallet MyWallet '\"pass\"'
   wcli -wallet=MyWallet getnewaddress \"label\" false
-  wcli -wallet=MyWallet startcoinjoin pass true true
-It auto-loads the RPC endpoint from Config.json (local RPC is auth-less).\n
-For a fuller cheat sheet (incl. raw curl):
-  sudo /home/admin/config.scripts/bonus.wasabid.sh examples\n
-Settings (RPC/network/bitcoind): ${ENV_FILE}
-Docs: https://docs.wasabiwallet.io/using-wasabi/RPC.html
-" 22 76
+  wcli -wallet=MyWallet startcoinjoin pass true true\n
+Full cheat sheet:  sudo /home/admin/config.scripts/bonus.wasabid.sh examples
+Logs:              sudo journalctl -u ${SERVICE} -f
+Settings:          ${ENV_FILE}
+Docs:              https://docs.wasabiwallet.io/using-wasabi/RPC.html" 24 78
   exit 0
 fi
 

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -1,0 +1,342 @@
+#!/bin/bash
+
+# https://github.com/WalletWasabi/WalletWasabi  (WalletWasabi.Daemon - headless client wallet)
+#
+# Headless Wasabi wallet daemon with a local JSON-RPC interface. Manage wallets
+# from the command line via the wcli script or any RPC client. This is the
+# client wallet (for end users) - NOT the coinjoin coordinator (that is the
+# advanced-only bonus.wasabi.sh).
+
+VERSION="v2.7.2"
+REPO="WalletWasabi/WalletWasabi"
+USERNAME="wasabid"
+HOME_DIR="/home/${USERNAME}"
+# dedicated clone path (isolated from any manual deployment / dev tree)
+SOURCE_DIR="${HOME_DIR}/wabisabi-client"
+CSPROJ="WalletWasabi.Daemon/WalletWasabi.Daemon.csproj"
+DATADIR="${HOME_DIR}/.walletwasabi/client"
+DOTNET_DIR="${HOME_DIR}/.dotnet"
+DOTNET="${DOTNET_DIR}/dotnet"
+DOTNET_CHANNEL="8.0"
+# local-only JSON-RPC (Wasabi default port); never exposed to the network
+RPC_PORT="37128"
+SERVICE="wasabid"
+
+RASPIBLITZ_INFO=/home/admin/raspiblitz.info
+RASPIBLITZ_CONF=/mnt/hdd/app-data/raspiblitz.conf
+
+# command info
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
+  echo "config script for the Wasabi Wallet daemon (headless client + JSON-RPC)"
+  echo "bonus.wasabid.sh [install|uninstall]"
+  echo "bonus.wasabid.sh [on|off|status|menu]"
+  echo "bonus.wasabid.sh [examples]   # print wcli + curl usage cheat sheet"
+  echo "bonus.wasabid.sh [update|update commit]"
+  exit 1
+fi
+
+source $RASPIBLITZ_INFO 2>/dev/null
+source $RASPIBLITZ_CONF 2>/dev/null
+
+isInstalled=$(compgen -u | grep -c "^${USERNAME}$")
+isActive=$(sudo ls /etc/systemd/system/${SERVICE}.service 2>/dev/null | grep -c "${SERVICE}.service")
+localip=$(hostname -I | awk '{print $1}')
+
+###################
+# STATUS
+###################
+if [ "$1" = "status" ]; then
+  running=$(systemctl is-active ${SERVICE} 2>/dev/null | grep -c "^active$")
+  echo "version='${VERSION}'"
+  echo "installed='${isActive}'"
+  echo "running='${running}'"
+  echo "localIP='${localip}'"
+  echo "rpcPort='${RPC_PORT}'"
+  echo "rpcBind='127.0.0.1'"
+  echo "dataDir='${DATADIR}'"
+  exit 0
+fi
+
+###################
+# MENU
+###################
+if [ "$1" = "menu" ]; then
+  if [ ${isActive} -eq 0 ]; then
+    echo "# *** WASABI DAEMON NOT INSTALLED ***"
+    exit 0
+  fi
+  whiptail --title " Wasabi Wallet Daemon " --msgbox "\
+Headless Wasabi wallet with a local JSON-RPC interface.\n
+JSON-RPC endpoint (localhost only):
+  http://127.0.0.1:${RPC_PORT}/           (global)
+  http://127.0.0.1:${RPC_PORT}/WalletName (per wallet)\n
+Easiest interaction is the dev-maintained 'wcli' command (installed):
+  wcli help                         list all methods
+  wcli createwallet MyWallet '\"pass\"'
+  wcli -wallet=MyWallet getnewaddress \"label\" false
+  wcli -wallet=MyWallet startcoinjoin pass true true
+It auto-loads the RPC endpoint + credentials from Config.json.\n
+For a fuller cheat sheet (incl. raw curl):
+  sudo /home/admin/config.scripts/bonus.wasabid.sh examples\n
+RPC creds live in: ${DATADIR}/Config.json
+Docs: https://docs.wasabiwallet.io/using-wasabi/RPC.html
+" 22 76
+  exit 0
+fi
+
+###################
+# EXAMPLES (teach the RPC calls)
+###################
+if [ "$1" = "examples" ] || [ "$1" = "rpc" ]; then
+  if [ ! -f "${DATADIR}/Config.json" ]; then
+    echo "# Wasabi daemon is not configured yet - run 'on' first."
+    exit 1
+  fi
+  # The 'wcli' wrapper (installed by 'on') is the dev-maintained CLI. It reads the
+  # RPC endpoint + credentials from Config.json itself, so you never type them.
+  cat <<EOF
+# ===== Wasabi wallet via wcli (recommended) =====
+# wcli is the dev-maintained CLI wrapper. It auto-loads the endpoint and the RPC
+# credentials from ${DATADIR}/Config.json - no need to pass a port or password.
+#
+#   wcli help                       # authoritative list of all methods
+#   wcli <method> [params...]       # global call
+#   wcli -wallet=<name> <method> ..  # call against a specific wallet
+#
+# Note on quoting: wcli auto-quotes the FIRST parameter as a string; pass any
+# further STRING parameters pre-quoted as '"..."' (numbers/bools stay bare).
+
+# 1) Create a new wallet (returns the recovery mnemonic - write it down!)
+wcli createwallet MyWallet '"MyPassphrase"'
+
+# 2) Recover a wallet from a BIP39 mnemonic
+wcli recoverwallet MyWallet '"word1 word2 ... word12"' '"MyPassphrase"'
+
+# 3) Get a new receive address  (label, isTaproot)
+wcli -wallet=MyWallet getnewaddress "my label" false
+
+# 4) Start coinjoin  (passphrase, stopWhenAllMixed, overridePlebStop)
+wcli -wallet=MyWallet startcoinjoin MyPassphrase true true
+
+# 5) Pay in coinjoin  (destinationAddress, amountInSats)
+wcli -wallet=MyWallet payincoinjoin "bc1q..." 100000
+
+# List wallets / wallet info
+wcli listwallets
+wcli -wallet=MyWallet getwalletinfo
+
+# ----- raw curl equivalent (if you prefer) -----
+# Add basic auth from Config.json: -u <JsonRpcUser>:<JsonRpcPassword>
+#   curl -s -u USER:PASS --data-binary \\
+#     '{"jsonrpc":"2.0","id":"1","method":"getnewaddress","params":["label",false]}' \\
+#     http://127.0.0.1:${RPC_PORT}/MyWallet | jq
+#
+# Full method reference: https://docs.wasabiwallet.io/using-wasabi/RPC.html
+EOF
+  exit 0
+fi
+
+###################
+# INSTALL
+###################
+if [ "$1" = "install" ]; then
+
+  if [ ${isInstalled} -gt 0 ] && [ -d "${SOURCE_DIR}" ]; then
+    echo "result='already installed'"
+    exit 0
+  fi
+
+  echo "# *** INSTALL WASABI DAEMON (user, .NET, source) ***"
+
+  if [ ${isInstalled} -eq 0 ]; then
+    echo "# creating the ${USERNAME} user"
+    sudo adduser --system --group --home ${HOME_DIR} ${USERNAME} || exit 1
+  fi
+
+  sudo apt-get install -y git curl libicu-dev jq || exit 1
+
+  if ! sudo -u ${USERNAME} ${DOTNET} --version 2>/dev/null | grep -q .; then
+    echo "# installing .NET SDK ${DOTNET_CHANNEL} into ${DOTNET_DIR}"
+    sudo -u ${USERNAME} bash -c "curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh"
+    sudo -u ${USERNAME} bash /tmp/dotnet-install.sh --channel ${DOTNET_CHANNEL} --install-dir ${DOTNET_DIR} || exit 1
+    rm -f /tmp/dotnet-install.sh
+  fi
+
+  if [ ! -d "${SOURCE_DIR}" ]; then
+    echo "# cloning ${REPO} @ ${VERSION}"
+    sudo -u ${USERNAME} git clone https://github.com/${REPO}.git ${SOURCE_DIR} || exit 1
+  fi
+  cd ${SOURCE_DIR} || exit 1
+  sudo -u ${USERNAME} git fetch --tags --force 1>&2
+  sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
+
+  echo "# building the daemon (this can take a while on a Pi)"
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || {
+    echo "result='fail - dotnet build failed'"
+    exit 1
+  }
+
+  echo "# OK - Wasabi daemon user, .NET and source installed"
+  exit 0
+fi
+
+###################
+# UNINSTALL
+###################
+if [ "$1" = "uninstall" ]; then
+  if [ ${isActive} -gt 0 ]; then
+    echo "result='still in use - switch off first'"
+    exit 1
+  fi
+  echo "# *** UNINSTALL WASABI DAEMON ***"
+  echo "# NOTE: keeping ${DATADIR} (holds your wallets). Delete manually if sure."
+  sudo rm -rf ${SOURCE_DIR} ${DOTNET_DIR}
+  exit 0
+fi
+
+###################
+# ON
+###################
+if [ "$1" = "1" ] || [ "$1" = "on" ]; then
+
+  if [ ${isActive} -gt 0 ]; then
+    echo "# Wasabi daemon already activated."
+    echo "result='OK'"
+    exit 0
+  fi
+
+  if [ ${isInstalled} -eq 0 ] || [ ! -d "${SOURCE_DIR}" ]; then
+    sudo /home/admin/config.scripts/bonus.wasabid.sh install 1>&2 || exit 1
+  fi
+
+  echo "# *** ACTIVATING WASABI DAEMON ***"
+
+  sudo -u ${USERNAME} mkdir -p ${DATADIR}
+
+  # write Config.json with JSON-RPC enabled (local only) on first run.
+  # The daemon fills any missing keys with its own defaults on start.
+  if [ ! -f "${DATADIR}/Config.json" ]; then
+    echo "# generating Config.json with a local JSON-RPC server"
+    RPCPASS=$(openssl rand -hex 24)
+    sudo python3 - "${DATADIR}/Config.json" "${RPC_PORT}" "${RPCPASS}" <<'PY'
+import json, sys
+path, port, pw = sys.argv[1], sys.argv[2], sys.argv[3]
+cfg = {
+    "Network": "Main",
+    "UseTor": "Enabled",
+    "JsonRpcServerEnabled": True,
+    "JsonRpcUser": "wasabi",
+    "JsonRpcPassword": pw,
+    "JsonRpcServerPrefixes": [f"http://127.0.0.1:{port}/"],
+}
+# NOTE (review): to fetch blocks from the local bitcoind instead of Wasabi's
+# default node, also set the RPC keys - the exact names are version-dependent
+# (e.g. BitcoinRpcUri + BitcoinRpcConnectionString). Left out so we don't ship
+# a key the daemon would silently ignore. The daemon works on defaults without it.
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(cfg, f, indent=2)
+PY
+    sudo chown -R ${USERNAME}:${USERNAME} "${HOME_DIR}/.walletwasabi"
+    sudo chmod 600 "${DATADIR}/Config.json"
+  fi
+
+  echo "# installing systemd service ${SERVICE}"
+  echo "\
+[Unit]
+Description=Wasabi Wallet daemon (headless client + JSON-RPC)
+Wants=bitcoind.service
+After=bitcoind.service
+
+[Service]
+ExecStart=${DOTNET} run -c Release --project ${SOURCE_DIR}/${CSPROJ} -- --datadir=${DATADIR}
+Environment=HOME=${HOME_DIR}
+Environment=DOTNET_ROOT=${DOTNET_DIR}
+User=${USERNAME}
+Group=${USERNAME}
+Type=simple
+Restart=always
+RestartSec=10
+
+# Hardening measures
+PrivateTmp=true
+ProtectSystem=full
+NoNewPrivileges=true
+PrivateDevices=true
+
+[Install]
+WantedBy=multi-user.target
+" | sudo tee /etc/systemd/system/${SERVICE}.service 1>&2
+  sudo systemctl daemon-reload 1>&2
+  sudo systemctl enable ${SERVICE} 1>&2
+
+  # install the dev-maintained 'wcli' as a system command (runs as the daemon
+  # user so it reads that user's Config.json for endpoint + credentials)
+  echo "# installing the wcli command"
+  printf '#!/bin/bash\nsudo -u %s HOME=%s bash %s/Contrib/CLI/wcli.sh "$@"\n' \
+    "${USERNAME}" "${HOME_DIR}" "${SOURCE_DIR}" | sudo tee /usr/local/bin/wcli >/dev/null
+  sudo chmod +x /usr/local/bin/wcli
+
+  # local-only RPC: no firewall port opened on purpose
+
+  /home/admin/config.scripts/blitz.conf.sh set wasabid "on" ${RASPIBLITZ_CONF} 1>&2
+
+  source $RASPIBLITZ_INFO 2>/dev/null
+  if [ "${state}" = "ready" ]; then
+    echo "# starting ${SERVICE} (first start compiles, may take minutes)"
+    sudo systemctl start ${SERVICE} 1>&2
+  else
+    echo "# enabled; start manually with: sudo systemctl start ${SERVICE}"
+  fi
+
+  echo "result='OK'"
+  exit 0
+fi
+
+###################
+# OFF
+###################
+if [ "$1" = "0" ] || [ "$1" = "off" ]; then
+  echo "# *** DEACTIVATE WASABI DAEMON ***"
+
+  sudo systemctl stop ${SERVICE} 2>/dev/null
+  sudo systemctl disable ${SERVICE} 2>/dev/null
+  sudo rm -f /etc/systemd/system/${SERVICE}.service
+  sudo systemctl daemon-reload 2>/dev/null
+
+  # remove the wcli command
+  sudo rm -f /usr/local/bin/wcli
+
+  /home/admin/config.scripts/blitz.conf.sh set wasabid "off" ${RASPIBLITZ_CONF} 1>&2
+
+  echo "# OK - Wasabi daemon deactivated (source & wallets kept)"
+  echo "result='OK'"
+  exit 0
+fi
+
+###################
+# UPDATE
+###################
+if [ "$1" = "update" ]; then
+  if [ ! -d "${SOURCE_DIR}" ]; then
+    echo "# *** WASABI DAEMON IS NOT INSTALLED ***"
+    exit 1
+  fi
+  echo "# *** UPDATE WASABI DAEMON ***"
+  cd ${SOURCE_DIR} || exit 1
+  sudo -u ${USERNAME} git fetch --tags --force 1>&2
+  if [ "$2" = "commit" ]; then
+    sudo -u ${USERNAME} git checkout --force master 1>&2
+    sudo -u ${USERNAME} git pull 1>&2
+  else
+    sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
+  fi
+  sudo -u ${USERNAME} bash -c "cd ${SOURCE_DIR} && HOME=${HOME_DIR} DOTNET_ROOT=${DOTNET_DIR} ${DOTNET} build -c Release ${CSPROJ}" || exit 1
+  if [ ${isActive} -gt 0 ]; then
+    sudo systemctl restart ${SERVICE} 1>&2
+  fi
+  echo "# OK - updated and rebuilt"
+  exit 0
+fi
+
+echo "FAIL - Unknown Parameter $1"
+exit 1

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -39,7 +39,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "bonus.wasabid.sh [install|uninstall]"
   echo "bonus.wasabid.sh [on|off|status|menu]"
   echo "bonus.wasabid.sh [examples]   # print wcli + curl usage cheat sheet"
-  echo "bonus.wasabid.sh [update|update commit]"
+  echo "bonus.wasabid.sh [update]"
   exit 1
 fi
 
@@ -402,12 +402,7 @@ if [ "$1" = "update" ]; then
   echo "# *** UPDATE WASABI DAEMON ***"
   cd ${SOURCE_DIR} || exit 1
   sudo -u ${USERNAME} git fetch --tags --force 1>&2
-  if [ "$2" = "commit" ]; then
-    sudo -u ${USERNAME} git checkout --force master 1>&2
-    sudo -u ${USERNAME} git pull 1>&2
-  else
-    sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
-  fi
+  sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
   # the new checkout may require a newer .NET SDK (e.g. 10.0) - ensure it
   ensure_dotnet_sdk || exit 1
   sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -270,16 +270,29 @@ lines = [
     f"WASABI_NETWORK={wnet}",
 ]
 # wire the client to the local bitcoind via RPC (trustless, uses the user's node)
-if os.path.exists(btc_path):
-    conf = {}
+# bitcoin.conf is network-scoped (main.rpcport=8332, test.rpcport=18332, ...), so
+# read the value for THIS network's prefix - never collapse them (a mainnet node
+# must not pick up test.rpcport=18332).
+NETMAP = {"Main": ("main", "8332"), "TestNet": ("test", "18332"),
+          "RegTest": ("regtest", "18443"), "Signet": ("signet", "38332")}
+cprefix, default_port = NETMAP.get(wnet, ("main", "8332"))
+def conf_get(key):
+    scoped = glob = None
     for line in open(btc_path, encoding="utf-8", errors="replace"):
         line = line.strip()
-        if "=" in line and not line.startswith("#"):
-            k, _, v = line.partition("=")
-            conf[k.strip().split(".")[-1]] = v.strip()  # drop main./test. prefixes
-    user = conf.get("rpcuser", "")
-    pwd = conf.get("rpcpassword", "")
-    rpcport = conf.get("rpcport", "8332")
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        k, v = k.strip(), v.strip()
+        if k == f"{cprefix}.{key}":
+            scoped = v
+        elif k == key:
+            glob = v
+    return scoped if scoped is not None else glob
+if os.path.exists(btc_path):
+    user = conf_get("rpcuser") or ""
+    pwd = conf_get("rpcpassword") or ""
+    rpcport = conf_get("rpcport") or default_port
     if user and pwd:
         lines += [
             "WASABI_USEBITCOINRPC=true",

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -8,9 +8,9 @@
 # advanced-only bonus.wasabi.sh).
 #
 # The .NET SDK channel is read from the project's global.json, so this auto-installs
-# the right SDK as the project moves on (8.0 for v2.7.2, 10.0 for the next release).
+# the right SDK as the project moves on (8.0 for v2.7.2, 10.0 for v2.8.0).
 
-VERSION="v2.7.2"
+VERSION="v2.8.0"
 REPO="WalletWasabi/WalletWasabi"
 USERNAME="wasabid"
 HOME_DIR="/home/${USERNAME}"

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -210,6 +210,12 @@ if [ "$1" = "install" ]; then
     exit 1
   }
 
+  # dotnet publish drops the execute bit on the bundled native binaries (Tor, hwi),
+  # so the daemon aborts at startup with "Permission denied" trying to launch Tor.
+  # Restore +x on them across whatever arch dirs were published.
+  echo "# restoring execute bit on bundled native binaries (Tor, hwi)"
+  sudo find ${PUBLISH_DIR}/BundledApps/Binaries -type f \( -name tor -o -name hwi \) -exec chmod +x {} \;
+
   echo "# OK - Wasabi daemon user, source, .NET and publish installed"
   exit 0
 fi

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -140,7 +140,8 @@ Manage it with the 'wcli' command:
   wcli createwallet MyWallet '\"pass\"'
   wcli -wallet=MyWallet getnewaddress \"label\" false
   wcli -wallet=MyWallet startcoinjoin pass true true\n
-Full cheat sheet:  sudo /home/admin/config.scripts/bonus.wasabid.sh examples
+Full cheat sheet (incl. raw curl):
+  sudo /home/admin/config.scripts/bonus.wasabid.sh examples\n
 Logs:              sudo journalctl -u ${SERVICE} -f
 Settings:          ${ENV_FILE}
 Docs:              https://docs.wasabiwallet.io/using-wasabi/RPC.html" 24 78

--- a/home.admin/config.scripts/bonus.wasabid.sh
+++ b/home.admin/config.scripts/bonus.wasabid.sh
@@ -39,7 +39,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "bonus.wasabid.sh [install|uninstall]"
   echo "bonus.wasabid.sh [on|off|status|menu]"
   echo "bonus.wasabid.sh [examples]   # print wcli + curl usage cheat sheet"
-  echo "bonus.wasabid.sh [update]"
+  echo "bonus.wasabid.sh [update|update <tag>]"
   exit 1
 fi
 
@@ -400,9 +400,14 @@ if [ "$1" = "update" ]; then
     exit 1
   fi
   echo "# *** UPDATE WASABI DAEMON ***"
+  # 'update' rebuilds the pinned VERSION; 'update <tag>' targets a specific upstream
+  # release tag (e.g. v2.8.1) for operators who want a newer build before the script
+  # pin is bumped. Only build a version you trust - it compiles upstream source as-is.
+  TARGET="${2:-$VERSION}"
+  [ "${TARGET}" != "${VERSION}" ] && echo "# NOTE: building ${TARGET}, not the pinned ${VERSION}" 1>&2
   cd ${SOURCE_DIR} || exit 1
   sudo -u ${USERNAME} git fetch --tags --force 1>&2
-  sudo -u ${USERNAME} git checkout --force ${VERSION} || exit 1
+  sudo -u ${USERNAME} git checkout --force "${TARGET}" || exit 1
   # the new checkout may require a newer .NET SDK (e.g. 10.0) - ensure it
   ensure_dotnet_sdk || exit 1
   sudo -u ${USERNAME} rm -rf ${PUBLISH_DIR}


### PR DESCRIPTION
## Summary

Adds two RaspiBlitz integrations for [WalletWasabi](https://github.com/WalletWasabi/WalletWasabi):

1. **`bonus.wasabid.sh`** — the headless **Wasabi client wallet daemon** (`WalletWasabi.Daemon`) with a local JSON-RPC interface, exposed as a regular **SERVICES menu** entry for everyday users.
2. **`bonus.wasabi.sh`** — the **WabiSabi coinjoin coordinator** backend, as an advanced **bonus script only** (intentionally *not* in the menu — running a coordinator is for advanced operators).

Both pin the latest official release (`v2.8.0`) and build from source.

## What's included

- `home.admin/config.scripts/bonus.wasabid.sh` — install/uninstall/on/off/status/menu/examples/update
- `home.admin/config.scripts/bonus.wasabi.sh` — install/uninstall/on/off/status/menu/update
- `home.admin/00settingsMenuServices.sh` — Services menu entry for the daemon (`wd`)
- `home.admin/_provision_.sh` — re-activate `wasabid` + `wasabi` after updates

## Daemon (client) details

- Dedicated `wasabid` user; per-user .NET SDK in `~/.dotnet`.
- Local-only JSON-RPC on `127.0.0.1:37128` with generated basic-auth credentials (no port exposed to the network).
- Wired to the **local bitcoind** via RPC (`UseBitcoinRpc`, `BitcoinRpcCredentialString`, `BitcoinRpcUri`) — uses the user's own node.
- Installs the dev-maintained **`wcli`** as a system command (auto-loads endpoint + credentials from `Config.json`, so users never type ports/passwords).
- `bonus.wasabid.sh examples` prints a copy-paste cheat sheet (`createwallet`, `recoverwallet`, `getnewaddress`, `startcoinjoin`, `payincoinjoin`) leading with `wcli`, curl as fallback.
- Verified against the daemon source: starts wallet-less (`InitializeNoWalletAsync`), RPC server up immediately, no restart loop before a wallet exists.

## Coordinator details

- Dedicated `wasabi` user; per-user .NET SDK.
- Binds `127.0.0.1:37126` only and is reached over a **Tor onion service by default** — no clearnet bind, no firewall port, no domain or port-forwarding, and the operator's IP stays private. (Operators who want clearnet can add their own reverse proxy.)
- **Ensures required `bitcoin.conf` settings** on activation: `txindex=1` (via `network.txindex.sh`), `blockfilterindex=1`, `peerblockfilters=1`, `server=1`, with a single bitcoind restart.
- Generates `Config.json` on first run (fresh `CoordinatorExtPubKey`), then patches in the bitcoind RPC connection; `chmod 600`.
- **Safety guard:** refuses to overwrite a pre-existing manually-installed coordinator service (won't clobber a hand-built deployment).

## Design notes

- **Services run a published build** (`dotnet publish` → `ExecStart=dotnet …/X.dll`), not `dotnet run` — no restore/build or network at service start.
- **.NET SDK channel is read from the project's `global.json`** — v2.7.2 used `8.0`, v2.8.0 uses `10.0`, provisioned automatically (verified on linux-arm64).
- **Network-aware**: `${network}.conf` path, `${network}d` service, Wasabi `Network` (Main/TestNet/RegTest).
- No secrets committed; RPC passwords are generated locally and stored `0600`.
- The coordinator changes are upstreamed and released in v2.8.0, so both scripts pin the `v2.8.0` tag (no master-tracking).

## Testing

- `bash -n` clean on all changed files; embedded Python validated with `ast.parse`.
- `.NET` channel parser verified for `8.0` / `10.0` / missing `global.json`.
- RPC method names, port, `UseTor` enum, and `wcli` quoting verified against the official docs and source.
- Config keys verified against a running v2.7.2 deployment.

## Notes for reviewers

- Coordinator and daemon target different user tiers; happy to split into two PRs if preferred.
- Defaults to mainnet config wiring; testnet/regtest mapped but less exercised.

---


---

## Update — v2.8.0 (verified on a linux-arm64 node)

Bumped both scripts from v2.7.2 to v2.8.0 and fixed issues that surfaced on v2.8.0, all verified end-to-end on a Raspberry Pi (linux-arm64):

1. **Build failure (NU1903).** v2.7.2 failed `dotnet publish`: the NuGet audit advisory [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (`SQLitePCLRaw.lib.e_sqlite3`) was promoted to an error under the project's `TreatWarningsAsErrors`. v2.8.0 bumps the dependency and adds a solution-wide `NuGetAuditSuppress`, so the build is clean with no script-side flag.
2. **.NET 10.** v2.8.0's `global.json` moves the SDK channel `8.0` -> `10.0`; `ensure_dotnet_sdk` provisions .NET 10 on demand, no script change.
3. **Bundled Tor not executable.** `dotnet publish` drops the execute bit on the bundled native binaries (Tor, hwi), so the daemon aborted at startup with "Permission denied" launching Tor and restart-looped. Restored with `chmod +x` after publish (install + update paths).
4. **Config.json no longer honored.** v2.8.0 runs a config migration on load that resets hand-written `Config.json` keys to defaults -- `JsonRpcServerEnabled` flipped to false (RPC server never bound; `wcli` couldn't connect) and the `UseBitcoinRpc` wiring was dropped (client synced over P2P, not the local node). Settings now go through `WASABI_*` environment variables (higher precedence, survive the rewrite) from a root-owned `0600` `EnvironmentFile`. Result: `getstatus` reports the local node (`peers: []`) and RPC binds `127.0.0.1:37128`. Local RPC is auth-less (loopback only, no firewall port) -- upstream's own localhost RPC model.

### Additional fixes found while testing both services end-to-end on linux-arm64

5. **bitcoind `rpcport` was read network-blind.** RaspiBlitz's `bitcoin.conf` is network-scoped (`main.rpcport=8332`, `test.rpcport=18332`, …); both scripts collapsed the prefixes and took the last `rpcport`, wiring a mainnet node to `18332`. Now the active network's scoped value is read (with the standard per-network default as fallback).
6. **Daemon RPC switch name.** The daemon's `BitcoinRpcUri` is populated by the switch named `BitcoinRpcEndPoint` (there is no `UseBitcoinRpc` switch), so the env file now sets `WASABI_BITCOINRPCENDPOINT` + `WASABI_BITCOINRPCCREDENTIALSTRING`. Verified: daemon now syncs from the local node (`Fetched fee rate from RPC node`), not P2P.
7. **Coordinator binds localhost + onion only.** It previously bound a second endpoint on `127.0.0.1:5000`, which collides with common services (LNBits) and crashed Kestrel. It now binds a single `127.0.0.1:37126` endpoint and publishes a Tor onion unconditionally (ensuring Tor is installed first). Verified: coordinator reaches the node (`Bitcoin Node is fully synchronized`) and creates WabiSabi rounds.

_Note: the daemon (`bonus.wasabid.sh`) is verified on linux-arm64. The coordinator (`bonus.wasabi.sh`) carries the same v2.8.0 + Tor fixes but its config wiring is still being validated separately._


