### PR TITLE
update joninbox to v0.9.0 w joinmarket v0.9.12

### DIFF
--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -6,8 +6,7 @@
 # https://github.com/openoms/joininbox
 
 # https://github.com/openoms/joininbox/tags
-JBTAG="v0.8.5" # installs JoinMarket commit https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/ce32bafbb5d716bde61830f71266410249d43dbc
-
+JBTAG="v0.9.0" # installs JoinMarket v0.9.12 https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.12
 # command info
 if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "JoinMarket install script to install and switch JoinMarket on or off"

--- a/home.admin/config.scripts/bonus.joinmarket.sh
+++ b/home.admin/config.scripts/bonus.joinmarket.sh
@@ -12,8 +12,8 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "-help" ]; then
   echo "JoinMarket install script to install and switch JoinMarket on or off"
   echo "sudo /home/admin/config.scripts/bonus.joinmarket.sh install"
   echo "sudo /home/admin/config.scripts/bonus.joinmarket.sh on|off"
-  echo "Installs JoininBox $JBTAG with JoinMarket commit:"
-  echo "https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/ce32bafbb5d716bde61830f71266410249d43dbc"
+  echo "Installs JoininBox $JBTAG with JoinMarket v0.9.12:"
+  echo "https://github.com/JoinMarket-Org/joinmarket-clientserver/releases/tag/v0.9.12"
   exit 1
 fi
 


### PR DESCRIPTION
This migrates the watch-only BItcoin Core wallets to descriptor format to be compatible with BItcoin Core v30 and above

Details: https://github.com/openoms/joininbox/blob/master/FAQ.md#migrating-from-legacy-walletdat-to-descriptor-wallet

Release notes: https://github.com/openoms/joininbox/releases/tag/v0.9.0