### PR TITLE
fix(nginx): proxy WebSocket upgrades for the API /api/ws endpoint

### DIFF
--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -17,6 +17,16 @@ server {
 
 
 	# proxy for API
+	# WebSocket endpoint for the realtime API channel
+	location /api/ws {
+		proxy_pass         http://127.0.0.1:11111/ws;
+		proxy_http_version 1.1;
+		proxy_set_header   Upgrade $http_upgrade;
+		proxy_set_header   Connection "upgrade";
+		proxy_set_header   X-Real-IP $remote_addr;
+		proxy_set_header   X-Forwarded-Host   $host;
+		proxy_read_timeout 86400;
+	}
 	location /api/ {
 		proxy_pass        http://127.0.0.1:11111/;
 		proxy_set_header  X-Real-IP $remote_addr;

--- a/home.admin/assets/nginx/sites-available/public.httponly.conf
+++ b/home.admin/assets/nginx/sites-available/public.httponly.conf
@@ -11,6 +11,16 @@ server {
 	include /etc/nginx/snippets/gzip-params.conf;
 
 	# proxy for API
+	# WebSocket endpoint for the realtime API channel
+	location /api/ws {
+		proxy_pass         http://127.0.0.1:11111/ws;
+		proxy_http_version 1.1;
+		proxy_set_header   Upgrade $http_upgrade;
+		proxy_set_header   Connection "upgrade";
+		proxy_set_header   X-Real-IP $remote_addr;
+		proxy_set_header   X-Forwarded-Host   $host;
+		proxy_read_timeout 86400;
+	}
 	location /api/ {
 		proxy_pass        http://127.0.0.1:11111/;
 		proxy_set_header  X-Real-IP $remote_addr;


### PR DESCRIPTION
## What
  The Web UI now uses a WebSocket (`/api/ws`) instead of SSE for realtime data.  Add a `location /api/ws` with `proxy_http_version 1.1` + `Upgrade`/`Connection`  headers so the handshake reaches `blitz_api`.  Without them nginx falls through to  `location /` and the connection fails.


  ## Testing
  - HTTP-only: `sudo cp .../public.httponly.conf /etc/nginx/sites-available/public.conf && sudo nginx -t && sudo systemctl reload nginx`
  - Open the Web UI → the `/api/ws` connection upgrades to `101` and realtime data flows.