### PR TITLE
Add menu option to disable public peer connectivity for LND and CLN

### DIFF
--- a/home.admin/99clMenu.sh
+++ b/home.admin/99clMenu.sh
@@ -23,6 +23,11 @@ OPTIONS=()
   OPTIONS+=(RECEIVE "Create an invoice / payment request")
   OPTIONS+=(SUMMARY "Information about this node")
   OPTIONS+=(NAME "Change the name / alias of the node")
+if [ "${clPublicPeers}" == "off" ]; then
+  OPTIONS+=(PUBPEERS "Public Peer Connectivity: OFF")
+else
+  OPTIONS+=(PUBPEERS "Public Peer Connectivity: ON")
+fi
 ln_getInfo=$($lightningcli_alias getinfo 2>/dev/null)
 ln_channels_online="$(echo "${ln_getInfo}" | jq -r '.num_active_channels')" 2>/dev/null
 cl_num_inactive_channels="$(echo "${ln_getInfo}" | jq -r '.num_inactive_channels')" 2>/dev/null
@@ -83,6 +88,29 @@ case $CHOICE in
       ;;
   NAME)
       sudo /home/admin/config.scripts/cl.setname.sh $CHAIN
+      ;;
+  PUBPEERS)
+      clear
+      echo
+      if [ "${clPublicPeers}" == "off" ]; then
+        # enable public peer connectivity (default)
+        /home/admin/config.scripts/blitz.conf.sh set clPublicPeers "on"
+        echo "# Public peer connectivity ENABLED"
+        echo "# The node is reachable and announced to the network over Tor."
+      else
+        # disable public peer connectivity - outbound-only node
+        /home/admin/config.scripts/blitz.conf.sh set clPublicPeers "off"
+        echo "# Public peer connectivity DISABLED"
+        echo "# The node is now outbound-only: not reachable and not announced."
+        echo "# Existing channels keep working over the outbound connections."
+        echo "# New inbound channels cannot be opened TO this node."
+      fi
+      echo
+      echo "# Restarting Core Lightning to apply the change ..."
+      sudo systemctl restart ${netprefix}lightningd
+      echo
+      echo "Press ENTER to return to main menu."
+      read key
       ;;
   WATCHTOWER)
       /home/admin/config.scripts/cl-plugin.watchtower-client.sh info

--- a/home.admin/99lndMenu.sh
+++ b/home.admin/99lndMenu.sh
@@ -32,6 +32,12 @@ fi
 
 OPTIONS+=(NAME "Change Name/Alias of Node")
 
+if [ "${lndPublicPeers}" == "off" ]; then
+  OPTIONS+=(PUBPEERS "Public Peer Connectivity: OFF")
+else
+  OPTIONS+=(PUBPEERS "Public Peer Connectivity: ON")
+fi
+
 openChannels=$($lncli_alias listchannels 2>/dev/null | jq '.[] | length')
 if [ ${#openChannels} -gt 0 ] && [ ${openChannels} -gt 0 ]; then
   OPTIONS+=(SUEZ "Visualize channels")
@@ -111,6 +117,29 @@ case $CHOICE in
         sudo /home/admin/config.scripts/blitz.shutdown.sh reboot
         exit 0
       fi
+      ;;
+  PUBPEERS)
+      clear
+      echo
+      if [ "${lndPublicPeers}" == "off" ]; then
+        # enable public peer connectivity (default)
+        /home/admin/config.scripts/blitz.conf.sh set lndPublicPeers "on"
+        echo "# Public peer connectivity ENABLED"
+        echo "# The node is reachable and announced to the network over Tor."
+      else
+        # disable public peer connectivity - outbound-only node
+        /home/admin/config.scripts/blitz.conf.sh set lndPublicPeers "off"
+        echo "# Public peer connectivity DISABLED"
+        echo "# The node is now outbound-only: not reachable and not announced."
+        echo "# Existing channels keep working over the outbound connections."
+        echo "# New inbound channels cannot be opened TO this node."
+      fi
+      echo
+      echo "# Restarting LND to apply the change ..."
+      sudo systemctl restart ${netprefix}lnd
+      echo
+      echo "Press ENTER to return to main menu."
+      read key
       ;;
   SUEZ)
       clear

--- a/home.admin/config.scripts/cl.check.sh
+++ b/home.admin/config.scripts/cl.check.sh
@@ -34,6 +34,22 @@ if [ "$1" == "prestart" ]; then
     sed -i "/^announce-addr=127.0.0.1/d" ${CLCONF}
   fi
 
+  # enforce/disable public peer connectivity (inbound connections)
+  # clPublicPeers=off in raspiblitz.conf -> node is outbound-only (not reachable, not announced)
+  if [ "${clPublicPeers}" == "off" ]; then
+    echo "# clPublicPeers=off -> remove announced/public addresses (outbound-only node)"
+    sed -i "/^addr=statictor/d" ${CLCONF}
+    sed -i "/^announce-addr/d" ${CLCONF}
+  else
+    # default: public peer connectivity over Tor enabled - restore announced address if missing
+    if [ "${runBehindTor}" == "on" ]; then
+      if [ $(grep -c "^addr=statictor" <${CLCONF}) -eq 0 ]; then
+        echo "# clPublicPeers is not off -> restore the announced Tor address"
+        echo "addr=statictor:127.0.0.1:9051/torport=${portprefix}9736" | tee -a ${CLCONF}
+      fi
+    fi
+  fi
+
   if [ $(grep -c "^clboss" <${CLCONF}) -gt 0 ]; then
     if [ ! -f /home/bitcoin/${netprefix}cl-plugins-enabled/clboss ] || [ "$(eval echo \$${netprefix}clboss)" != "on" ]; then
       echo "# The clboss plugin is not present but in config"

--- a/home.admin/config.scripts/cl.install.sh
+++ b/home.admin/config.scripts/cl.install.sh
@@ -446,6 +446,12 @@ always-use-proxy=true
   else
     echo "# The file ${CLCONF} is already present"
   fi
+  # honor clPublicPeers=off - remove announced/public addresses (outbound-only node)
+  if [ "${clPublicPeers}" == "off" ]; then
+    echo "# clPublicPeers=off -> remove announced/public addresses from ${CLCONF}"
+    sudo sed -i "/^addr=statictor/d" ${CLCONF}
+    sudo sed -i "/^announce-addr/d" ${CLCONF}
+  fi
   sudo chown -R bitcoin:bitcoin /mnt/hdd/app-data/.lightning
   sudo chown -R bitcoin:bitcoin /home/bitcoin/
 

--- a/home.admin/config.scripts/lnd.check.sh
+++ b/home.admin/config.scripts/lnd.check.sh
@@ -224,6 +224,7 @@ if [ "$1" == "prestart" ]; then
   # lndPublicPeers=off in raspiblitz.conf -> node is outbound-only (not reachable, not announced)
   if [ "${lndPublicPeers}" == "off" ]; then
     echo "# lndPublicPeers=off -> disable the inbound peer listener (outbound-only node)"
+    echo "# (the [tor] section below sets tor.v3=false as lnd rejects nolisten + tor.v3=true)"
     setting ${lndConfFile} ${insertLine} "nolisten" "1"
   else
     # default: public peer connectivity enabled - remove nolisten if present
@@ -317,7 +318,14 @@ if [ "$1" == "prestart" ]; then
     setting ${lndConfFile} ${insertLine} "tor.control" "9051"
     setting ${lndConfFile} ${insertLine} "tor.socks" "9050"
     setting ${lndConfFile} ${insertLine} "tor.privatekeypath" "\/mnt\/hdd\/lnd\/${netprefix}v3_onion_private_key"
-    setting ${lndConfFile} ${insertLine} "tor.v3" "true"
+    # lndPublicPeers=off -> outbound-only over Tor: no inbound hidden service
+    # (tor.v3=false, because nolisten + tor.v3=true is rejected by lnd:
+    # 'listening must be enabled when enabling inbound connections over Tor')
+    if [ "${lndPublicPeers}" == "off" ]; then
+      setting ${lndConfFile} ${insertLine} "tor.v3" "false"
+    else
+      setting ${lndConfFile} ${insertLine} "tor.v3" "true"
+    fi
     setting ${lndConfFile} ${insertLine} "tor.active" "true"
 
     # take care of incompatible settings https://github.com/rootzoll/raspiblitz/issues/2787#issuecomment-991245694

--- a/home.admin/config.scripts/lnd.check.sh
+++ b/home.admin/config.scripts/lnd.check.sh
@@ -220,6 +220,16 @@ if [ "$1" == "prestart" ]; then
     sed -i '/^externalip=*/d' ${lndConfFile}
   fi
 
+  # enforce/disable public peer connectivity (inbound connections)
+  # lndPublicPeers=off in raspiblitz.conf -> node is outbound-only (not reachable, not announced)
+  if [ "${lndPublicPeers}" == "off" ]; then
+    echo "# lndPublicPeers=off -> disable the inbound peer listener (outbound-only node)"
+    setting ${lndConfFile} ${insertLine} "nolisten" "1"
+  else
+    # default: public peer connectivity enabled - remove nolisten if present
+    sed -i '/^nolisten=*/d' ${lndConfFile}
+  fi
+
   # if no maxlogfiles set - set to 2
   if [ $(cat ${lndConfFile} | grep -c "^maxlogfiles=") -eq 0 ]; then
     setting ${lndConfFile} ${insertLine} "maxlogfiles" "2"


### PR DESCRIPTION
## What

In view of the current vulnerabilities affecting publicly reachable Lightning nodes, this adds a per-implementation toggle (LND menu / CLN menu) to make the node **outbound-only**: not reachable and not announced on the network, while channels keep working over the outbound Tor connections.

## Exact config changes

### raspiblitz.conf (written by the menu toggle)
```ini
lndPublicPeers=off   # or =on (default / unset = on)
clPublicPeers=off    # or =on (default / unset = on)
```

### LND — /mnt/hdd/app-data/lnd/lnd.conf (applied by lnd.check.sh prestart)

When `lndPublicPeers=off`:
```diff
 [Application Options]
+nolisten=1                  # no p2p listener at all (incl. clearnet)
 [tor]
 tor.active=true             # unchanged - outbound over Tor stays
-tor.v3=true
+tor.v3=false                # no inbound Tor hidden service is created
```
Note: lnd rejects `nolisten` + `tor.v3=true` (`ValidateConfig: listening must be enabled when enabling inbound connections over Tor`, config.go: `DisableListen && Tor.V3`), so `tor.v3=false` is required. The hidden service is only created when `tor.v3=true`.

When re-enabled (`lndPublicPeers=on` / unset):
```diff
 [Application Options]
-nolisten=1                  # line removed
 [tor]
-tor.v3=false
+tor.v3=true                 # inbound hidden service restored
```

### CLN — /home/bitcoin/.lightning/config (applied by cl.check.sh prestart, honored at install by cl.install.sh)

When `clPublicPeers=off`:
```diff
 proxy=127.0.0.1:9050        # unchanged - outbound over Tor stays
 bind-addr=127.0.0.1:9736    # unchanged - localhost only
-addr=statictor:127.0.0.1:9051/torport=9736   # removed - no announced Tor address
 always-use-proxy=true       # unchanged
-announce-addr=...           # removed if present
```
No announced address = outbound-only, node is not announced in gossip.

When re-enabled with `runBehindTor=on`:
```diff
+addr=statictor:127.0.0.1:9051/torport=9736   # restored
```

## Other changes

- **`99lndMenu.sh` / `99clMenu.sh`** — new `Public Peer Connectivity: ON/OFF` menu entry. Toggling writes `lndPublicPeers` / `clPublicPeers` to `raspiblitz.conf` and restarts the service so the change is applied.
- The check scripts now *respect* the disabled setting instead of resetting the conf back to public on every start.

## Behavior

- Default is unchanged: unset = public connectivity **ON**, existing nodes are unaffected.
- Disabling = outbound-only node: existing channels keep working over outbound connections, but no new inbound channels can be opened *to* the node and it is no longer announced in gossip.

## Testing

- `bash -n` syntax check on all modified scripts: OK
- Simulated the sed/grep enforcement logic on sample `lnd.conf` / CLN `config`: disable strips announced addresses / sets `nolisten=1` + `tor.v3=false`, re-enable restores defaults: OK
- Verified against lnd master source that the `nolisten` + `tor.v3=true` combination is rejected and that the inbound hidden service is only created when `tor.v3=true`.