### PR TITLE
fix cl.hsmtool.sh generatehsm stdin interface for CLN >= v25.12

### DIFF
--- a/.github/workflows/test-bats.yml
+++ b/.github/workflows/test-bats.yml
@@ -10,10 +10,14 @@ on:
     branches: ["dev"]
     paths:
       - "home.admin/config.scripts/bonus.postgresql.sh"
+      - "home.admin/config.scripts/cl.hsmtool.sh"
+      - "test/cl.hsmtool-generatehsm.bats"
   pull_request:
     branches: ["*"]
     paths:
       - "home.admin/config.scripts/bonus.postgresql.sh"
+      - "home.admin/config.scripts/cl.hsmtool.sh"
+      - "test/cl.hsmtool-generatehsm.bats"
 
 jobs:
   run-bats-tests:
@@ -36,3 +40,8 @@ jobs:
         run: |
           cd test
           sudo bats ./bonus.postgresql-13.bats
+
+      - name: Run the cl.hsmtool generatehsm interface tests
+        run: |
+          cd test
+          bats ./cl.hsmtool-generatehsm.bats

--- a/home.admin/config.scripts/cl.hsmtool.sh
+++ b/home.admin/config.scripts/cl.hsmtool.sh
@@ -54,6 +54,17 @@ fi
 #############
 # Functions #
 #############
+# Builds the stdin payload for 'lightning-hsmtool generatehsm'.
+# CLN >= v25.12 expects the BIP39 mnemonic on the first stdin line and the
+# passphrase (may be empty) on the second line - there is no language
+# selection prompt and no passphrase confirmation any more.
+# $1 = seedwords (space separated)
+# $2 = seedpassword (may be empty)
+function generateHsmInput() {
+  echo "$1"
+  echo "$2"
+}
+
 function passwordToFile() {
   if [ $# -gt 0 ];then
     text="$1"
@@ -264,14 +275,9 @@ seedwords6x4='${seedwords6x4}'
 " | sudo -u bitcoin tee /home/bitcoin/.lightning/${CLNETWORK}/seedwords.info
 
   # pass to 'hsmtool generatehsm hsm_secret'
-  if [ ${#seedpassword} -eq 0 ]; then
-    (echo "0"; echo "${seedwords}"; echo) | sudo -u bitcoin lightning-hsmtool \
-     "generatehsm" $hsmSecretPath 1>&2
-  else
-    # pass to 'hsmtool generatehsm hsm_secret' - confirm seedpassword
-    (echo "0"; echo "${seedwords}"; echo "$seedpassword"; echo "$seedpassword")\
-     | sudo -u bitcoin lightning-hsmtool "generatehsm" $hsmSecretPath 1>&2
-  fi
+  # CLN >= v25.12: mnemonic on the first stdin line, passphrase on the second
+  generateHsmInput "${seedwords}" "${seedpassword}" | sudo -u bitcoin \
+   lightning-hsmtool "generatehsm" $hsmSecretPath 1>&2 || exit 1
 
   echo "# Re-init the backup plugin with the new wallet"
   /home/admin/config.scripts/cl-plugin.backup.sh on $CHAIN

--- a/test/cl.hsmtool-generatehsm.bats
+++ b/test/cl.hsmtool-generatehsm.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+
+# Tests for the 'lightning-hsmtool generatehsm' stdin interface used by
+# home.admin/config.scripts/cl.hsmtool.sh
+#
+# Background:
+# CLN < v25.12 'generatehsm' first asked for a wordlist number ("0" = english),
+# then the mnemonic, then the passphrase twice (confirmation).
+# CLN >= v25.12 reads the BIP39 mnemonic from the FIRST stdin line and the
+# passphrase (once) from the second line. Sending the old payload makes
+# hsmtool read "0" as the mnemonic, fail BIP39 validation and abort
+# (fail-closed: no hsm_secret is created and no weak wallet is possible).
+
+SCRIPT="${BATS_TEST_DIRNAME}/../home.admin/config.scripts/cl.hsmtool.sh"
+# 12-word BIP39 test vector (valid checksum)
+MNEMONIC="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+setup() {
+  TESTDIR="$(mktemp -d)"
+
+  # mock 'lightning-hsmtool' implementing the CLN >= v25.12 generatehsm
+  # interface: first stdin line = mnemonic, second stdin line = passphrase
+  cat > "$TESTDIR/lightning-hsmtool" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" != "generatehsm" ] || [ -z "$2" ]; then
+  echo "usage: lightning-hsmtool generatehsm <path>" >&2
+  exit 1
+fi
+hsm="$2"
+if [ -e "$hsm" ]; then
+  echo "hsm_secret file at $hsm already exists" >&2
+  exit 1
+fi
+# first stdin line must be a valid BIP39 mnemonic (>=12 lowercase words)
+read -r mnemonic
+count=$(echo "$mnemonic" | wc -w)
+if [ "$count" -lt 12 ] || ! echo "$mnemonic" | grep -qE '^[a-z ]+$'; then
+  echo "Could not read mnemonic: invalid format" >&2
+  exit 1
+fi
+# second stdin line is the passphrase (may be empty)
+read -r passphrase || passphrase=""
+{
+  echo "mock-hsm-secret"
+  echo "mnemonic=$mnemonic"
+  echo "passphrase=$passphrase"
+} > "$hsm"
+echo "New hsm_secret file created at $hsm"
+EOF
+  chmod +x "$TESTDIR/lightning-hsmtool"
+
+  # mock 'sudo': drop '-u <user>' and exec the rest
+  cat > "$TESTDIR/sudo" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "-u" ]; then shift 2; fi
+exec "$@"
+EOF
+  chmod +x "$TESTDIR/sudo"
+
+  export PATH="$TESTDIR:$PATH"
+
+  # load the function under test from the real script
+  eval "$(sed -n '/^function generateHsmInput/,/^}/p' "$SCRIPT")"
+}
+
+teardown() {
+  rm -rf "$TESTDIR"
+}
+
+# replicate the exact pipeline used in cl.hsmtool.sh
+pipe_to_hsmtool() {
+  generateHsmInput "$1" "$2" | sudo -u bitcoin \
+    lightning-hsmtool "generatehsm" "$3" 1>&2
+}
+
+@test "problem: old input format (language id first) is rejected by CLN >= v25.12" {
+  hsm="$TESTDIR/hsm_secret_old"
+  # this is exactly what cl.hsmtool.sh piped before the fix:
+  # language id "0", mnemonic, empty passphrase
+  run bash -c "(echo '0'; echo '$MNEMONIC'; echo) | lightning-hsmtool generatehsm '$hsm'"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Could not read mnemonic"* ]]
+  # fail-closed: no wallet file was created
+  [ ! -e "$hsm" ]
+}
+
+@test "fix: generateHsmInput without seedpassword creates the wallet" {
+  hsm="$TESTDIR/hsm_secret_nopass"
+  run pipe_to_hsmtool "$MNEMONIC" "" "$hsm"
+  [ "$status" -eq 0 ]
+  [ -f "$hsm" ]
+  grep -q "mnemonic=$MNEMONIC" "$hsm"
+  grep -q "^passphrase=$" "$hsm"
+}
+
+@test "fix: generateHsmInput with seedpassword passes it as the second line" {
+  hsm="$TESTDIR/hsm_secret_pass"
+  run pipe_to_hsmtool "$MNEMONIC" "secretpass" "$hsm"
+  [ "$status" -eq 0 ]
+  [ -f "$hsm" ]
+  grep -q "mnemonic=$MNEMONIC" "$hsm"
+  grep -q "^passphrase=secretpass$" "$hsm"
+}
+
+@test "fix: first line of generateHsmInput output is the mnemonic" {
+  run generateHsmInput "$MNEMONIC" "whatever"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$MNEMONIC" ]
+  [ "${lines[1]}" = "whatever" ]
+  [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "script: generatehsm call uses generateHsmInput" {
+  grep -q 'generateHsmInput "${seedwords}" "${seedpassword}"' "$SCRIPT"
+}
+
+@test "script: no legacy language id is piped to hsmtool anymore" {
+  run grep -n 'echo "0"' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Problem

CLN **v25.12** changed the `lightning-hsmtool generatehsm` stdin interface (see `tools/lightning-hsmtool.c` → `generate_hsm` → `read_stdin_mnemonic` in `common/hsm_secret.c`):

| | CLN < v25.12 | CLN >= v25.12 |
|---|---|---|
| stdin line 1 | wordlist number (`0` = english) | **BIP39 mnemonic** |
| stdin line 2 | mnemonic | passphrase (once) |
| stdin line 3 | passphrase | — |
| stdin line 4 | passphrase (confirm) | — |

`cl.hsmtool.sh` still pipes the **old** payload:

```bash
(echo "0"; echo "${seedwords}"; echo) | sudo -u bitcoin lightning-hsmtool "generatehsm" $hsmSecretPath
```

With the pinned **CLN v26.06.1** (`cl.install.sh`: `CLVERSION="v26.06.1"`) hsmtool reads `"0"` as the mnemonic, BIP39 validation fails, and `errx(EXITCODE_ERROR_HSM_FILE, "Could not read mnemonic")` aborts **before any file is created** → wallet creation is broken.

The failure is **fail-closed**: no `hsm_secret` is written, so no weak/misformed wallet can ever result. It is a functional break, not a security weakness. (Found during an AI-assisted audit of RaspiBlitz self-generated wallet seed entropy — the entropy path itself, `blitz.mnemonic.py` → `python-mnemonic==0.19` → `os.urandom(32)`, is sound.)

## Fix

New `generateHsmInput()` helper pipes the payload in the new format:

```bash
generateHsmInput "${seedwords}" "${seedpassword}" | sudo -u bitcoin \
 lightning-hsmtool "generatehsm" $hsmSecretPath 1>&2 || exit 1
```

- line 1 = mnemonic, line 2 = passphrase (may be empty)
- no more language id, no more passphrase confirmation (the new hsmtool reads the passphrase only once)
- the script now also **exits non-zero if hsmtool fails** instead of silently continuing to re-init the backup plugin

## Test

`test/cl.hsmtool-generatehsm.bats` — runs in the existing `test-bats.yml` workflow (now also triggered on `cl.hsmtool.sh` changes). It uses a mock `lightning-hsmtool` implementing the **new >= v25.12 interface** and:

1. **demonstrates the problem** — the exact old payload (`echo '0'` first) is rejected, no wallet file created (fail-closed verified)
2. **demonstrates the fix** — `generateHsmInput` creates the wallet, with and without seedpassword
3. guards the function output format (mnemonic on line 1, exactly 2 lines)
4. guards the script: no legacy `echo "0"` left, `generatehsm` call uses `generateHsmInput`

All 6 tests pass locally with bats-core:

```
1..6
ok 1 problem: old input format (language id first) is rejected by CLN >= v25.12
ok 2 fix: generateHsmInput without seedpassword creates the wallet
ok 3 fix: generateHsmInput with seedpassword passes it as the second line
ok 4 fix: first line of generateHsmInput output is the mnemonic
ok 5 script: generatehsm call uses generateHsmInput
ok 6 script: no legacy language id is piped to hsmtool anymore
```

## Note

The new hsmtool writes `hsm_secret` in the **mnemonic format** (seed hash + mnemonic) instead of the legacy 32-byte binary — this is the intended CLN >= v25.12 behavior; `lightningd` reads both formats.