### PR TITLE
cl.install.sh: add update-binary path for prebuilt CLN tarballs

### DIFF
--- a/.github/workflows/test-bats.yml
+++ b/.github/workflows/test-bats.yml
@@ -35,7 +35,7 @@ jobs:
         # no sudo: these only exercise the version / asset existence checks
         run: |
           cd test
-          bats --verbose-run ./cl.install.bats
+          bats ./cl.install.bats
 
       - name: Run the bats tests with postgresql 15
         run: |

--- a/.github/workflows/test-bats.yml
+++ b/.github/workflows/test-bats.yml
@@ -10,10 +10,14 @@ on:
     branches: ["dev"]
     paths:
       - "home.admin/config.scripts/bonus.postgresql.sh"
+      - "home.admin/config.scripts/cl.install.sh"
+      - "test/**"
   pull_request:
     branches: ["*"]
     paths:
       - "home.admin/config.scripts/bonus.postgresql.sh"
+      - "home.admin/config.scripts/cl.install.sh"
+      - "test/**"
 
 jobs:
   run-bats-tests:
@@ -26,6 +30,12 @@ jobs:
         run: |
           sudo apt update &>/dev/null
           sudo apt install -y bats
+
+      - name: Run the cl.install.sh pre-flight tests
+        # no sudo: these only exercise the version / asset existence checks
+        run: |
+          cd test
+          bats --verbose-run ./cl.install.bats
 
       - name: Run the bats tests with postgresql 15
         run: |

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -33,7 +33,7 @@ if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "cl.install.sh install - called by build_sdcard.sh"
   echo "cl.install.sh on <mainnet|testnet|signet>"
   echo "cl.install.sh off <mainnet|testnet|signet> <purge>"
-  echo "cl.install.sh [update <version>|testPR <PRnumber>]"
+  echo "cl.install.sh [update <version>|update-binary <version>|testPR <PRnumber>]"
   echo "cl.install.sh display-seed <mainnet|testnet|signet>"
   echo
   exit 1
@@ -143,10 +143,12 @@ function importPGPKey() {
 }
 
 function verifySHA256SUMSSignature() {
+  # Optional parameter: basename of the SHA256SUMS file (default SHA256SUMS-${CLVERSION})
+  local sumsFile="${1:-SHA256SUMS-${CLVERSION}}"
   local verifyOutput="/tmp/cl_gpg_verify.txt"
   local goodSignature
 
-  sudo -u bitcoin gpg --verify "SHA256SUMS-${CLVERSION}.asc" "SHA256SUMS-${CLVERSION}" 2>&1 | tee "${verifyOutput}"
+  sudo -u bitcoin gpg --verify "${sumsFile}.asc" "${sumsFile}" 2>&1 | tee "${verifyOutput}"
   goodSignature=$(grep -c "Good signature" "${verifyOutput}")
   [ "${goodSignature}" -ge 1 ]
 }
@@ -220,6 +222,111 @@ function downloadAndVerifySourceZip() {
   sudo -u bitcoin rm -f "clightning-${CLVERSION}.zip" "SHA256SUMS-${CLVERSION}" "SHA256SUMS-${CLVERSION}.asc"
 }
 
+function downloadAndVerifyBinaryTarball() {
+  # Downloads, verifies and extracts the prebuilt CLN binary tarball
+  # Uses CLVERSION variable for the version to download
+  # Needed for embargoed security releases where the source zip is not published
+  local arch tarballArch tarballName sumsSuffix ubuntuVersion glibcVersion
+  local downloadUrl expectedChecksum actualChecksum
+
+  cd /home/bitcoin || exit 1
+  echo
+  echo "- Downloading Core Lightning ${CLVERSION} binary release"
+  echo
+
+  # Map machine architecture to release asset naming
+  arch=$(uname -m)
+  case "${arch}" in
+    x86_64) tarballArch="amd64" ;;
+    aarch64) tarballArch="arm64" ;;
+    *)
+      echo "# ERROR --> unsupported architecture for binary install: ${arch}"
+      exit 1
+      ;;
+  esac
+
+  # arm64 checksums are in a separate manifest file
+  if [ "${tarballArch}" = "arm64" ]; then
+    sumsSuffix="-arm64"
+  else
+    sumsSuffix=""
+  fi
+
+  # Pick the Ubuntu build matching the local glibc (binaries need glibc >= build version)
+  # Ubuntu 22.04 = glibc 2.35, 24.04 = 2.39, 26.04 = 2.41
+  glibcVersion=$(ldd --version | head -1 | grep -oE '[0-9]+\.[0-9]+$')
+  case "${glibcVersion}" in
+    2.35|2.36|2.37|2.38) ubuntuVersion="22.04" ;;
+    2.39|2.40) ubuntuVersion="24.04" ;;
+    2.41|2.42) ubuntuVersion="26.04" ;;
+    *)
+      echo "# ERROR --> unsupported glibc version: ${glibcVersion}"
+      echo "# Need glibc >= 2.35 (Debian 12+ / Ubuntu 22.04+)"
+      exit 1
+      ;;
+  esac
+  echo "# Detected: arch=${tarballArch} glibc=${glibcVersion} -> Ubuntu-${ubuntuVersion} build"
+
+  tarballName="clightning-${CLVERSION}-Ubuntu-${ubuntuVersion}-${tarballArch}.tar.xz"
+  downloadUrl="https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}"
+
+  # Download the tarball, checksum manifest and signature
+  sudo -u bitcoin wget -O "${tarballName}" \
+    "${downloadUrl}/${tarballName}" || exit 1
+  sudo -u bitcoin wget -O "SHA256SUMS-${CLVERSION}${sumsSuffix}" \
+    "${downloadUrl}/SHA256SUMS-${CLVERSION}${sumsSuffix}" || exit 1
+  sudo -u bitcoin wget -O "SHA256SUMS-${CLVERSION}${sumsSuffix}.asc" \
+    "${downloadUrl}/SHA256SUMS-${CLVERSION}${sumsSuffix}.asc" || exit 1
+
+  if importPGPKey "${PGPsigner}" "${PGPpubkeyLink}" "${PGPpubkeyFingerprint}"; then
+    primaryKeyImported=1
+  else
+    echo "# WARNING --> ${PGPsigner} PGP key could not be imported"
+    primaryKeyImported=0
+  fi
+
+  echo
+  echo "- Verifying SHA256SUMS signature"
+  echo
+
+  if [ "${primaryKeyImported}" -ne 1 ] || ! verifySHA256SUMSSignature "SHA256SUMS-${CLVERSION}${sumsSuffix}"; then
+    echo "# SHA256SUMS signature was not verified with ${PGPsigner}"
+    echo "# Trying fallback PGP key ${PGPfallbackSigner}"
+    importPGPKey "${PGPfallbackSigner}" "${PGPfallbackPubkeyLink}" "${PGPfallbackPubkeyFingerprint}" || exit 1
+    echo
+    echo "- Verifying SHA256SUMS signature with fallback key"
+    echo
+    if ! verifySHA256SUMSSignature "SHA256SUMS-${CLVERSION}${sumsSuffix}"; then
+      echo "# ERROR --> SHA256SUMS signature verification failed"
+      exit 1
+    fi
+  fi
+  echo "# OK - SHA256SUMS signature verified"
+
+  echo
+  echo "- Verifying tarball checksum"
+  echo
+
+  expectedChecksum=$(grep "${tarballName}" "SHA256SUMS-${CLVERSION}${sumsSuffix}" | awk '{print $1}')
+  actualChecksum=$(sha256sum "${tarballName}" | awk '{print $1}')
+  if [ -z "${expectedChecksum}" ] || [ "${expectedChecksum}" != "${actualChecksum}" ]; then
+    echo "# ERROR --> Checksum mismatch for ${tarballName}"
+    echo "# Expected: ${expectedChecksum}"
+    echo "# Actual: ${actualChecksum}"
+    exit 1
+  fi
+  echo "# OK - Checksum verified for ${tarballName}"
+
+  echo
+  echo "- Extracting binaries to /usr/local"
+  echo
+
+  # Tarball contains ./usr/bin, ./usr/libexec, ./usr/share -> strip 2 levels to land in /usr/local
+  sudo tar -xvf "${tarballName}" -C /usr/local --strip-components=2 || exit 1
+  sudo rm -f "${tarballName}" "SHA256SUMS-${CLVERSION}${sumsSuffix}" "SHA256SUMS-${CLVERSION}${sumsSuffix}.asc"
+  echo "# OK - Binaries installed to /usr/local"
+}
+
 function runTests() {
   # Test dependencies are managed by uv sync in installDependencies()
   cd /home/bitcoin/lightning || exit 1
@@ -231,7 +338,7 @@ function runTests() {
 echo "# Running: 'cl.install.sh $*'"
 
 # check for version if specified
-if [ "$1" = "update" ] && [ $# -gt 1 ]; then
+if { [ "$1" = "update" ] || [ "$1" = "update-binary" ]; } && [ $# -gt 1 ]; then
   CLVERSION=$2
   if curl --output /dev/null --silent --head --fail \
     https://github.com/ElementsProject/lightning/releases/tag/${CLVERSION}; then
@@ -303,6 +410,59 @@ if [ "$1" = "install" ]; then
   fi
   echo
   echo "- OK the installation of Core Lightning ${installed} is successful"
+  exit 0
+fi
+
+if [ "$1" = "update-binary" ]; then
+
+  echo "# *** UPDATE CORE LIGHTNING TO ${CLVERSION} FROM BINARY TARBALL ***"
+  echo "# downloads and verifies the prebuilt release, then installs to /usr/local"
+  echo "# use for embargoed security releases where the source zip is not published"
+
+  # check if CLN is installed at all
+  if [ ! -f /usr/local/bin/lightningd ]; then
+    echo "# ERROR --> /usr/local/bin/lightningd not found"
+    echo "# Run 'cl.install.sh on <mainnet|testnet|signet>' for a fresh install instead"
+    exit 1
+  fi
+
+  echo
+  echo "# This replaces the running Core Lightning binaries with ${CLVERSION}"
+  echo "# Enabled lightningd services will be restarted"
+  echo "# Make sure this is intended, there might be no way to downgrade your database"
+  echo "# Press ENTER to continue or CTRL+C to abort the update"
+  read -r key
+
+  downloadAndVerifyBinaryTarball
+
+  installed=$(sudo -u bitcoin /usr/local/bin/lightningd --version)
+  if [ ${#installed} -eq 0 ]; then
+    echo
+    echo "# INSTALL FAILED --> Was not able to install Core Lightning"
+    exit 1
+  fi
+  correctVersion=$(echo "${installed}" | grep -c "${CLVERSION:1}")
+  if [ "${correctVersion}" -eq 0 ]; then
+    echo
+    echo "# INSTALL FAILED --> installed Core Lightning is not version ${CLVERSION}"
+    sudo -u bitcoin /usr/local/bin/lightningd --version
+    exit 1
+  fi
+
+  echo
+  echo "# Restarting enabled lightningd services"
+  for service in lightningd tlightningd slightningd; do
+    if sudo systemctl is-enabled ${service} 2>/dev/null | grep -q "enabled"; then
+      echo "# sudo systemctl restart ${service}"
+      sudo systemctl restart ${service}
+    fi
+  done
+
+  echo
+  echo "- OK the update to Core Lightning ${installed} is successful"
+  echo "# Monitor with:"
+  echo "sudo journalctl -fu lightningd"
+  echo "sudo tail -f /home/bitcoin/.lightning/bitcoin/cl.log"
   exit 0
 fi
 

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -349,6 +349,19 @@ if { [ "$1" = "update" ] || [ "$1" = "update-binary" ]; } && [ $# -gt 1 ]; then
     echo "# Exiting 'cl.install.sh $*' script"
     exit 1
   fi
+
+  if [ "$1" = "update" ]; then
+    # The source zip is not published for embargoed security releases
+    if curl --output /dev/null --silent --head --fail \
+      "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/clightning-${CLVERSION}.zip"; then
+      echo "# OK the source zip exists for ${CLVERSION}"
+    else
+      echo "# ERROR --> the source zip clightning-${CLVERSION}.zip is not published"
+      echo "# Embargoed security releases only ship prebuilt tarballs"
+      echo "# Use: cl.install.sh update-binary ${CLVERSION}"
+      exit 1
+    fi
+  fi
 fi
 
 # check for PR if testPR

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -356,10 +356,25 @@ if { [ "$1" = "update" ] || [ "$1" = "update-binary" ]; } && [ $# -gt 1 ]; then
       "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/clightning-${CLVERSION}.zip"; then
       echo "# OK the source zip exists for ${CLVERSION}"
     else
-      echo "# ERROR --> the source zip clightning-${CLVERSION}.zip is not published"
+      echo "# The source zip clightning-${CLVERSION}.zip is not published"
       echo "# Embargoed security releases only ship prebuilt tarballs"
-      echo "# Use: cl.install.sh update-binary ${CLVERSION}"
-      exit 1
+      # check that the prebuilt tarball manifest exists for this architecture
+      case "$(uname -m)" in
+        x86_64) sumsFile="SHA256SUMS-${CLVERSION}" ;;
+        aarch64) sumsFile="SHA256SUMS-${CLVERSION}-arm64" ;;
+        *)
+          echo "# ERROR --> unsupported architecture for binary install: $(uname -m)"
+          exit 1
+          ;;
+      esac
+      if curl --output /dev/null --silent --head --fail \
+        "https://github.com/ElementsProject/lightning/releases/download/${CLVERSION}/${sumsFile}"; then
+        echo "# Falling back to the prebuilt binary tarball"
+        exec bash "$0" update-binary "${CLVERSION}"
+      else
+        echo "# ERROR --> no source zip and no prebuilt tarball found for ${CLVERSION}"
+        exit 1
+      fi
     fi
   fi
 fi
@@ -444,7 +459,11 @@ if [ "$1" = "update-binary" ]; then
   echo "# Enabled lightningd services will be restarted"
   echo "# Make sure this is intended, there might be no way to downgrade your database"
   echo "# Press ENTER to continue or CTRL+C to abort the update"
-  read -r key
+  read -r key || {
+    echo
+    echo "# Aborted - no confirmation given"
+    exit 1
+  }
 
   downloadAndVerifyBinaryTarball
 

--- a/test/cl.install.bats
+++ b/test/cl.install.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# Tests for cl.install.sh update / update-binary pre-flight checks
+# These only exercise the version / asset existence checks, so no root
+# and no lightning install is needed - but they do access github.com
+
+SCRIPT="$BATS_TEST_DIRNAME/../home.admin/config.scripts/cl.install.sh"
+
+@test "update with a nonexistent version exits 1 with a clear error" {
+  run bash "$SCRIPT" update v99.99.99-notreal
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "update with an embargoed release points to update-binary" {
+  # v26.06.7 was released under embargo: the source zip was not published,
+  # only prebuilt tarballs. Once the source zip is published upstream this
+  # test needs a newer embargoed release as its example.
+  run bash "$SCRIPT" update v26.06.7
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"source zip clightning-v26.06.7.zip is not published"* ]]
+  [[ "$output" == *"update-binary v26.06.7"* ]]
+}
+
+@test "update-binary with a nonexistent version exits 1 with a clear error" {
+  run bash "$SCRIPT" update-binary v99.99.99-notreal
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"does not exist"* ]]
+}
+
+@test "update-binary with a published release passes the pre-flight checks" {
+  # must not fail before the interactive confirmation prompt
+  run bash -c "echo | bash '$SCRIPT' update-binary v26.06.7"
+  [[ "$output" == *"OK version exists"* ]]
+}

--- a/test/cl.install.bats
+++ b/test/cl.install.bats
@@ -1,34 +1,64 @@
 #!/usr/bin/env bats
 # Tests for cl.install.sh update / update-binary pre-flight checks
-# These only exercise the version / asset existence checks, so no root
-# and no lightning install is needed - but they do access github.com
+# Only exercises the version / release-asset existence checks:
+# no root and no lightning install needed, but requires network access
+# to github.com. Safe to run on a live node - stdin is redirected from
+# /dev/null so no test can get past a confirmation prompt.
 
 SCRIPT="$BATS_TEST_DIRNAME/../home.admin/config.scripts/cl.install.sh"
+REPO="https://github.com/ElementsProject/lightning"
 
-@test "update with a nonexistent version exits 1 with a clear error" {
-  run bash "$SCRIPT" update v99.99.99-notreal
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"does not exist"* ]]
+latestReleaseTag() {
+  curl -sf "https://api.github.com/repos/ElementsProject/lightning/releases/latest" |
+    grep -o '"tag_name":[[:space:]]*"[^"]*"' | cut -d'"' -f4
 }
 
-@test "update with an embargoed release points to update-binary" {
-  # v26.06.7 was released under embargo: the source zip was not published,
-  # only prebuilt tarballs. Once the source zip is published upstream this
-  # test needs a newer embargoed release as its example.
-  run bash "$SCRIPT" update v26.06.7
+assetExists() {
+  # $1 release tag, $2 asset filename
+  curl --output /dev/null --silent --head --fail \
+    "${REPO}/releases/download/$1/$2"
+}
+
+@test "update with a nonexistent version exits 1 with a clear error" {
+  run bash "$SCRIPT" update v99.99.99-notreal </dev/null
   [ "$status" -eq 1 ]
-  [[ "$output" == *"source zip clightning-v26.06.7.zip is not published"* ]]
-  [[ "$output" == *"update-binary v26.06.7"* ]]
+  [[ "$output" == *"does not exist"* ]]
 }
 
 @test "update-binary with a nonexistent version exits 1 with a clear error" {
-  run bash "$SCRIPT" update-binary v99.99.99-notreal
+  run bash "$SCRIPT" update-binary v99.99.99-notreal </dev/null
   [ "$status" -eq 1 ]
   [[ "$output" == *"does not exist"* ]]
 }
 
-@test "update-binary with a published release passes the pre-flight checks" {
-  # must not fail before the interactive confirmation prompt
-  run bash -c "echo | bash '$SCRIPT' update-binary v26.06.7"
+@test "update with an existing release passes the version check" {
+  # v26.06.7 exists as a release tag - tags are permanent, safe as a fixture
+  run bash "$SCRIPT" update v26.06.7 </dev/null
   [[ "$output" == *"OK version exists"* ]]
+}
+
+@test "update falls back to update-binary when the source zip is not published" {
+  # Uses the latest release so the test adapts automatically:
+  # skips when there is no embargoed release to test with
+  latest=$(latestReleaseTag)
+  [ -n "$latest" ] || skip "could not query the latest release"
+  if assetExists "$latest" "clightning-${latest}.zip"; then
+    skip "latest release ${latest} has a source zip (no embargoed release to test with)"
+  fi
+  if ! assetExists "$latest" "SHA256SUMS-${latest}"; then
+    skip "latest release ${latest} has no checksum manifest (no prebuilt tarballs to test with)"
+  fi
+  run bash "$SCRIPT" update "$latest" </dev/null
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Falling back to the prebuilt binary tarball"* ]]
+  [[ "$output" == *"update-binary"* ]]
+}
+
+@test "update-binary aborts without confirmation instead of installing" {
+  latest=$(latestReleaseTag)
+  [ -n "$latest" ] || skip "could not query the latest release"
+  run bash "$SCRIPT" update-binary "$latest" </dev/null
+  [ "$status" -eq 1 ]
+  # must never reach the download step without a TTY confirmation
+  [[ "$output" != *"Downloading Core Lightning"* ]]
 }


### PR DESCRIPTION
## Why

The v26.06.7 security release is under a 2-week embargo: the source zip (`clightning-v26.06.7.zip`) is not published, only prebuilt tarballs. The existing `cl.install.sh update <version>` path downloads the source zip and builds from source, so it 404s for embargoed releases. Upstream explicitly recommends upgrading promptly via the tarballs rather than waiting for the source to drop.

## What

Adds `cl.install.sh update-binary <version>`:

- maps `uname -m` to the amd64/arm64 release assets (arm64 uses the separate `SHA256SUMS-<version>-arm64` manifest)
- picks the oldest Ubuntu build compatible with the local glibc (22.04/2.35, 24.04/2.39, 26.04/2.41) — on a Pi 5 with Debian 12 this selects the Ubuntu-22.04-arm64 build
- verifies the GPG-signed checksum manifest (reuses the existing cln/ngoline primary+fallback PGP key logic) and the tarball SHA256
- extracts with `--strip-components=2` into `/usr/local`, checks the installed version, restarts enabled lightningd services
- generalizes `verifySHA256SUMSSignature` to accept a manifest name (existing source-zip path unchanged)

## Tested

- `bash -n` syntax check
- download + checksum verification of `clightning-v26.06.7-Ubuntu-22.04-arm64.tar.xz` against `SHA256SUMS-v26.06.7-arm64`
- GPG verification of `SHA256SUMS-v26.06.7-arm64.asc` — good signature with the ngoline fallback key already used by the script
- glibc detection on Debian 12 (2.36 → Ubuntu 22.04 build)

Not run end-to-end on a live blitz (no node to hand) — the interactive confirmation and service restart steps would be worth a quick check on a test node.