### PR TITLE
blitz.data.sh: detect VirtIO Block (vd*) drives

### DIFF
--- a/home.admin/config.scripts/blitz.data.sh
+++ b/home.admin/config.scripts/blitz.data.sh
@@ -231,8 +231,8 @@ if [ "$action" = "status" ]; then
     dataConfigFound=0
     combinedDataStorage=0
     
-    # get a list of all existing ext4 partitions of connected storage drives (sdX, nvmeX) - sorted by size (smallest first, then by name)
-    ext4Partitions=$(lsblk -b -n -l -o NAME,SIZE,FSTYPE,TYPE | grep "part" | grep "ext4" | grep -E "^(sd|nvme)" | awk '{print $1, $2}' | sort -k2,2n -k1,1)
+    # get a list of all existing ext4 partitions of connected storage drives (sdX, vdX, nvmeX) - sorted by size (smallest first, then by name)
+    ext4Partitions=$(lsblk -b -n -l -o NAME,SIZE,FSTYPE,TYPE | grep "part" | grep "ext4" | grep -E "^(sd|vd|nvme)" | awk '{print $1, $2}' | sort -k2,2n -k1,1)
     if [ ${#ext4Partitions} -eq 0 ]; then
         echo "# no ext4 partitions found"
     fi
@@ -441,7 +441,7 @@ if [ "$action" = "status" ]; then
     biggerSizeGB=""
     if [ -n "${storageDevice}" ]; then
         # get a list of all connected drives >7GB ordered by size (biggest first)
-        listOfBiggerDevices=$(lsblk -dno NAME,SIZE | grep -E "^(sd|nvme)" | \
+        listOfBiggerDevices=$(lsblk -dno NAME,SIZE | grep -E "^(sd|vd|nvme)" | \
         awk '{ 
         size=$2
         if(size ~ /T/) { 
@@ -485,7 +485,7 @@ if [ "$action" = "status" ]; then
         echo "# PROPOSING LAYOUT ..."
 
         # get a list of all connected drives >31GB ordered by size (biggest first)
-        listOfDevices=$(lsblk -dno NAME,SIZE | grep -E "^(sd|nvme)" | \
+        listOfDevices=$(lsblk -dno NAME,SIZE | grep -E "^(sd|vd|nvme)" | \
         awk '{ 
         size=$2
         if(size ~ /T/) { 


### PR DESCRIPTION
## Problem
Drive detection in `blitz.data.sh` only matches `sd*` and `nvme*` devices. Disks attached via **VirtIO Block** in Proxmox/KVM VMs appear as `/dev/vdX` and are invisible to the script — bootstrap hangs forever at `Waiting for HDD/SSD ...` even though the drive is attached and readable.

Reported by a user upgrading 1.11.4 → dev on a Proxmox VM (Telegram support group). Worked in v1.11 (old datadrive script accepted vd*), so this is a regression. VirtIO Block is the default/recommended disk bus in Proxmox and easier for PCI/USB pass-through than SCSI, so VM users will hit this often.

## Fix
Add `vd` to the three device-list filters in `blitz.data.sh status`:
- ext4 partition scan (l.235)
- bigger-device scan (l.444)
- layout proposal (l.488)

No partition-naming special case needed: vd partitions are `vdX1`-style like sd (unlike nvme `p1` scheme), so existing `sed 's/p?[0-9]+$//'` device-name extraction works unchanged.

`_bootstrap.sh` GPT integrity check already includes `vd` — this aligns the data-drive detection with it.

## Test
- `bash -n` syntax check passes
- User confirmed detection works after re-attaching the same disk as SCSI (sd*); with this patch VirtIO (vd*) behaves identically