### PR TITLE
fix(nginx): forward WebSocket upgrades to Blitz API

### DIFF
--- a/home.admin/assets/nginx/sites-available/public.conf
+++ b/home.admin/assets/nginx/sites-available/public.conf
@@ -19,6 +19,10 @@ server {
 	# proxy for API
 	location /api/ {
 		proxy_pass        http://127.0.0.1:11111/;
+		# Allow WebSocket upgrades for realtime API updates.
+		proxy_http_version 1.1;
+		proxy_set_header  Upgrade $http_upgrade;
+		proxy_set_header  Connection "upgrade";
 		proxy_set_header  X-Real-IP $remote_addr;
 		proxy_set_header  X-Forwarded-Host   $host;
 		proxy_read_timeout 300;

--- a/home.admin/assets/nginx/sites-available/public.httponly.conf
+++ b/home.admin/assets/nginx/sites-available/public.httponly.conf
@@ -13,6 +13,10 @@ server {
 	# proxy for API
 	location /api/ {
 		proxy_pass        http://127.0.0.1:11111/;
+		# Allow WebSocket upgrades for realtime API updates.
+		proxy_http_version 1.1;
+		proxy_set_header  Upgrade $http_upgrade;
+		proxy_set_header  Connection "upgrade";
 		proxy_set_header  X-Real-IP $remote_addr;
 		proxy_set_header  X-Forwarded-Host   $host;
 	}


### PR DESCRIPTION
Enable HTTP/1.1 and forward Upgrade and Connection headers in both public API proxy templates so /api/ws reaches the WebSocket endpoint.

Validated both templates with nginx -t and isolated HTTP/HTTPS proxies against Blitz API: health, login, authenticated warmup, and 4401 authentication rejection.

Thank you for your contribution to RaspiBlitz. Before submitting this PR, please make sure:
- [x] That its based against the `dev` branch - not the default release branch.
