### PR TITLE
Harden Tor update path for 0.4.9 sunset

### DIFF
--- a/home.admin/config.scripts/tor.install.sh
+++ b/home.admin/config.scripts/tor.install.sh
@@ -33,6 +33,7 @@ tor_deb_repo="tor+http://apow7mjfryruh65chtdydfmqfpj5btws7nbocgtaovhvezgccyjazpq
 #tor_deb_repo="https://deb.torproject.org"
 tor_deb_repo_clean="${tor_deb_repo#*tor+}"
 tor_deb_repo_pgp_fingerprint="A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89"
+tor_min_supported_version="0.4.9"
 
 ## https://github.com/keroserene/snowflake/commits/master
 snowflake_commit_hash="af6e2c30e1a6aacc6e7adf9a31df0a387891cc37"
@@ -116,6 +117,28 @@ configure_bridges_torrc(){
 " | sudo tee ${torrc_bridges}
 }
 
+require_supported_tor_version(){
+  tor_version=$(tor --version | awk 'NR==1 {print $3}' | sed 's/\.$//')
+  if [ ${#tor_version} -eq 0 ]; then
+    echo "! FAIL: Was not able to detect installed Tor version"
+    exit 1
+  fi
+  if ! dpkg --compare-versions "${tor_version}" ge "${tor_min_supported_version}"; then
+    echo "! FAIL: Installed Tor ${tor_version} is older than required ${tor_min_supported_version}"
+    echo "! INFO: Tor 0.4.8 and older are EOL and scheduled to stop working on the Tor network"
+    exit 1
+  fi
+  echo "- OK Tor ${tor_version} >= ${tor_min_supported_version}"
+}
+
+restart_tor_service(){
+  if systemctl cat tor@default.service >/dev/null 2>&1; then
+    sudo systemctl restart tor@default
+  else
+    sudo systemctl restart tor
+  fi
+}
+
 
 action=$1
 
@@ -175,6 +198,7 @@ if [ "${action}" = "install" ]; then
   sudo apt -o Dpkg::Options::="--force-confold" install -y tor
   # shellcheck disable=SC2086
   sudo apt install -y ${tor_pkgs}
+  require_supported_tor_version
 
   # make sure tor is not running after is was installed
   # should be enabled after main menu when HDD is mounted
@@ -305,13 +329,19 @@ if [ "${action}" = "update" ]; then
         sudo systemctl stop tor
         echo "# Update ..."
         sudo dpkg -i tor_*.deb
+        require_supported_tor_version
         echo "# Starting the tor.service "
-        sudo systemctl start tor
+        restart_tor_service
         echo "# Installed $(tor --version)"
       ;;
       *)
         add_tor_sources
-        sudo apt update && sudo apt install tor && sudo systemctl restart tor
+        sudo apt update || exit 1
+        sudo apt -o Dpkg::Options::="--force-confold" install -y tor || exit 1
+        # shellcheck disable=SC2086
+        sudo apt install -y ${tor_pkgs} || exit 1
+        require_supported_tor_version
+        restart_tor_service
       ;;
     esac
   echo


### PR DESCRIPTION
## Summary

Tor Project announced that Tor 0.4.8 reached EOL on June 1, 2026 and that 0.4.8 and older are expected to stop working on the Tor network around September 1, 2026.

RaspiBlitz already adds deb.torproject.org in `tor.install.sh`, and current Bookworm repositories provide Tor 0.4.9.x. This PR hardens the update path so older nodes do not silently remain on an EOL Tor release.

## Changes

- add a minimum supported Tor version guard of 0.4.9
- verify the installed Tor version after fresh install, binary package update, and source-package update
- make the default Tor update path non-interactive with `apt install -y`
- reinstall the existing Tor helper package set during updates so the Tor Project repo is applied consistently
- restart `tor@default` when available, falling back to `tor`

## Validation

- `bash -n home.admin/config.scripts/tor.install.sh`
- `git diff --check`

Fixes #5298
